### PR TITLE
fix(auth): исправить критичные проблемы JWT-авторизации

### DIFF
--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -82,7 +82,6 @@ class AuthController extends Controller
             $request->password
         );
         $credentials = $request->only('email', 'password');
-        $token = auth()->attempt($credentials, true);
         if (!$token = auth()->attempt($credentials, true)) {
             return response()->json(['message' => 'Логин и пароль указан не верно'], 401);
         }

--- a/Backend/src/User/Account/Domain/ProcessPasswordResets.php
+++ b/Backend/src/User/Account/Domain/ProcessPasswordResets.php
@@ -36,7 +36,7 @@ class ProcessPasswordResets implements ShouldQueue, DomainEvent
      */
     public function handle(): void
     {
-        $token = urlencode(md5($this->user->email));
+        $token = urlencode(bin2hex(random_bytes(32)));
 
         $activationLink = "https://org.spaceofjoy.ru/resetPassword/".$token;
 

--- a/FrontEnd/src/main.js
+++ b/FrontEnd/src/main.js
@@ -11,37 +11,70 @@ window.store = store;
 // API URL from .env file (VUE_APP_API_URL)
 // Dev: http://api.tickets.loc/
 // Prod: https://api.spaceofjoy.ru/
-// Test: http://api.tickets.loc/
 axios.defaults.baseURL = process.env.VUE_APP_API_URL || 'http://api.tickets.loc/'
 axios.defaults.withCredentials = true
-/*
-if (localStorage['secret'] !== 'XyzWar') {
-    window.location.href = 'https://ya.ru/';
-}*/
 
+// Флаг и очередь для предотвращения race condition при обновлении токена
+let isRefreshing = false;
+let failedQueue = [];
 
-// добавить токент клиента
+const processQueue = (error, token = null) => {
+    failedQueue.forEach(prom => error ? prom.reject(error) : prom.resolve(token));
+    failedQueue = [];
+};
+
+// Подставляет актуальный токен в каждый исходящий запрос
 axios.interceptors.request.use(function (config) {
-    let token = localStorage['user.token'];
-    let lifetime = localStorage['user.token.lifetime'];
+    const token = localStorage['user.token'];
     if (token) {
         config.headers.Authorization = token;
-
-        if (config.url !== '/api/refresh' && config.url !== '/api/logout'){
-            console.log(config.url)
-            if (Math.trunc(Date.now() / 1000) > +lifetime) {
-                store.dispatch('appUser/tokenRefresh').catch(r => {
-                    console.error(r)
-                });
-            }
-        }
     }
-
     return config;
 }, function (error) {
-    console.log('unauthorized, logging out ...');
-    return Promise.reject(error.response);
+    return Promise.reject(error);
 });
+
+// Перехватывает 401 — обновляет токен ровно один раз, повторяет все накопившиеся запросы
+axios.interceptors.response.use(
+    response => response,
+    error => {
+        const originalRequest = error.config;
+        const isAuthEndpoint = ['/api/refresh', '/api/login', '/api/logout']
+            .some(url => originalRequest.url === url);
+
+        if (error.response?.status === 401 && !originalRequest._retry && !isAuthEndpoint) {
+            if (isRefreshing) {
+                // Ставим запрос в очередь — он выполнится после получения нового токена
+                return new Promise((resolve, reject) => {
+                    failedQueue.push({ resolve, reject });
+                }).then(token => {
+                    originalRequest.headers.Authorization = token;
+                    return axios(originalRequest);
+                }).catch(err => Promise.reject(err));
+            }
+
+            originalRequest._retry = true;
+            isRefreshing = true;
+
+            return store.dispatch('appUser/tokenRefresh')
+                .then(token => {
+                    processQueue(null, token);
+                    originalRequest.headers.Authorization = token;
+                    return axios(originalRequest);
+                })
+                .catch(err => {
+                    processQueue(err, null);
+                    store.dispatch('appUser/logOut');
+                    return Promise.reject(err);
+                })
+                .finally(() => {
+                    isRefreshing = false;
+                });
+        }
+
+        return Promise.reject(error);
+    }
+);
 
 createApp(App)
     .use(store)

--- a/FrontEnd/src/router/index.js
+++ b/FrontEnd/src/router/index.js
@@ -364,22 +364,19 @@ const router = createRouter({
  */
 router.beforeEach((to, from, next) => {
         store.commit('HIDE_MENU');
-        let token = (localStorage['user.token'] !== undefined && localStorage['user.token'] !== '' && localStorage['user.token'] !== null);
+        const rawToken = localStorage['user.token'];
+        const lifetime = localStorage['user.token.lifetime'];
+        const token = rawToken && rawToken !== 'null' && lifetime
+            && Math.trunc(Date.now() / 1000) < +lifetime;
+
         if (to.matched.some(record => record.meta.requiresAuth)) {
             if (!token) {
-                next({
-                    path: '/login',
-                    query: {
-                        nextUrl: to.fullPath,
-                    }
-                });
+                next({ path: '/login', query: { nextUrl: to.fullPath } });
             } else {
-                if(to.matched.some(record => record.meta.role)) {
-                    window.store.dispatch('appUser/isCorrectRole',{
-                        'role':to.meta.role
-                    }).then(function (){
-                        next();
-                    })
+                if (to.matched.some(record => record.meta.role)) {
+                    window.store.dispatch('appUser/isCorrectRole', { 'role': to.meta.role })
+                        .then(() => next())
+                        .catch(() => next({ path: '/login' }));
                 } else {
                     next();
                 }
@@ -388,7 +385,7 @@ router.beforeEach((to, from, next) => {
             if (!token) {
                 next();
             } else {
-                next({path: '/'});
+                next({ path: '/' });
             }
         } else {
             next();

--- a/FrontEnd/src/store/modules/UserModule/actions.js
+++ b/FrontEnd/src/store/modules/UserModule/actions.js
@@ -99,23 +99,20 @@ export const loadUserData = (context, payload) => {
 }
 
 /**
- * Пересобрать токен
+ * Пересобрать токен — возвращает Promise с новым токеном для Axios interceptor
  *
  * @param context
+ * @returns {Promise<string>}
  */
 export const tokenRefresh = (context) => {
-    let promise = axios.post('/api/refresh');
-    promise.then(async function (response) {
+    return axios.post('/api/refresh').then(function (response) {
         if (response.data.status === 'success') {
             context.commit('setToken', response.data.authorisation);
             context.commit('setUserInfo', response.data.user);
+            return response.data.authorisation.type + ' ' + response.data.authorisation.token;
         }
-    }).catch(function (error) {
-        if (error.response.status === 401) {
-            context.dispatch('logOut').then(r => console.log(r));
-        }
-        console.error(error);
-    })
+        return Promise.reject(new Error('Refresh failed'));
+    });
 };
 
 /**

--- a/FrontEnd/src/store/modules/UserModule/index.js
+++ b/FrontEnd/src/store/modules/UserModule/index.js
@@ -8,12 +8,12 @@ export default {
         userToken: localStorage.getItem('user.token') || null,
         userTimeLifeForToken: localStorage.getItem('user.token.lifetime') || null,
         userInfo: {
-            'id': localStorage.getItem('user.id') || null,
-            'email': localStorage.getItem('user.email') || null,
-            'admin': localStorage.getItem('user.isAdmin') == 'true' || localStorage.getItem('user.role') == 'admin' || false,
-            'manager': localStorage.getItem('user.isManager') == 'true' || localStorage.getItem('user.role') == 'manager' || false,
-            'seller': localStorage.getItem('user.role') == 'seller' || localStorage.getItem('user.role') == 'seller' || false,
-            'pusher': localStorage.getItem('user.role') == 'pusher' || localStorage.getItem('user.role') == 'pusher' || false,
+            'id':      localStorage.getItem('user.id') || null,
+            'email':   localStorage.getItem('user.email') || null,
+            'admin':   localStorage.getItem('user.isAdmin') === 'true' || localStorage.getItem('user.role') === 'admin',
+            'manager': localStorage.getItem('user.isManager') === 'true' || localStorage.getItem('user.role') === 'manager',
+            'seller':  localStorage.getItem('user.isSeller') === 'true' || localStorage.getItem('user.role') === 'seller',
+            'pusher':  localStorage.getItem('user.isPusher') === 'true' || localStorage.getItem('user.role') === 'pusher',
         },
         userData: {
             'city': null,

--- a/FrontEnd/src/store/modules/UserModule/mutations.js
+++ b/FrontEnd/src/store/modules/UserModule/mutations.js
@@ -1,25 +1,30 @@
 export const setError = (state, payload) => {
     state.dataError = payload;
 };
+
 /**
  * Записать токен
  *
  * @param state
  * @param payload
  */
-export const setToken = async (state, payload) => {
+export const setToken = (state, payload) => {
     state.userToken = payload.type + ' ' + payload.token;
     state.userTimeLifeForToken = payload.lifetime;
 
-    await localStorage.setItem('user.token', payload.type + ' ' + payload.token); // сохранение токена пользователя на стороне клиента
-    await localStorage.setItem('user.token.lifetime', payload.lifetime);
+    localStorage.setItem('user.token', payload.type + ' ' + payload.token);
+    localStorage.setItem('user.token.lifetime', payload.lifetime);
 };
 
-export const removeToken = async (state) => {
+export const removeToken = (state) => {
     state.userToken = null;
     state.userTimeLifeForToken = null;
+    state.userInfo = { id: null, email: null, admin: false, manager: false, seller: false, pusher: false };
 
-    await localStorage.clear();
+    // Удаляем только ключи пользователя, не трогая остальной localStorage
+    ['user.token', 'user.token.lifetime', 'user.email', 'user.id',
+     'user.isAdmin', 'user.isManager', 'user.isSeller', 'user.isPusher', 'user.role']
+        .forEach(key => localStorage.removeItem(key));
 };
 
 /**
@@ -28,15 +33,26 @@ export const removeToken = async (state) => {
  * @param state
  * @param payload
  */
-export const setUserInfo = async (state, payload) => {
-    state.userInfo = payload;
-    await localStorage.setItem('user.email', payload.email);
-    await localStorage.setItem('user.id', payload.id);
-    await localStorage.setItem('user.isAdmin', payload.role == 'admin');
-    await localStorage.setItem('user.isManager', payload.role == 'manager');
-    await localStorage.setItem('user.isSaller', payload.role == 'saller');
-    await localStorage.setItem('user.isPusher', payload.role == 'pusher');
-    await localStorage.setItem('user.role', payload.role);
+export const setUserInfo = (state, payload) => {
+    const role = payload.role || '';
+
+    // Обновляем state напрямую — геттеры isAdmin/isSeller/etc. работают без перезагрузки страницы
+    state.userInfo = {
+        id:      payload.id,
+        email:   payload.email,
+        admin:   payload.is_admin || role === 'admin',
+        manager: role === 'manager',
+        seller:  role === 'seller',
+        pusher:  role === 'pusher',
+    };
+
+    localStorage.setItem('user.email',     payload.email);
+    localStorage.setItem('user.id',        payload.id);
+    localStorage.setItem('user.isAdmin',   String(state.userInfo.admin));
+    localStorage.setItem('user.isManager', String(state.userInfo.manager));
+    localStorage.setItem('user.isSeller',  String(state.userInfo.seller));
+    localStorage.setItem('user.isPusher',  String(state.userInfo.pusher));
+    localStorage.setItem('user.role',      role);
 };
 
 export const setUserData = (state, payload) => {


### PR DESCRIPTION
Frontend:
- Заменить fire-and-forget refresh на response interceptor с queue-паттерном (race condition: N параллельных 401 → ровно 1 refresh, остальные ждут)
- tokenRefresh возвращает Promise с новым токеном для interceptor
- setUserInfo обновляет state напрямую (геттеры работают без reload страницы)
- removeToken удаляет только user.* ключи вместо localStorage.clear()
- Исправить опечатку isSaller/saller → isSeller/seller
- Инициализация ролей из корректных ключей localStorage (isSeller/isPusher)
- Router guard: добавить .catch() к isCorrectRole (навигация не зависает при 403)
- Router guard: проверять lifetime токена, а не только наличие строки
- Убрать console.log(config.url) из production кода

Backend:
- Убрать двойной auth()->attempt() в register (двойной запрос к БД)
- Заменить MD5(email) на bin2hex(random_bytes(32)) в токене сброса пароля (MD5 от email предсказуем — уязвимость захвата аккаунта)