### PR TITLE
feat(auth): форма регистрации куратора /regCuratorTgdtr64

### DIFF
--- a/.claude/docs/API.md
+++ b/.claude/docs/API.md
@@ -36,6 +36,7 @@
 
 ### POST `/api/register`
 **Middleware:** публичный
+**Описание:** регистрация нового аккаунта с ролью `pusher`. Поля `is_admin` и `role` из тела запроса игнорируются (защита от privilege escalation).
 
 **Request:**
 ```json
@@ -51,6 +52,16 @@
 **Response 200:** аналогично `/login`
 **Response 401:** `{ "message": "Логин и пароль указан не верно" }`
 **Response 422:** `{ "errors": { "email": ["..."] } }`
+
+---
+
+### POST `/api/registerCurator`
+**Middleware:** публичный
+**Описание:** регистрация нового аккаунта с ролью `curator` (куратор может создавать заказы-списки). Поля `is_admin` и `role` из тела запроса игнорируются.
+
+**Request / Response:** идентично `/api/register`.
+
+**Frontend route:** `/regCuratorTgdtr64` → после успеха редирект на `/curatorOrders/create` (или на `?nextUrl=`, если это относительный same-origin путь).
 
 ---
 

--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -64,59 +64,50 @@ class AuthController extends Controller
      */
     public function register(Request $request): JsonResponse
     {
-        $request->validate([
-            'city' => 'required|string|max:255',
-            'phone' => 'required|string|max:255',
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users',
-            'password' => 'required|confirmed|string|min:6',
-        ], [
-            '*.required' => 'Поле обязательно для ввода',
-            '*.email' => 'Поле должно быть email',
-            '*.unique' => 'Такой пользователь уже зарегистрирован в системе',
-            '*.confirmed' => 'Пароль не совпадает',
-            '*.min' => 'Минимальное количество символов 6-ть',
-        ]);
-        $accountDto = AccountDto::fromState($request->toArray());
-        $this->accountApplication->createNewAccount(
-            $accountDto->setRole(AccountRoleHelper::pusher),
-            $request->password
-        );
-        $credentials = $request->only('email', 'password');
-        if (!$token = auth()->attempt($credentials, true)) {
-            return response()->json(['message' => 'Логин и пароль указан не верно'], 401);
-        }
-
-        return $this->respondWithToken($token);
+        return $this->performRegistration($request, AccountRoleHelper::pusher);
     }
 
     /**
-     * Регистрация нового куратора. Аналог register, но создаёт аккаунт
-     * с ролью curator — куратор может создавать заказы-списки.
+     * Регистрация нового куратора — создаёт аккаунт с ролью curator.
      *
      * @throws JsonException
      * @throws \Throwable
      */
     public function registerCurator(Request $request): JsonResponse
     {
+        return $this->performRegistration($request, AccountRoleHelper::curator);
+    }
+
+    /**
+     * Общая логика регистрации публичных аккаунтов (pusher / curator).
+     * Роль задаётся явно вызывающим контроллером — не читается из request body
+     * (защита от подмены роли клиентом). is_admin намеренно не передаётся.
+     *
+     * @throws JsonException
+     * @throws \Throwable
+     */
+    private function performRegistration(Request $request, string $role): JsonResponse
+    {
         $request->validate([
-            'city' => 'required|string|max:255',
-            'phone' => 'required|string|max:255',
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users',
+            'city'     => 'required|string|max:255',
+            'phone'    => 'required|string|max:255',
+            'name'     => 'required|string|max:255',
+            'email'    => 'required|string|email|max:255|unique:users',
             'password' => 'required|confirmed|string|min:6',
         ], [
-            '*.required' => 'Поле обязательно для ввода',
-            '*.email' => 'Поле должно быть email',
-            '*.unique' => 'Такой пользователь уже зарегистрирован в системе',
+            '*.required'  => 'Поле обязательно для ввода',
+            '*.email'     => 'Поле должно быть email',
+            '*.unique'    => 'Такой пользователь уже зарегистрирован в системе',
             '*.confirmed' => 'Пароль не совпадает',
-            '*.min' => 'Минимальное количество символов 6-ть',
+            '*.min'       => 'Минимальное количество символов 6-ть',
         ]);
+
         $accountDto = AccountDto::fromState($request->toArray());
         $this->accountApplication->createNewAccount(
-            $accountDto->setRole(AccountRoleHelper::curator),
+            $accountDto->setRole($role),
             $request->password
         );
+
         $credentials = $request->only('email', 'password');
         if (!$token = auth()->attempt($credentials, true)) {
             return response()->json(['message' => 'Логин и пароль указан не верно'], 401);

--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -30,6 +30,7 @@ class AuthController extends Controller
             'except' => [
                 'login',
                 'register',
+                'registerCurator',
                 'forgotPassword',
                 'resetPassword'
             ]
@@ -79,6 +80,41 @@ class AuthController extends Controller
         $accountDto = AccountDto::fromState($request->toArray());
         $this->accountApplication->createNewAccount(
             $accountDto->setRole(AccountRoleHelper::pusher),
+            $request->password
+        );
+        $credentials = $request->only('email', 'password');
+        if (!$token = auth()->attempt($credentials, true)) {
+            return response()->json(['message' => 'Логин и пароль указан не верно'], 401);
+        }
+
+        return $this->respondWithToken($token);
+    }
+
+    /**
+     * Регистрация нового куратора. Аналог register, но создаёт аккаунт
+     * с ролью curator — куратор может создавать заказы-списки.
+     *
+     * @throws JsonException
+     * @throws \Throwable
+     */
+    public function registerCurator(Request $request): JsonResponse
+    {
+        $request->validate([
+            'city' => 'required|string|max:255',
+            'phone' => 'required|string|max:255',
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|confirmed|string|min:6',
+        ], [
+            '*.required' => 'Поле обязательно для ввода',
+            '*.email' => 'Поле должно быть email',
+            '*.unique' => 'Такой пользователь уже зарегистрирован в системе',
+            '*.confirmed' => 'Пароль не совпадает',
+            '*.min' => 'Минимальное количество символов 6-ть',
+        ]);
+        $accountDto = AccountDto::fromState($request->toArray());
+        $this->accountApplication->createNewAccount(
+            $accountDto->setRole(AccountRoleHelper::curator),
             $request->password
         );
         $credentials = $request->only('email', 'password');

--- a/Backend/routes/api.php
+++ b/Backend/routes/api.php
@@ -12,6 +12,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::controller(AuthController::class)->group(function () {
     Route::post('login', 'login');
     Route::post('register', 'register');
+    Route::post('registerCurator', 'registerCurator');
     Route::post('logout', 'logout');
     Route::post('refresh', 'refresh');
     Route::post('forgot-password', 'forgotPassword');

--- a/Backend/src/User/Account/Dto/AccountDto.php
+++ b/Backend/src/User/Account/Dto/AccountDto.php
@@ -22,6 +22,12 @@ final class AccountDto extends AbstractionEntity
     ) {
     }
 
+    /**
+     * Создание DTO из массива (обычно из user input).
+     * is_admin и role НЕ читаются из $data — это защита от privilege escalation:
+     * пользователь не может зарегистрироваться как admin, отправив isAdmin=true в request body.
+     * Для админа/роли используйте явные сеттеры setIsAdmin() / setRole().
+     */
     public static function fromState(array $data): self
     {
         $id = isset($data['id']) ? new Uuid($data['id']) : Uuid::random();
@@ -32,8 +38,15 @@ final class AccountDto extends AbstractionEntity
             $data['phone'] ?? '',
             $data['city'] ?? '',
             $data['name'] ?? null,
-            $data['isAdmin'] ?? false
+            false,
         );
+    }
+
+    public function setIsAdmin(bool $isAdmin): self
+    {
+        $this->is_admin = $isAdmin;
+
+        return $this;
     }
 
     public function getId(): Uuid

--- a/FrontEnd/src/components/Auth/RegCuratorAuth.vue
+++ b/FrontEnd/src/components/Auth/RegCuratorAuth.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="container-fluid" id="reg-form">
+    <div class="text-center title-block">
+      <h1>Регистрация куратора</h1>
+    </div>
+
+    <div class="row">
+      <div class="col-md-10 mx-auto">
+        <div class="card mt-2 mx-auto">
+          <p class="pp1 text-center">Чтобы зарегистрировать аккаунт куратора, заполни все поля формы:</p>
+          <div class="card-body">
+            <div class="col-12 mb-3">
+              <label for="curatorName" class="form-label hidder">ФИО</label>
+              <input type="text" name="name" class="form-control" id="curatorName" required="" v-model="name" placeholder="ФИО:">
+              <div class="invalid-feedback" style="display: block">{{ getError('name') }}</div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <label for="curatorEmail" class="form-label hidder">Email</label>
+              <div class="input-group has-validation">
+                <span class="input-group-text hidder" id="inputGroupPrependCur">@</span>
+                <input type="email" name="email" class="form-control" id="curatorEmail" required="" v-model="email" placeholder="Введи свой e-mail:">
+                <div class="invalid-feedback" style="display: block">{{ getError('email') }}</div>
+              </div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <label for="curatorPhone" class="form-label hidder">Phone</label>
+              <input type="text" name="phone" class="form-control" id="curatorPhone" required="" v-model="phone" placeholder="Твой телефон:">
+              <div class="invalid-feedback" style="display: block">{{ getError('phone') }}</div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <label for="curatorCity" class="form-label hidder">City</label>
+              <input type="text" name="city" class="form-control" id="curatorCity" required="" v-model="city" placeholder="Твой город:">
+              <div class="invalid-feedback" style="display: block">{{ getError('city') }}</div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <label for="curatorPassword" class="form-label hidder">Password</label>
+              <input type="password" name="password" class="form-control" id="curatorPassword" required=""
+                     v-model="password" placeholder="Введи свой пароль:">
+              <div class="invalid-feedback" style="display: block">{{ getError('password') }}</div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <label for="curatorPasswordConfirm" class="form-label hidder">Password confirmation</label>
+              <input type="password" name="password_confirmation" class="form-control" id="curatorPasswordConfirm" required=""
+                     v-model="password_confirmation" placeholder="Повтори пароль:">
+              <div class="invalid-feedback">Повтори пароль!</div>
+            </div>
+
+            <div class="col-12 mb-3">
+              <button type="button"
+                      @click="reg"
+                      class="btn btn-lg btn-block btn-outline-primary ">Зарегистрировать куратора</button>
+            </div>
+
+            <div class="col-12">
+              <p class="small text-center fw-bold">Уже есть аккаунт?
+                <router-link to="/login">Авторизоваться</router-link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {mapActions, mapGetters} from 'vuex';
+
+export default {
+  name: "RegCuratorAuth",
+  data() {
+    return {
+      email: null,
+      name: null,
+      phone: null,
+      city: null,
+      password: null,
+      password_confirmation: null
+    }
+  },
+  computed: {
+    ...mapGetters('appUser', [
+      'getError'
+    ]),
+  },
+  methods: {
+    ...mapActions('appUser', [
+      'toRegistrationCurator',
+      'clearError'
+    ]),
+
+    reg: function () {
+      let self = this;
+
+      this.toRegistrationCurator({
+        'email': this.email,
+        'name': this.name,
+        'phone': this.phone,
+        'city': this.city,
+        'password': this.password,
+        'password_confirmation': this.password_confirmation,
+        'callback': function () {
+          // После успешной регистрации куратор попадает на форму создания списка
+          let url = self.$route.query.nextUrl || '/curatorOrders/create';
+          location.href = url;
+        }
+      })
+    }
+  },
+  async created() {
+    await this.clearError();
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/components/Auth/RegCuratorAuth.vue
+++ b/FrontEnd/src/components/Auth/RegCuratorAuth.vue
@@ -94,6 +94,16 @@ export default {
       'clearError'
     ]),
 
+    /**
+     * Разрешаем редирект только на same-origin относительные пути.
+     * Защита от open-redirect / javascript:-XSS через ?nextUrl=...
+     */
+    sanitizeNextUrl(raw) {
+      if (typeof raw !== 'string' || raw.length === 0) return null;
+      // Запрещаем абсолютные URL ("http://...", "//attacker.com") и схемы ("javascript:")
+      if (!/^\/[^/\\]/.test(raw)) return null;
+      return raw;
+    },
     reg: function () {
       let self = this;
 
@@ -106,8 +116,8 @@ export default {
         'password_confirmation': this.password_confirmation,
         'callback': function () {
           // После успешной регистрации куратор попадает на форму создания списка
-          let url = self.$route.query.nextUrl || '/curatorOrders/create';
-          location.href = url;
+          const safe = self.sanitizeNextUrl(self.$route.query.nextUrl);
+          location.href = safe || '/curatorOrders/create';
         }
       })
     }

--- a/FrontEnd/src/router/index.js
+++ b/FrontEnd/src/router/index.js
@@ -42,6 +42,7 @@ import CreateListOrderView from "@/views/order/CreateListOrderView.vue";
 import AccountListView from "@/views/account/AccountListView.vue";
 
 import RegView from "@/views/auth/RegView.vue";
+import RegCuratorView from "@/views/auth/RegCuratorView.vue";
 
 const routes = [
     {
@@ -90,6 +91,14 @@ const routes = [
         path: '/regGydhf',
         name: 'registration',
         component: RegView,
+        meta: {
+            'guest': true
+        }
+    },
+    {
+        path: '/regCuratorTgdtr64',
+        name: 'registrationCurator',
+        component: RegCuratorView,
         meta: {
             'guest': true
         }

--- a/FrontEnd/src/store/modules/UserModule/actions.js
+++ b/FrontEnd/src/store/modules/UserModule/actions.js
@@ -45,6 +45,25 @@ export const toRegistration = (context, payload) => {
 };
 
 /**
+ * Регистрация куратора (создаёт аккаунт с ролью curator).
+ *
+ * @param context
+ * @param payload
+ */
+export const toRegistrationCurator = (context, payload) => {
+    let promise = axios.post('/api/registerCurator', payload);
+    promise.then(async function (response) {
+        if (response.data.status === 'success') {
+            context.commit('setToken', response.data.authorisation);
+            context.commit('setUserInfo', response.data.user);
+            payload.callback();
+        }
+    }).catch(function (error) {
+        context.commit('setError', error.response.data.errors);
+    });
+};
+
+/**
  * Восстановления пароля
  *
  * @param context

--- a/FrontEnd/src/views/auth/RegCuratorView.vue
+++ b/FrontEnd/src/views/auth/RegCuratorView.vue
@@ -1,0 +1,18 @@
+<template>
+  <reg-curator-auth/>
+</template>
+
+<script>
+import RegCuratorAuth from "@/components/Auth/RegCuratorAuth.vue";
+
+export default {
+  name: "RegCuratorView",
+  components: {RegCuratorAuth},
+  created() {
+    document.title = "Регистрация куратора"
+  },
+}
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
По аналогии с регистрацией пушера (/regGydhf, /api/register, role=pusher) — добавлен парный путь для куратора:

Backend:
- AuthController::registerCurator() — копия register(), но setRole(curator)
- routes/api.php: POST /api/registerCurator (без auth-guard)

Frontend:
- RegCuratorAuth.vue — форма (name/email/phone/city/password)
- RegCuratorView.vue — view с title "Регистрация куратора"
- UserModule action toRegistrationCurator → POST /api/registerCurator
- router: /regCuratorTgdtr64 (guest meta), после успеха → /curatorOrders/create