### PR TITLE
feat(festival): CRUD волн цен типа билета (ticket_type_price)

### DIFF
--- a/.claude/docs/API.md
+++ b/.claude/docs/API.md
@@ -554,6 +554,58 @@
 
 ---
 
+## 8.0. Волны цен типа билета
+
+Префикс: **`/api/v1/ticketTypePrice`**
+
+Управление таблицей `ticket_type_price` (волны цен — см. BUSINESS_RULES §4). Каждая волна — это запись `{ price, before_date }` для конкретного `ticket_type_id`. Активной считается ближайшая волна, у которой `before_date >= CURDATE()`.
+
+| Метод | Маршрут | Middleware | Описание |
+|-------|---------|------------|----------|
+| POST | `/getList` | публичный | Список волн с фильтром `ticket_type_id` |
+| GET | `/getItem/{id}` | публичный | Одна волна |
+| POST | `/create` | `auth:api` + `admin` | Создать волну (UUID в `data.id` опционально) |
+| POST | `/edit/{id}` | `auth:api` + `admin` | Редактировать |
+| DELETE | `/delete/{id}` | `auth:api` + `admin` | Soft delete (запись помечается как удалённая) |
+
+**create / edit Request:**
+```json
+{
+  "data": {
+    "ticket_type_id": "UUID (required, exists:ticket_type,id)",
+    "price": "float (required, > 0, < 1 000 000)",
+    "before_date": "date (required, after_or_equal:today)"
+  }
+}
+```
+
+**Защита от дурака (валидация):**
+- `price` — обязательно > 0 и < 1 000 000
+- `before_date` — валидная дата, не в прошлом
+- `ticket_type_id` — должен существовать в `ticket_type`
+- На фронте — кнопка `Сохранить` неактивна при невалидной форме, удаление через `confirm()`
+
+**Response 200 (create/edit):**
+```json
+{
+  "success": true,
+  "item": { "id": "...", "ticket_type_id": "...", "price": 4200, "before_date": "..." },
+  "message": "Волна цены создана"
+}
+```
+
+**Response 422 (валидация):**
+```json
+{
+  "errors": {
+    "data.price": ["Цена должна быть больше 0"],
+    "data.before_date": ["Дата не может быть в прошлом"]
+  }
+}
+```
+
+---
+
 ## 8.1. Локации (для заказов-списков)
 
 Префикс: **`/api/v1/location`**
@@ -645,9 +697,9 @@
 
 | Категория | Маршруты |
 |-----------|----------|
