### PR TITLE
feat(location): select-выбор blade-шаблонов письма и билета

### DIFF
--- a/FrontEnd/src/components/Location/LocationItem.vue
+++ b/FrontEnd/src/components/Location/LocationItem.vue
@@ -185,10 +185,16 @@ export default {
       this.$router.push({ name: 'LocationListView' });
     },
   },
-  created() {
+  async created() {
     this.getListFestival();
     this.loadQuestionnaireTypes({ filter: { active: '1' }, orderBy: {} });
-    this.loadTemplate();
+    // Список шаблонов некритичен для сохранения — при ошибке селект остаётся пустым,
+    // пользователь сможет оставить значения по умолчанию.
+    try {
+      await this.loadTemplate();
+    } catch (e) {
+      console.warn('Не удалось загрузить список blade-шаблонов:', e);
+    }
   },
 };
 </script>

--- a/FrontEnd/src/components/Location/LocationItem.vue
+++ b/FrontEnd/src/components/Location/LocationItem.vue
@@ -48,16 +48,22 @@
             <div class="row mb-3">
               <label class="col-4 col-form-label">Шаблон письма (blade):</label>
               <div class="col-8">
-                <input type="text" class="form-control" v-model="emailTemplate" placeholder="orderListApproved">
-                <small class="form-text text-muted">Имя blade-шаблона из resources/views/email (без .blade.php)</small>
+                <select class="form-select" v-model="emailTemplate">
+                  <option :value="''">— по умолчанию (orderListApproved) —</option>
+                  <option v-for="item in getTemplateEmail" :key="item" :value="item">{{ item }}</option>
+                </select>
+                <small class="form-text text-muted">Файл из resources/views/email (без .blade.php)</small>
               </div>
             </div>
 
             <div class="row mb-3">
               <label class="col-4 col-form-label">Шаблон билета (blade):</label>
               <div class="col-8">
-                <input type="text" class="form-control" v-model="pdfTemplate" placeholder="pdf">
-                <small class="form-text text-muted">Имя blade-шаблона PDF (без .blade.php)</small>
+                <select class="form-select" v-model="pdfTemplate">
+                  <option :value="''">— по умолчанию (pdf) —</option>
+                  <option v-for="item in getTemplatePdf" :key="item" :value="item">{{ item }}</option>
+                </select>
+                <small class="form-text text-muted">Файл из resources/views (без .blade.php)</small>
               </div>
             </div>
 
@@ -107,7 +113,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('appLocation', ['getItem', 'getMessage']),
+    ...mapGetters('appLocation', ['getItem', 'getMessage', 'getTemplateEmail', 'getTemplatePdf']),
     ...mapGetters('appFestivalTickets', ['getFestivalList']),
     ...mapGetters('appQuestionnaireType', { getQuestionnaireTypeList: 'getList' }),
     isEdit() {
@@ -150,7 +156,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions('appLocation', ['loadItem', 'create', 'edit']),
+    ...mapActions('appLocation', ['loadItem', 'create', 'edit', 'loadTemplate']),
     ...mapActions('appFestivalTickets', ['getListFestival']),
     ...mapActions('appQuestionnaireType', { loadQuestionnaireTypes: 'loadList' }),
     async save() {
@@ -182,6 +188,7 @@ export default {
   created() {
     this.getListFestival();
     this.loadQuestionnaireTypes({ filter: { active: '1' }, orderBy: {} });
+    this.loadTemplate();
   },
 };
 </script>

--- a/FrontEnd/src/store/modules/LocationModule/actions.js
+++ b/FrontEnd/src/store/modules/LocationModule/actions.js
@@ -1,6 +1,25 @@
 import axios from 'axios';
 
 const API = '/api/v1/location';
+// Список blade-шаблонов общий для типов билетов и локаций — переиспользуем существующий endpoint
+const TEMPLATE_API = '/api/v1/ticketType';
+
+/**
+ * Загрузить список доступных blade-шаблонов (email + pdf).
+ */
+export const loadTemplate = (context) => {
+    return new Promise((resolve, reject) => {
+        axios.get(TEMPLATE_API + '/getBlade')
+            .then((response) => {
+                context.commit('setTemplateList', response.data.list);
+                resolve(response.data.list);
+            })
+            .catch((error) => {
+                context.commit('setError', error);
+                reject(error);
+            });
+    });
+};
 
 export const loadList = (context, payload) => {
     return new Promise((resolve, reject) => {

--- a/FrontEnd/src/store/modules/LocationModule/actions.js
+++ b/FrontEnd/src/store/modules/LocationModule/actions.js
@@ -15,7 +15,8 @@ export const loadTemplate = (context) => {
                 resolve(response.data.list);
             })
             .catch((error) => {
-                context.commit('setError', error);
+                // Согласованный формат с другими actions модуля — всегда массив errors
+                context.commit('setError', error.response?.data?.errors ?? []);
                 reject(error);
             });
     });

--- a/FrontEnd/src/store/modules/LocationModule/getters.js
+++ b/FrontEnd/src/store/modules/LocationModule/getters.js
@@ -11,3 +11,7 @@ export const getIsLoading = (state) => state.isLoading;
 export const getDataError = (state) => state.dataError;
 
 export const getMessage = (state) => state.message;
+
+export const getTemplateEmail = (state) => state.templateList?.email ?? [];
+
+export const getTemplatePdf = (state) => state.templateList?.pdf ?? [];

--- a/FrontEnd/src/store/modules/LocationModule/index.js
+++ b/FrontEnd/src/store/modules/LocationModule/index.js
@@ -12,6 +12,7 @@ export default {
         isLoading: false,
         dataError: [],
         message: null,
+        templateList: { email: [], pdf: [] },
     },
     getters,
     actions,

--- a/FrontEnd/src/store/modules/LocationModule/mutations.js
+++ b/FrontEnd/src/store/modules/LocationModule/mutations.js
@@ -29,3 +29,10 @@ export const setMessage = (state, payload) => {
 export const removeInList = (state, payload) => {
     state.list = state.list.filter((item) => item.id !== payload.id);
 };
+
+export const setTemplateList = (state, payload) => {
+    state.templateList = {
+        email: payload?.email ?? [],
+        pdf: payload?.pdf ?? [],
+    };
+};


### PR DESCRIPTION
Раньше в форме локации (LocationItem.vue) шаблоны email_template и pdf_template вводились произвольным текстом — пользователь мог опечататься и сохранить несуществующий blade-файл (ошибка проявится только при попытке отправить письмо APPROVE_LIST).

По аналогии с TicketTypeItem (использует /api/v1/ticketType/getBlade) — переиспользуем тот же endpoint для списка доступных blade-файлов:

LocationModule (Vuex):
- state.templateList: { email: [], pdf: [] }
- action loadTemplate() → GET /api/v1/ticketType/getBlade
- mutation setTemplateList()
- getters getTemplateEmail / getTemplatePdf

LocationItem.vue:
- input → select для email_template и pdf_template
- первая опция — "по умолчанию" (пустое значение → fallback в Mailable)
- created() вызывает loadTemplate()