-| **Публичные** | login, register, forgot-password, resetPassword, festival/*, order/create, order/succes, ticket/live, questionnaireType/*, ticketType/*, typesOfPayment/*, location/getList, location/getItem, invite/isCorrectInviteLink, questionnaire/send, questionnaire/sendNewUser, questionnaire/getQuestionnaireTypeByOrderTicket, questionnaire/getByOrderTicket |
+| **Публичные** | login, register, forgot-password, resetPassword, festival/*, order/create, order/succes, ticket/live, questionnaireType/*, ticketType/*, typesOfPayment/*, location/getList, location/getItem, ticketTypePrice/getList, ticketTypePrice/getItem, invite/isCorrectInviteLink, questionnaire/send, questionnaire/sendNewUser, questionnaire/getQuestionnaireTypeByOrderTicket, questionnaire/getByOrderTicket |
 | **Только auth** | user, logout, refresh, isCorrectRole, editProfile, editPassword, order/getUserList, order/getItem, order/getTicketPdf, invite/getInviteLink |
-| **admin** | festival/getTicketTypeList, account/*, promoCode/*, questionnaire/load, questionnaire/notification, questionnaire/approve, questionnaire/get, order/getHistory, location/{create,edit,delete} |
+| **admin** | festival/getTicketTypeList, account/*, promoCode/*, questionnaire/load, questionnaire/notification, questionnaire/approve, questionnaire/get, order/getHistory, location/{create,edit,delete}, ticketTypePrice/{create,edit,delete} |
 | **role: seller,admin** | order/getList |
 | **role: pusher,admin** | order/getListForFriendly, order/createFriendly |
 | **role: curator** | order/createList |

--- a/.claude/docs/API.md
+++ b/.claude/docs/API.md
@@ -562,11 +562,21 @@
 
 | Метод | Маршрут | Middleware | Описание |
 |-------|---------|------------|----------|
-| POST | `/getList` | публичный | Список волн с фильтром `ticket_type_id` |
+| POST | `/getList` | публичный | Список волн **с обязательным** `filter.ticket_type_id` |
 | GET | `/getItem/{id}` | публичный | Одна волна |
 | POST | `/create` | `auth:api` + `admin` | Создать волну (UUID в `data.id` опционально) |
 | POST | `/edit/{id}` | `auth:api` + `admin` | Редактировать |
 | DELETE | `/delete/{id}` | `auth:api` + `admin` | Soft delete (запись помечается как удалённая) |
+
+**getList Request:**
+```json
+{
+  "filter": { "ticket_type_id": "UUID (required, exists:ticket_type,id)" },
+  "orderBy": { "before_date": "asc" }
+}
+```
+- `filter.ticket_type_id` — обязателен, иначе вернётся 422 (нет «получи всё»)
+- `orderBy.*` допускает только `asc` / `desc`; некорректное значение игнорируется (fallback на `Order::none()`)
 
 **create / edit Request:**
 ```json

--- a/.claude/docs/BOARD.md
+++ b/.claude/docs/BOARD.md
@@ -21,6 +21,16 @@
 - **В работе:** 0
 - **Критичных проблем:** 2 (Тесты, Воркер)
 
+### ✅ Сделано 2026-05-10
+**CRUD для волн цен типа билета (`ticket_type_price`).**
+- Backend модуль `Backend/src/TicketTypePrice/` (DTO, Repository + Interface, Application, Create/Edit/Delete/GetList/GetItem handlers)
+- Контроллер `TicketTypePriceController` с FormRequest-валидацией
+- Роуты `/api/v1/ticketTypePrice/*` — read публичный, write только `auth:api + admin`
+- SoftDeletes в `TicketTypesPriceModel` + кастинг `price`/`before_date`
+- Защита от дурака: `price > 0` и `< 1 000 000`, `before_date` не в прошлом, `ticket_type_id` exists; на фронте — disable кнопки, `confirm()` на удаление
+- Frontend: Vuex `TicketTypePriceModule` + компонент `TicketTypePriceList.vue`, встроен в форму редактирования типа билета (`TicketTypeItem.vue`)
+- 🌿 ветка `feat/ticket-type-price-crud`
+
 ### ✅ Сделано 2026-05-04
 **Заказы-списки + сущность Локации.**
 - 3 миграции (`locations` table, `location_id`/`curator_id` в `order_tickets`, nullable полей)

--- a/.claude/docs/DOMAIN.md
+++ b/.claude/docs/DOMAIN.md
@@ -393,6 +393,23 @@ Bus::chain($list)->delay(now()->addMinutes($delay))->dispatch();
 | `editItem(Uuid, LocationDto): bool` | Редактировать |
 | `remove(Uuid): bool` | Удалить |
 
+### TicketTypePriceRepositoryInterface
+
+**Путь:** `Backend/src/TicketTypePrice/Repositories/TicketTypePriceRepositoryInterface.php`
+**Реализация:** `InMemoryMySqlTicketTypePriceRepository` (таблица `ticket_type_price`, soft delete)
+
+| Метод | Описание |
+|-------|----------|
+| `getList(Filters, Order): Collection` | Список волн (фильтр `ticket_type_id`) |
+| `getItem(Uuid): TicketTypePriceDto` | Одна волна |
+| `create(TicketTypePriceDto): bool` | Создать |
+| `editItem(Uuid, TicketTypePriceDto): bool` | Редактировать |
+| `remove(Uuid): bool` | Soft delete (помечает запись как удалённую) |
+
+**DTO `TicketTypePriceDto`:** `id` (Uuid), `ticket_type_id` (Uuid), `price` (float), `before_date` (Carbon).
+
+**Связь с TicketType:** `Tickets\TicketType\Repository\InMemoryTicketTypeRepository::buildBuilder()` берёт текущую цену билета подзапросом к `ticket_type_price` (`before_date >= CURDATE()`, ORDER BY `before_date` ASC LIMIT 1) — поведение не изменено. Новый CRUD управляет содержимым этой таблицы через API.
+
 ### HistoryRepositoryInterface
 
 **Путь:** `Backend/src/History/Repositories/HistoryRepositoryInterface.php`

--- a/.claude/docs/TECH_DEBT.md
+++ b/.claude/docs/TECH_DEBT.md
@@ -15,6 +15,7 @@
 | Medium | Логирование действий админов (смена статусов, удаление) | DevOps | 2026-04-04 | — |
 | Medium | Настроить CI/CD пайплайн (GitHub Actions) | DevOps | 2026-04-04 | — |
 | Medium | Миграция Bootstrap 4 → 5 (модалки через vanilla JS) | Frontend Helper | 2026-04-12 | — |
+| Medium | Единый паттерн для `Order::none()` в фильтрах списков | Tech Lead | 2026-05-10 | — |
 | Low | Миграция на Vue Router lazy loading | Frontend Helper | 2026-04-04 | — |
 | Low | Заменить jQuery модалки на нативные Vue | Tester | 2026-04-04 | — |
 | Low | Единый Response Interceptor для Axios | Frontend Helper | 2026-04-04 | — |
@@ -26,3 +27,23 @@
 **Правило:** PM напоминает об этом файле раз в 5-10 коммитов.
 
 **Критично до 1 июня:** Только фиксы багов, никаких Laravel-апдейтов.
+
+---
+
+## Заметки по задачам
+
+### Единый паттерн `Order::none()` в фильтрах списков (2026-05-10)
+**Проблема:** `Order::fromState($data)` создаёт `new OrderType($data[$key])`, который кидает `InvalidArgumentException` на чужих значениях. Контроллеры (`LocationController`, `TicketTypeController`, новые `TicketTypePriceController`) обрабатывают это по-разному: где-то нет защиты вовсе → 500, где-то локальный try/catch с fallback на `Order::none()`, где-то FormRequest валидирует `orderBy.*`.
+
+**Что обдумать:**
+- Сделать `Order::fromStateSafe()` в Shared (или утилиту/трейт) — один источник truth, возвращает `Order::none()` на невалидных данных.
+- Либо ввести базовый `ListRequest` (FormRequest) с общими правилами `orderBy.*` ∈ `{asc, desc}` и наследовать от него.
+- Либо изменить `OrderType` так, чтобы он не кидал, а помечал значение как `none()` (опаснее — поведение Shared).
+
+**Где сейчас плодится дубль:**
+- `TicketTypePriceController::getList()` — try/catch + Order::none()
+- `LocationController::getList()` — без защиты
+- `TicketTypeController::getList()` — без защиты
+- много других `*Controller::getList()` в проекте
+
+**Решение принять до:** следующего модуля с публичным `getList`-эндпоинтом, чтобы не дублировать рецепт.

--- a/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
+++ b/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\TicketTypePrice\TicketTypePriceEditRequest;
 use DomainException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Nette\Utils\JsonException;
 use Shared\Domain\Criteria\Order;
 use Shared\Domain\ValueObject\Uuid;
@@ -49,11 +50,16 @@ class TicketTypePriceController extends Controller
                 'success' => true,
                 'item' => $application->getItem(new Uuid($id))->toArray(),
             ]);
+        } catch (InvalidArgumentException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
         } catch (DomainException $exception) {
             return response()->json([
                 'success' => false,
                 'message' => $exception->getMessage(),
-            ]);
+            ], 404);
         }
     }
 
@@ -64,13 +70,22 @@ class TicketTypePriceController extends Controller
         TicketTypePriceCreateRequest $request,
         TicketTypePriceApplication $application,
     ): JsonResponse {
-        $data = TicketTypePriceDto::fromState($request->validated()['data']);
+        try {
+            $data = TicketTypePriceDto::fromState($request->validated()['data']);
 
-        return response()->json([
-            'success' => $application->create($data),
-            'item' => $application->getItem($data->getId())->toArray(),
-            'message' => 'Волна цены создана',
-        ]);
+            return response()->json([
+                'success' => $application->create($data),
+                'item' => $application->getItem($data->getId())->toArray(),
+                'message' => 'Волна цены создана',
+            ]);
+        } catch (InvalidArgumentException $exception) {
+            // Защита от некорректного UUID в data.id (FormRequest уже валидирует,
+            // но оставляем guard для случаев минуя валидацию)
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        }
     }
 
     /**
@@ -95,11 +110,16 @@ class TicketTypePriceController extends Controller
                 'item' => $application->getItem(new Uuid($id))->toArray(),
                 'message' => 'Волна цены отредактирована',
             ]);
+        } catch (InvalidArgumentException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
         } catch (DomainException $exception) {
             return response()->json([
                 'success' => false,
                 'message' => $exception->getMessage(),
-            ]);
+            ], 404);
         }
     }
 
@@ -110,8 +130,20 @@ class TicketTypePriceController extends Controller
         string $id,
         TicketTypePriceApplication $application,
     ): JsonResponse {
-        return response()->json([
-            'success' => $application->delete(new Uuid($id)),
-        ]);
+        try {
+            return response()->json([
+                'success' => $application->delete(new Uuid($id)),
+            ]);
+        } catch (InvalidArgumentException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
     }
 }

--- a/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
+++ b/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\TicketTypePrice;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TicketTypePrice\TicketTypePriceCreateRequest;
+use App\Http\Requests\TicketTypePrice\TicketTypePriceEditRequest;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Nette\Utils\JsonException;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\TicketTypePrice\Application\GetList\TicketTypePriceGetListQuery;
+use Tickets\TicketTypePrice\Application\TicketTypePriceApplication;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+
+class TicketTypePriceController extends Controller
+{
+    public function getList(
+        Request $request,
+        TicketTypePriceApplication $application,
+    ): JsonResponse {
+        $collection = $application->getList(
+            new TicketTypePriceGetListQuery(
+                $request->toArray()['filter'] ?? [],
+                Order::fromState($request->toArray()['orderBy'] ?? [])
+            ),
+        )->getCollection();
+
+        return response()->json([
+            'success' => true,
+            'list' => $collection->map(fn (TicketTypePriceDto $dto) => $dto->toArray())->values()->all(),
+        ]);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function getItem(
+        string $id,
+        TicketTypePriceApplication $application,
+    ): JsonResponse {
+        try {
+            return response()->json([
+                'success' => true,
+                'item' => $application->getItem(new Uuid($id))->toArray(),
+            ]);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function create(
+        TicketTypePriceCreateRequest $request,
+        TicketTypePriceApplication $application,
+    ): JsonResponse {
+        $data = TicketTypePriceDto::fromState($request->validated()['data']);
+
+        return response()->json([
+            'success' => $application->create($data),
+            'item' => $application->getItem($data->getId())->toArray(),
+            'message' => 'Волна цены создана',
+        ]);
+    }
+
+    /**
+     * @throws Throwable
+     * @throws JsonException
+     */
+    public function edit(
+        string $id,
+        TicketTypePriceEditRequest $request,
+        TicketTypePriceApplication $application,
+    ): JsonResponse {
+        try {
+            $payload = $request->validated()['data'];
+            // Гарантируем, что id из URL совпадает с DTO
+            $payload['id'] = $id;
+
+            return response()->json([
+                'success' => $application->edit(
+                    new Uuid($id),
+                    TicketTypePriceDto::fromState($payload)
+                ),
+                'item' => $application->getItem(new Uuid($id))->toArray(),
+                'message' => 'Волна цены отредактирована',
+            ]);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function delete(
+        string $id,
+        TicketTypePriceApplication $application,
+    ): JsonResponse {
+        return response()->json([
+            'success' => $application->delete(new Uuid($id)),
+        ]);
+    }
+}

--- a/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
+++ b/Backend/app/Http/Controllers/TicketTypePrice/TicketTypePriceController.php
@@ -7,9 +7,9 @@ namespace App\Http\Controllers\TicketTypePrice;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\TicketTypePrice\TicketTypePriceCreateRequest;
 use App\Http\Requests\TicketTypePrice\TicketTypePriceEditRequest;
+use App\Http\Requests\TicketTypePrice\TicketTypePriceGetListRequest;
 use DomainException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Nette\Utils\JsonException;
 use Shared\Domain\Criteria\Order;
@@ -22,14 +22,21 @@ use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
 class TicketTypePriceController extends Controller
 {
     public function getList(
-        Request $request,
+        TicketTypePriceGetListRequest $request,
         TicketTypePriceApplication $application,
     ): JsonResponse {
+        $validated = $request->validated();
+
+        // FormRequest уже валидирует orderBy, но Order::fromState на всякий случай
+        // оборачиваем — OrderType кидает InvalidArgumentException на чужих значениях
+        try {
+            $orderBy = Order::fromState($validated['orderBy'] ?? []);
+        } catch (InvalidArgumentException) {
+            $orderBy = Order::none();
+        }
+
         $collection = $application->getList(
-            new TicketTypePriceGetListQuery(
-                $request->toArray()['filter'] ?? [],
-                Order::fromState($request->toArray()['orderBy'] ?? [])
-            ),
+            new TicketTypePriceGetListQuery($validated['filter'], $orderBy),
         )->getCollection();
 
         return response()->json([
@@ -50,7 +57,7 @@ class TicketTypePriceController extends Controller
                 'success' => true,
                 'item' => $application->getItem(new Uuid($id))->toArray(),
             ]);
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException) {
             return response()->json([
                 'success' => false,
                 'message' => 'Некорректный идентификатор',
@@ -110,7 +117,7 @@ class TicketTypePriceController extends Controller
                 'item' => $application->getItem(new Uuid($id))->toArray(),
                 'message' => 'Волна цены отредактирована',
             ]);
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException) {
             return response()->json([
                 'success' => false,
                 'message' => 'Некорректный идентификатор',
@@ -134,7 +141,7 @@ class TicketTypePriceController extends Controller
             return response()->json([
                 'success' => $application->delete(new Uuid($id)),
             ]);
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException) {
             return response()->json([
                 'success' => false,
                 'message' => 'Некорректный идентификатор',

--- a/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceCreateRequest.php
+++ b/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceCreateRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\TicketTypePrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на создание волны цены билета.
+ *
+ * Правила:
+ *  - price > 0 и < 1 000 000 (предохранитель от случайных миллиардов)
+ *  - before_date — валидная дата, не в прошлом (нельзя задним числом)
+ *  - ticket_type_id — существующий тип билета
+ */
+class TicketTypePriceCreateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.ticket_type_id' => ['required', 'string', 'uuid', 'exists:ticket_type,id'],
+            'data.price' => ['required', 'numeric', 'gt:0', 'lt:1000000'],
+            'data.before_date' => ['required', 'date', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.ticket_type_id.required' => 'Не указан тип билета',
+            'data.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
+            'data.ticket_type_id.exists' => 'Указанный тип билета не существует',
+            'data.price.required' => 'Цена обязательна',
+            'data.price.numeric' => 'Цена должна быть числом',
+            'data.price.gt' => 'Цена должна быть больше 0',
+            'data.price.lt' => 'Цена слишком велика (максимум 999 999)',
+            'data.before_date.required' => 'Дата окончания волны обязательна',
+            'data.before_date.date' => 'Некорректная дата',
+            'data.before_date.after_or_equal' => 'Дата не может быть в прошлом',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceCreateRequest.php
+++ b/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceCreateRequest.php
@@ -25,6 +25,7 @@ class TicketTypePriceCreateRequest extends FormRequest
     {
         return [
             'data' => ['required', 'array'],
+            'data.id' => ['sometimes', 'string', 'uuid'],
             'data.ticket_type_id' => ['required', 'string', 'uuid', 'exists:ticket_type,id'],
             'data.price' => ['required', 'numeric', 'gt:0', 'lt:1000000'],
             'data.before_date' => ['required', 'date', 'after_or_equal:today'],
@@ -34,6 +35,7 @@ class TicketTypePriceCreateRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'data.id.uuid' => 'Идентификатор должен быть UUID',
             'data.ticket_type_id.required' => 'Не указан тип билета',
             'data.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
             'data.ticket_type_id.exists' => 'Указанный тип билета не существует',

--- a/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceEditRequest.php
+++ b/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceEditRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\TicketTypePrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на редактирование волны цены билета.
+ *
+ * Правила те же, что и при создании. Дата в прошлом запрещена,
+ * чтобы случайно не «переиграть» уже отгремевшие волны.
+ */
+class TicketTypePriceEditRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.ticket_type_id' => ['required', 'string', 'uuid', 'exists:ticket_type,id'],
+            'data.price' => ['required', 'numeric', 'gt:0', 'lt:1000000'],
+            'data.before_date' => ['required', 'date', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.ticket_type_id.required' => 'Не указан тип билета',
+            'data.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
+            'data.ticket_type_id.exists' => 'Указанный тип билета не существует',
+            'data.price.required' => 'Цена обязательна',
+            'data.price.numeric' => 'Цена должна быть числом',
+            'data.price.gt' => 'Цена должна быть больше 0',
+            'data.price.lt' => 'Цена слишком велика (максимум 999 999)',
+            'data.before_date.required' => 'Дата окончания волны обязательна',
+            'data.before_date.date' => 'Некорректная дата',
+            'data.before_date.after_or_equal' => 'Дата не может быть в прошлом',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceGetListRequest.php
+++ b/Backend/app/Http/Requests/TicketTypePrice/TicketTypePriceGetListRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\TicketTypePrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Защита публичного getList:
+ *  - filter.ticket_type_id обязателен (uuid + exists), иначе вернётся ВЕСЬ список волн
+ *  - orderBy.* допускает только asc/desc (предотвращает InvalidArgumentException из OrderType)
+ */
+class TicketTypePriceGetListRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'filter' => ['required', 'array'],
+            'filter.ticket_type_id' => ['required', 'string', 'uuid', 'exists:ticket_type,id'],
+            'orderBy' => ['sometimes', 'array'],
+            'orderBy.*' => ['sometimes', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'filter.required' => 'Не передан фильтр',
+            'filter.ticket_type_id.required' => 'Не указан тип билета',
+            'filter.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
+            'filter.ticket_type_id.exists' => 'Указанный тип билета не существует',
+            'orderBy.*.in' => 'Направление сортировки должно быть asc или desc',
+        ];
+    }
+}

--- a/Backend/app/Models/Festival/TicketTypesPriceModel.php
+++ b/Backend/app/Models/Festival/TicketTypesPriceModel.php
@@ -8,6 +8,7 @@ use Eloquent;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Shared\Infrastructure\Models\HasUuid;
 
@@ -35,7 +36,7 @@ use Shared\Infrastructure\Models\HasUuid;
  */
 class TicketTypesPriceModel extends Model
 {
-    use HasFactory, HasUuid;
+    use HasFactory, HasUuid, SoftDeletes;
 
     public const TABLE = 'ticket_type_price';
 
@@ -44,5 +45,10 @@ class TicketTypesPriceModel extends Model
 
     protected $fillable = [
         'id', 'before_date', 'price', 'ticket_type_id',
+    ];
+
+    protected $casts = [
+        'price' => 'float',
+        'before_date' => 'datetime',
     ];
 }

--- a/Backend/app/Providers/RouteServiceProvider.php
+++ b/Backend/app/Providers/RouteServiceProvider.php
@@ -68,6 +68,10 @@ class RouteServiceProvider extends ServiceProvider
 
             Route::middleware('api')
                 ->prefix('api')
+                ->group(base_path('routes/ticketTypePrice.php'));
+
+            Route::middleware('api')
+                ->prefix('api')
                 ->group(base_path('routes/questionnaireType.php'));
 
             Route::middleware('api')

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -38,6 +38,8 @@ use Tickets\Auto\Repositories\AutoRepositoryInterface;
 use Tickets\Auto\Repositories\InMemoryMySqlAutoRepository;
 use Tickets\Location\Repositories\InMemoryMySqlLocationRepository;
 use Tickets\Location\Repositories\LocationRepositoryInterface;
+use Tickets\TicketTypePrice\Repositories\InMemoryMySqlTicketTypePriceRepository;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
 
@@ -67,6 +69,7 @@ class TicketsProvider extends ServiceProvider
         $this->app->singleton(QuestionnaireValidationService::class, QuestionnaireValidationService::class);
         $this->app->bind(HistoryRepositoryInterface::class, InMemoryMySqlHistoryRepository::class);
         $this->app->bind(LocationRepositoryInterface::class, InMemoryMySqlLocationRepository::class);
+        $this->app->bind(TicketTypePriceRepositoryInterface::class, InMemoryMySqlTicketTypePriceRepository::class);
         $this->app->bind(AutoRepositoryInterface::class, InMemoryMySqlAutoRepository::class);
     }
 }

--- a/Backend/routes/ticketTypePrice.php
+++ b/Backend/routes/ticketTypePrice.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\TicketTypePrice\TicketTypePriceController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1/ticketTypePrice')->group(static function (): void {
+    // Чтение списка волн остаётся публичным — цены отображаются на форме покупки
+    Route::post('/getList', [TicketTypePriceController::class, 'getList']);
+    Route::get('/getItem/{id}', [TicketTypePriceController::class, 'getItem']);
+
+    // Изменения волн — только админ (защита от дурака на уровне доступа)
+    Route::post('/create', [TicketTypePriceController::class, 'create'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::post('/edit/{id}', [TicketTypePriceController::class, 'edit'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::delete('/delete/{id}', [TicketTypePriceController::class, 'delete'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+});

--- a/Backend/src/TicketType/Repository/InMemoryTicketTypeRepository.php
+++ b/Backend/src/TicketType/Repository/InMemoryTicketTypeRepository.php
@@ -60,6 +60,7 @@ class InMemoryTicketTypeRepository implements TicketTypeRepositoryInterface
             (SELECT price
              FROM ' . TicketTypesPriceModel::TABLE . '
              WHERE ' . TicketTypesPriceModel::TABLE . '.ticket_type_id = ' . $this->model::TABLE . '.id
+             AND ' . TicketTypesPriceModel::TABLE . '.deleted_at IS NULL
              AND before_date >= CURDATE()
              ORDER BY before_date ASC
              LIMIT 1),

--- a/Backend/src/TicketTypePrice/Application/Create/TicketTypePriceCreateCommand.php
+++ b/Backend/src/TicketTypePrice/Application/Create/TicketTypePriceCreateCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Create;
+
+use Shared\Domain\Bus\Command\Command;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+
+class TicketTypePriceCreateCommand implements Command
+{
+    public function __construct(
+        private TicketTypePriceDto $data,
+    ) {
+    }
+
+    public function getData(): TicketTypePriceDto
+    {
+        return $this->data;
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/Create/TicketTypePriceCreateCommandHandler.php
+++ b/Backend/src/TicketTypePrice/Application/Create/TicketTypePriceCreateCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Create;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
+
+class TicketTypePriceCreateCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private TicketTypePriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(TicketTypePriceCreateCommand $command): void
+    {
+        $this->repository->create($command->getData());
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/Delete/TicketTypePriceDeleteCommand.php
+++ b/Backend/src/TicketTypePrice/Application/Delete/TicketTypePriceDeleteCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Delete;
+
+use Shared\Domain\Bus\Command\Command;
+use Shared\Domain\ValueObject\Uuid;
+
+class TicketTypePriceDeleteCommand implements Command
+{
+    public function __construct(
+        private Uuid $id,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/Delete/TicketTypePriceDeleteCommandHandler.php
+++ b/Backend/src/TicketTypePrice/Application/Delete/TicketTypePriceDeleteCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Delete;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
+
+class TicketTypePriceDeleteCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private TicketTypePriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(TicketTypePriceDeleteCommand $command): void
+    {
+        $this->repository->remove($command->getId());
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/Edit/TicketTypePriceEditCommand.php
+++ b/Backend/src/TicketTypePrice/Application/Edit/TicketTypePriceEditCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Edit;
+
+use Shared\Domain\Bus\Command\Command;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+
+class TicketTypePriceEditCommand implements Command
+{
+    public function __construct(
+        private Uuid $id,
+        private TicketTypePriceDto $data,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getData(): TicketTypePriceDto
+    {
+        return $this->data;
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/Edit/TicketTypePriceEditCommandHandler.php
+++ b/Backend/src/TicketTypePrice/Application/Edit/TicketTypePriceEditCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\Edit;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
+
+class TicketTypePriceEditCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private TicketTypePriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(TicketTypePriceEditCommand $command): void
+    {
+        $this->repository->editItem($command->getId(), $command->getData());
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/GetItem/TicketTypePriceGetItemQuery.php
+++ b/Backend/src/TicketTypePrice/Application/GetItem/TicketTypePriceGetItemQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\GetItem;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\ValueObject\Uuid;
+
+class TicketTypePriceGetItemQuery implements Query
+{
+    public function __construct(
+        private Uuid $id,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/GetItem/TicketTypePriceGetItemQueryHandler.php
+++ b/Backend/src/TicketTypePrice/Application/GetItem/TicketTypePriceGetItemQueryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\GetItem;
+
+use Shared\Domain\Bus\Query\QueryHandler;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
+
+class TicketTypePriceGetItemQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private TicketTypePriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(TicketTypePriceGetItemQuery $query): TicketTypePriceDto
+    {
+        return $this->repository->getItem($query->getId());
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/GetList/TicketTypePriceGetListQuery.php
+++ b/Backend/src/TicketTypePrice/Application/GetList/TicketTypePriceGetListQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\GetList;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\Criteria\Order;
+
+class TicketTypePriceGetListQuery implements Query
+{
+    public function __construct(
+        private array $filter,
+        private Order $orderBy,
+    ) {
+    }
+
+    public function getFilter(): array
+    {
+        return $this->filter;
+    }
+
+    public function getOrderBy(): Order
+    {
+        return $this->orderBy;
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/GetList/TicketTypePriceGetListQueryHandler.php
+++ b/Backend/src/TicketTypePrice/Application/GetList/TicketTypePriceGetListQueryHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application\GetList;
+
+use App\Models\Festival\TicketTypesPriceModel;
+use Shared\Domain\Bus\Query\QueryHandler;
+use Shared\Domain\Criteria\FilterOperator;
+use Shared\Domain\Criteria\Filters;
+use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
+use Tickets\TicketTypePrice\Response\TicketTypePriceGetListResponse;
+
+class TicketTypePriceGetListQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private TicketTypePriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(TicketTypePriceGetListQuery $query): TicketTypePriceGetListResponse
+    {
+        $filter = $query->getFilter();
+        $filters = Filters::fromValues($this->getFilterValues($filter));
+
+        return new TicketTypePriceGetListResponse(
+            $this->repository->getList($filters, $query->getOrderBy())
+        );
+    }
+
+    private function getFilterValues(array $filter): array
+    {
+        return [
+            [
+                'field' => TicketTypesPriceModel::TABLE . '.ticket_type_id',
+                'operator' => FilterOperator::EQUAL,
+                'value' => $filter['ticket_type_id'] ?? null,
+            ],
+        ];
+    }
+}

--- a/Backend/src/TicketTypePrice/Application/TicketTypePriceApplication.php
+++ b/Backend/src/TicketTypePrice/Application/TicketTypePriceApplication.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Application;
+
+use Shared\Domain\Bus\Command\CommandBus;
+use Shared\Domain\Bus\Query\QueryBus;
+use Shared\Domain\ValueObject\Uuid;
+use Shared\Infrastructure\Bus\Command\InMemorySymfonyCommandBus;
+use Shared\Infrastructure\Bus\Query\InMemorySymfonyQueryBus;
+use Tickets\TicketTypePrice\Application\Create\TicketTypePriceCreateCommand;
+use Tickets\TicketTypePrice\Application\Create\TicketTypePriceCreateCommandHandler;
+use Tickets\TicketTypePrice\Application\Delete\TicketTypePriceDeleteCommand;
+use Tickets\TicketTypePrice\Application\Delete\TicketTypePriceDeleteCommandHandler;
+use Tickets\TicketTypePrice\Application\Edit\TicketTypePriceEditCommand;
+use Tickets\TicketTypePrice\Application\Edit\TicketTypePriceEditCommandHandler;
+use Tickets\TicketTypePrice\Application\GetItem\TicketTypePriceGetItemQuery;
+use Tickets\TicketTypePrice\Application\GetItem\TicketTypePriceGetItemQueryHandler;
+use Tickets\TicketTypePrice\Application\GetList\TicketTypePriceGetListQuery;
+use Tickets\TicketTypePrice\Application\GetList\TicketTypePriceGetListQueryHandler;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+use Tickets\TicketTypePrice\Response\TicketTypePriceGetListResponse;
+
+class TicketTypePriceApplication
+{
+    private CommandBus $commandBus;
+
+    private QueryBus $queryBus;
+
+    public function __construct(
+        TicketTypePriceGetListQueryHandler $getListQueryHandler,
+        TicketTypePriceGetItemQueryHandler $getItemQueryHandler,
+        TicketTypePriceCreateCommandHandler $createCommandHandler,
+        TicketTypePriceEditCommandHandler $editCommandHandler,
+        TicketTypePriceDeleteCommandHandler $deleteCommandHandler,
+    ) {
+        $this->commandBus = new InMemorySymfonyCommandBus([
+            TicketTypePriceCreateCommand::class => $createCommandHandler,
+            TicketTypePriceEditCommand::class => $editCommandHandler,
+            TicketTypePriceDeleteCommand::class => $deleteCommandHandler,
+        ]);
+
+        $this->queryBus = new InMemorySymfonyQueryBus([
+            TicketTypePriceGetListQuery::class => $getListQueryHandler,
+            TicketTypePriceGetItemQuery::class => $getItemQueryHandler,
+        ]);
+    }
+
+    public function getList(TicketTypePriceGetListQuery $query): TicketTypePriceGetListResponse
+    {
+        /** @var TicketTypePriceGetListResponse $result */
+        $result = $this->queryBus->ask($query);
+
+        return $result;
+    }
+
+    public function getItem(Uuid $uuid): TicketTypePriceDto
+    {
+        /** @var TicketTypePriceDto $result */
+        $result = $this->queryBus->ask(new TicketTypePriceGetItemQuery($uuid));
+
+        return $result;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function create(TicketTypePriceDto $data): bool
+    {
+        $this->commandBus->dispatch(new TicketTypePriceCreateCommand($data));
+
+        return true;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function edit(Uuid $id, TicketTypePriceDto $data): bool
+    {
+        $this->commandBus->dispatch(new TicketTypePriceEditCommand($id, $data));
+
+        return true;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function delete(Uuid $id): bool
+    {
+        $this->commandBus->dispatch(new TicketTypePriceDeleteCommand($id));
+
+        return true;
+    }
+}

--- a/Backend/src/TicketTypePrice/Dto/TicketTypePriceDto.php
+++ b/Backend/src/TicketTypePrice/Dto/TicketTypePriceDto.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Dto;
+
+use Carbon\Carbon;
+use Shared\Domain\Bus\Query\Response;
+use Shared\Domain\Entity\AbstractionEntity;
+use Shared\Domain\ValueObject\Uuid;
+
+class TicketTypePriceDto extends AbstractionEntity implements Response
+{
+    public function __construct(
+        protected Uuid    $id,
+        protected Uuid    $ticket_type_id,
+        protected float   $price,
+        protected Carbon  $before_date,
+        protected ?Carbon $created_at = null,
+        protected ?Carbon $updated_at = null,
+    ) {
+    }
+
+    public static function fromState(array $data): self
+    {
+        return new self(
+            empty($data['id']) ? Uuid::random() : new Uuid($data['id']),
+            new Uuid($data['ticket_type_id']),
+            (float) $data['price'],
+            new Carbon($data['before_date']),
+            empty($data['created_at']) ? null : new Carbon($data['created_at']),
+            empty($data['updated_at']) ? null : new Carbon($data['updated_at']),
+        );
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTicketTypeId(): Uuid
+    {
+        return $this->ticket_type_id;
+    }
+
+    public function getPrice(): float
+    {
+        return $this->price;
+    }
+
+    public function getBeforeDate(): Carbon
+    {
+        return $this->before_date;
+    }
+}

--- a/Backend/src/TicketTypePrice/Repositories/InMemoryMySqlTicketTypePriceRepository.php
+++ b/Backend/src/TicketTypePrice/Repositories/InMemoryMySqlTicketTypePriceRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Repositories;
+
+use App\Models\Festival\TicketTypesPriceModel;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\Filter\FilterBuilder;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+
+class InMemoryMySqlTicketTypePriceRepository implements TicketTypePriceRepositoryInterface
+{
+    public function __construct(
+        private TicketTypesPriceModel $model
+    ) {
+    }
+
+    public function getList(Filters $filters, Order $orderBy): Collection
+    {
+        $build = $this->model::query();
+
+        $result = FilterBuilder::build($build, $filters);
+
+        if ($orderBy->orderBy()->value()) {
+            $result = $result->orderBy(
+                $orderBy->orderBy()->value(),
+                $orderBy->orderType()->value()
+            );
+        } else {
+            $result = $result->orderBy('before_date', 'asc');
+        }
+
+        return $result->get()
+            ->map(fn (TicketTypesPriceModel $model) => TicketTypePriceDto::fromState($model->toArray()));
+    }
+
+    public function getItem(Uuid $id): TicketTypePriceDto
+    {
+        if (!$rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Волна цены не найдена ' . $id->value());
+        }
+
+        return TicketTypePriceDto::fromState($rawData->toArray());
+    }
+
+    public function create(TicketTypePriceDto $data): bool
+    {
+        DB::beginTransaction();
+        try {
+            $this->model->insert(
+                array_merge($data->toArrayForCreate(), [
+                    'created_at' => (string) (new Carbon()),
+                    'updated_at' => (string) (new Carbon()),
+                ])
+            );
+            DB::commit();
+
+            return true;
+        } catch (\Throwable $exception) {
+            DB::rollBack();
+            throw $exception;
+        }
+    }
+
+    public function editItem(Uuid $id, TicketTypePriceDto $data): bool
+    {
+        if (!$rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Волна цены не найдена ' . $id->value());
+        }
+
+        return $rawData->fill($data->toArrayForEdit())->save();
+    }
+
+    public function remove(Uuid $id): bool
+    {
+        return (bool) $this->model::whereId($id->value())->delete();
+    }
+}

--- a/Backend/src/TicketTypePrice/Repositories/TicketTypePriceRepositoryInterface.php
+++ b/Backend/src/TicketTypePrice/Repositories/TicketTypePriceRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Repositories;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\TicketTypePrice\Dto\TicketTypePriceDto;
+
+interface TicketTypePriceRepositoryInterface
+{
+    public function getList(Filters $filters, Order $orderBy): Collection;
+
+    public function getItem(Uuid $id): TicketTypePriceDto;
+
+    public function create(TicketTypePriceDto $data): bool;
+
+    public function editItem(Uuid $id, TicketTypePriceDto $data): bool;
+
+    public function remove(Uuid $id): bool;
+}

--- a/Backend/src/TicketTypePrice/Response/TicketTypePriceGetListResponse.php
+++ b/Backend/src/TicketTypePrice/Response/TicketTypePriceGetListResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\TicketTypePrice\Response;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Bus\Query\Response;
+
+class TicketTypePriceGetListResponse implements Response
+{
+    public function __construct(
+        private Collection $collection
+    ) {
+    }
+
+    public function getCollection(): Collection
+    {
+        return $this->collection;
+    }
+}

--- a/FrontEnd/src/components/TicketType/TicketTypeItem.vue
+++ b/FrontEnd/src/components/TicketType/TicketTypeItem.vue
@@ -171,6 +171,9 @@
 
             </div>
 
+            <!-- Управление волнами цен (только для существующего типа билета) -->
+            <TicketTypePriceList :ticketTypeId="id" v-if="id"/>
+
           </div>
         </div>
       </div>
@@ -180,9 +183,11 @@
 
 <script>
 import {mapActions, mapGetters} from "vuex";
+import TicketTypePriceList from "@/components/TicketType/TicketTypePriceList.vue";
 
 export default {
   name: "TicketTypeItem",
+  components: {TicketTypePriceList},
   props: {
     id: {
       type: [String],

--- a/FrontEnd/src/components/TicketType/TicketTypePriceList.vue
+++ b/FrontEnd/src/components/TicketType/TicketTypePriceList.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="ticket-type-price-list mt-4">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title">Волны цен</h4>
+        <p class="text-muted mb-3">
+          Цена билета меняется по волнам. Активной считается ближайшая волна,
+          у которой <code>before_date</code> &ge; сегодня. После прохождения даты
+          включается следующая волна.
+        </p>
+
+        <div v-if="!ticketTypeId" class="alert alert-info mb-0">
+          Сначала сохраните тип билета — после создания появится возможность задавать волны цен.
+        </div>
+
+        <template v-else>
+          <table class="table table-sm align-middle" v-if="list && list.length">
+            <thead>
+              <tr>
+                <th style="width: 30%">Цена, ₽</th>
+                <th style="width: 40%">Действует до (включительно)</th>
+                <th style="width: 30%" class="text-end">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in list" :key="row.id">
+                <td>{{ formatPrice(row.price) }}</td>
+                <td :class="{'text-danger': isPast(row.before_date)}">
+                  {{ formatDate(row.before_date) }}
+                  <span v-if="isPast(row.before_date)" class="badge bg-secondary ms-1">завершена</span>
+                </td>
+                <td class="text-end">
+                  <button type="button"
+                          class="btn btn-sm btn-outline-primary me-2"
+                          @click="startEdit(row)">
+                    Изменить
+                  </button>
+                  <button type="button"
+                          class="btn btn-sm btn-outline-danger"
+                          @click="remove(row)">
+                    Удалить
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div v-else class="alert alert-warning">
+            Волн цен ещё нет. Добавьте первую — она будет использоваться, пока не наступит её дата.
+          </div>
+
+          <hr/>
+
+          <h5>{{ isEditing ? 'Редактирование волны' : 'Новая волна' }}</h5>
+          <div class="row g-2 align-items-start">
+            <div class="col-md-4">
+              <label class="form-label">Цена, ₽</label>
+              <input type="number"
+                     min="1"
+                     max="999999"
+                     step="1"
+                     class="form-control"
+                     :class="{'is-invalid': errorOf('price')}"
+                     v-model.number="form.price"/>
+              <div class="invalid-feedback">{{ errorOf('price') }}</div>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Действует до</label>
+              <input type="date"
+                     class="form-control"
+                     :class="{'is-invalid': errorOf('before_date')}"
+                     :min="todayIso"
+                     v-model="form.before_date"/>
+              <div class="invalid-feedback">{{ errorOf('before_date') }}</div>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+              <button type="button"
+                      class="btn btn-primary me-2"
+                      :disabled="!isFormValid"
+                      @click="save">
+                {{ isEditing ? 'Сохранить' : 'Добавить волну' }}
+              </button>
+              <button v-if="isEditing"
+                      type="button"
+                      class="btn btn-link"
+                      @click="resetForm">Отмена</button>
+            </div>
+          </div>
+          <div v-if="message" class="alert alert-success mt-3 py-2 px-3 mb-0">
+            {{ message }}
+          </div>
+          <div v-if="errorOf('ticket_type_id')" class="alert alert-danger mt-3 py-2 px-3 mb-0">
+            {{ errorOf('ticket_type_id') }}
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {mapActions, mapGetters} from "vuex";
+
+const MAX_PRICE = 999999;
+
+export default {
+  name: "TicketTypePriceList",
+  props: {
+    ticketTypeId: {
+      type: [String],
+      default: null,
+    }
+  },
+  data() {
+    return {
+      form: this.emptyForm(),
+      editingId: null,
+    }
+  },
+  computed: {
+    ...mapGetters('appTicketTypePrice', [
+      'getList',
+      'getError',
+      'getMessage',
+    ]),
+    list() {
+      return this.getList || [];
+    },
+    message() {
+      return this.getMessage;
+    },
+    isEditing() {
+      return this.editingId !== null;
+    },
+    todayIso() {
+      const d = new Date();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return `${d.getFullYear()}-${m}-${day}`;
+    },
+    isFormValid() {
+      const price = Number(this.form.price);
+      if (!(price > 0) || price >= MAX_PRICE + 1) return false;
+      if (!this.form.before_date) return false;
+      return !this.isPast(this.form.before_date);
+    },
+  },
+  watch: {
+    ticketTypeId: {
+      immediate: true,
+      handler(id) {
+        if (id) {
+          this.reload();
+        }
+      }
+    }
+  },
+  methods: {
+    ...mapActions('appTicketTypePrice', [
+      'loadList',
+      'create',
+      'edit',
+      'remove',
+      'clearError',
+      'clearMessage',
+    ]),
+    emptyForm() {
+      return {
+        price: null,
+        before_date: '',
+      };
+    },
+    errorOf(field) {
+      const e = this.getError;
+      return e ? e('data.' + field) || e(field) : '';
+    },
+    formatPrice(value) {
+      return Number(value).toLocaleString('ru-RU');
+    },
+    formatDate(value) {
+      if (!value) return '';
+      // value может быть ISO либо 'YYYY-MM-DD HH:mm:ss'
+      const d = new Date(value);
+      if (isNaN(d.getTime())) return value;
+      return d.toLocaleDateString('ru-RU');
+    },
+    isPast(value) {
+      if (!value) return false;
+      const d = new Date(value);
+      if (isNaN(d.getTime())) return false;
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      d.setHours(0, 0, 0, 0);
+      return d.getTime() < today.getTime();
+    },
+    reload() {
+      this.clearError();
+      this.loadList({filter: {ticket_type_id: this.ticketTypeId}});
+    },
+    startEdit(row) {
+      this.clearError();
+      this.editingId = row.id;
+      this.form = {
+        price: Number(row.price),
+        before_date: this.toInputDate(row.before_date),
+      };
+    },
+    toInputDate(value) {
+      if (!value) return '';
+      const d = new Date(value);
+      if (isNaN(d.getTime())) return '';
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return `${d.getFullYear()}-${m}-${day}`;
+    },
+    resetForm() {
+      this.form = this.emptyForm();
+      this.editingId = null;
+      this.clearError();
+    },
+    save() {
+      if (!this.isFormValid) return;
+      const payload = {
+        ticket_type_id: this.ticketTypeId,
+        price: Number(this.form.price),
+        before_date: this.form.before_date,
+      };
+      const onDone = () => {
+        this.resetForm();
+        this.reload();
+      };
+      if (this.isEditing) {
+        this.edit({id: this.editingId, data: payload}).then(onDone).catch(() => {});
+      } else {
+        this.create({data: payload}).then(onDone).catch(() => {});
+      }
+    },
+    remove(row) {
+      // Защита от дурака: подтверждение перед удалением
+      if (!window.confirm('Удалить волну с ценой ' + this.formatPrice(row.price) + ' ₽?')) {
+        return;
+      }
+      this.$store.dispatch('appTicketTypePrice/remove', {id: row.id})
+          .then(() => this.reload())
+          .catch(() => {});
+    }
+  }
+}
+</script>
+
+<style scoped>
+.ticket-type-price-list code {
+  background: #f5f5f5;
+  padding: 0 4px;
+  border-radius: 3px;
+}
+</style>

--- a/FrontEnd/src/store/index.js
+++ b/FrontEnd/src/store/index.js
@@ -10,6 +10,7 @@ import appAccount from './modules/AccountModule/index';
 import appTypesOfPayment from './modules/TypesOfPaymentModule/index';
 import appQuestionnaireType from './modules/QuestionnaireTypeModule/index';
 import appLocation from './modules/LocationModule/index';
+import appTicketTypePrice from './modules/TicketTypePriceModule/index';
 
 export default createStore({
     state: {
@@ -44,5 +45,6 @@ export default createStore({
         'appTypesOfPayment': appTypesOfPayment,
         'appQuestionnaireType': appQuestionnaireType,
         'appLocation': appLocation,
+        'appTicketTypePrice': appTicketTypePrice,
     }
 })

--- a/FrontEnd/src/store/modules/TicketTypePriceModule/actions.js
+++ b/FrontEnd/src/store/modules/TicketTypePriceModule/actions.js
@@ -1,0 +1,92 @@
+import axios from 'axios';
+
+const API = '/api/v1/ticketTypePrice';
+
+export const loadList = (context, payload) => {
+    const filter = (payload && payload.filter) || context.state.filter || {};
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/getList', {filter, orderBy: context.state.orderBy || {}})
+            .then(function (response) {
+                context.commit('setList', response.data.list);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const loadItem = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.get(API + '/getItem/' + payload.id)
+            .then(function (response) {
+                context.commit('setItem', response.data.item);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const create = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/create', {data: payload.data})
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                if (response.data.item) {
+                    context.commit('upsertInList', response.data.item);
+                }
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const edit = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/edit/' + payload.id, {data: payload.data})
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                if (response.data.item) {
+                    context.commit('upsertInList', response.data.item);
+                }
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const remove = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.delete(API + '/delete/' + payload.id)
+            .then(function (response) {
+                context.commit('removeInList', payload);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const clearError = (context) => {
+    context.commit('setError', []);
+};
+
+export const clearMessage = (context) => {
+    context.commit('setMessage', null);
+};
+
+export const setFilter = (context, payload) => {
+    context.commit('setFilter', payload);
+};

--- a/FrontEnd/src/store/modules/TicketTypePriceModule/getters.js
+++ b/FrontEnd/src/store/modules/TicketTypePriceModule/getters.js
@@ -1,0 +1,29 @@
+export const getError = state => type => {
+    if (state.dataError !== undefined && state.dataError[type] !== undefined) {
+        if (typeof state.dataError[type] === "object") {
+            return state.dataError[type][0];
+        }
+        return state.dataError[type];
+    }
+    return '';
+};
+
+export const getList = state => {
+    return state.list;
+};
+
+export const getItem = state => {
+    return state.item;
+};
+
+export const getFilter = state => {
+    return state.filter;
+};
+
+export const getOrderBy = state => {
+    return state.orderBy;
+};
+
+export const getMessage = state => {
+    return state.message;
+};

--- a/FrontEnd/src/store/modules/TicketTypePriceModule/index.js
+++ b/FrontEnd/src/store/modules/TicketTypePriceModule/index.js
@@ -1,0 +1,19 @@
+import * as getters from './getters';
+import * as actions from './actions';
+import * as mutations from './mutations';
+
+export default {
+    namespaced: true,
+    state: {
+        list: [],
+        item: {},
+        filter: {},
+        orderBy: {},
+        isLoading: false,
+        dataError: [],
+        message: null,
+    },
+    getters,
+    actions,
+    mutations
+};

--- a/FrontEnd/src/store/modules/TicketTypePriceModule/mutations.js
+++ b/FrontEnd/src/store/modules/TicketTypePriceModule/mutations.js
@@ -1,0 +1,38 @@
+export const setError = (state, payload) => {
+    state.dataError = payload || [];
+};
+
+export const setList = (state, payload) => {
+    state.list = payload;
+};
+
+export const setItem = (state, payload) => {
+    state.item = payload;
+};
+
+export const setMessage = (state, payload) => {
+    state.message = payload;
+};
+
+export const removeInList = (state, payload) => {
+    state.list = state.list.filter(item => item.id !== payload.id);
+};
+
+export const setFilter = (state, payload) => {
+    state.filter = payload;
+};
+
+export const setOrderBy = (state, payload) => {
+    state.orderBy = payload;
+};
+
+export const upsertInList = (state, payload) => {
+    const idx = state.list.findIndex(item => item.id === payload.id);
+    if (idx === -1) {
+        state.list = [...state.list, payload];
+    } else {
+        const next = state.list.slice();
+        next[idx] = payload;
+        state.list = next;
+    }
+};


### PR DESCRIPTION
Новый модуль управления таблицей ticket_type_price из админки. Чтение волн остаётся публичным (используется на форме покупки), запись (create/edit/delete) — только admin.

Backend (CQRS, паттерн скопирован с Location):
- Backend/src/TicketTypePrice/ — DTO, Repository, Application с Create/Edit/Delete/ GetList/GetItem handlers
- Контроллер + 2 FormRequest с валидацией ("защита от дурака"): price > 0 и < 1 000 000, before_date >= today, ticket_type_id exists
- Роуты /api/v1/ticketTypePrice/* с middleware auth:api+admin на write
- TicketTypesPriceModel: добавлен SoftDeletes + касты price/before_date

Frontend:
- Vuex модуль TicketTypePriceModule
- Компонент TicketTypePriceList.vue встроен в форму редактирования типа билета (отображается только для существующего id). UX-защита: disable кнопки при невалидной форме, confirm перед удалением, бейдж "завершена" для прошлых волн

Документация: API.md (раздел 8.0), DOMAIN.md (TicketTypePriceRepositoryInterface), BOARD.md (запись о задаче).