### PR TITLE
feat(ticket): новый тип билета "парковка" + фикс festival_id в baza

### DIFF
--- a/Backend/app/Models/Festival/TicketTypesModel.php
+++ b/Backend/app/Models/Festival/TicketTypesModel.php
@@ -25,6 +25,7 @@ use Shared\Infrastructure\Models\HasUuid;
  * @property int $sort
  * @property int $active
  * @property int $is_live_ticket
+ * @property int $is_parking
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Festival\FestivalModel[] $festivals
  * @property-read int|null $festivals_count
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Festival\TicketTypesPriceModel[] $ticketTypePrice
@@ -37,6 +38,7 @@ use Shared\Infrastructure\Models\HasUuid;
  * @method static Builder|TicketTypesModel whereGroupLimit($value)
  * @method static Builder|TicketTypesModel whereId($value)
  * @method static Builder|TicketTypesModel whereIsLiveTicket($value)
+ * @method static Builder|TicketTypesModel whereIsParking($value)
  * @method static Builder|TicketTypesModel whereName($value)
  * @method static Builder|TicketTypesModel wherePrice($value)
  * @method static Builder|TicketTypesModel whereSort($value)
@@ -60,6 +62,7 @@ class TicketTypesModel extends Model
         'sort',
         'active',
         'is_live_ticket',
+        'is_parking',
         'groupLimit',
         'questionnaire_type_id',
     ];

--- a/Backend/app/Models/Ordering/InfoForOrder/TicketTypesModel.php
+++ b/Backend/app/Models/Ordering/InfoForOrder/TicketTypesModel.php
@@ -28,6 +28,7 @@ use Shared\Infrastructure\Models\HasUuid;
  * @property int $sort
  * @property int $active
  * @property int $is_live_ticket
+ * @property int $is_parking
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Festival\FestivalModel[] $festivals
  * @property-read int|null $festivals_count
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Festival\TicketTypesPriceModel[] $ticketTypePrice
@@ -40,6 +41,7 @@ use Shared\Infrastructure\Models\HasUuid;
  * @method static Builder|TicketTypesModel whereGroupLimit($value)
  * @method static Builder|TicketTypesModel whereId($value)
  * @method static Builder|TicketTypesModel whereIsLiveTicket($value)
+ * @method static Builder|TicketTypesModel whereIsParking($value)
  * @method static Builder|TicketTypesModel whereName($value)
  * @method static Builder|TicketTypesModel wherePrice($value)
  * @method static Builder|TicketTypesModel whereSort($value)
@@ -63,6 +65,7 @@ class TicketTypesModel extends Model
         'sort',
         'active',
         'is_live_ticket',
+        'is_parking',
         'groupLimit'
     ];
 

--- a/Backend/database/migrations/2026_05_11_120000_add_is_parking_in_ticket_type.php
+++ b/Backend/database/migrations/2026_05_11_120000_add_is_parking_in_ticket_type.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ticket_type', function (Blueprint $table) {
+            $table->boolean('is_parking')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_type', function (Blueprint $table) {
+            $table->dropColumn('is_parking');
+        });
+    }
+};

--- a/Backend/src/Festival/Response/TicketTypeDto.php
+++ b/Backend/src/Festival/Response/TicketTypeDto.php
@@ -21,6 +21,7 @@ final class TicketTypeDto extends AbstractionEntity implements Response
      * @param PriceDto[] $priceList
      * @param int $sort
      * @param bool $isLiveTicket
+     * @param bool $isParking
      * @param string|null $description
      * @param Uuid|null $questionnaireTypeId
      */
@@ -33,6 +34,7 @@ final class TicketTypeDto extends AbstractionEntity implements Response
         protected array  $priceList,
         protected int    $sort = 0,
         protected bool   $isLiveTicket = false,
+        protected bool   $isParking = false,
         protected ?string $description = null,
         protected ?Uuid  $questionnaireTypeId = null,
     )
@@ -71,6 +73,7 @@ final class TicketTypeDto extends AbstractionEntity implements Response
             $priceList,
             $data['sort'],
             (bool)$data['is_live_ticket'],
+            (bool)($data['is_parking'] ?? false),
             $data['description'] ?? null,
             empty($data['questionnaire_type_id']) ? null : new Uuid($data['questionnaire_type_id']),
         );
@@ -106,6 +109,11 @@ final class TicketTypeDto extends AbstractionEntity implements Response
     public function isLiveTicket(): bool
     {
         return $this->isLiveTicket;
+    }
+
+    public function isParking(): bool
+    {
+        return $this->isParking;
     }
 
     public function getId(): Uuid

--- a/Backend/src/Ticket/CreateTickets/Application/GetTicket/TicketResponse.php
+++ b/Backend/src/Ticket/CreateTickets/Application/GetTicket/TicketResponse.php
@@ -97,6 +97,7 @@ class TicketResponse extends AbstractionEntity implements Response
             'is_need_seedling' => $this->is_need_seedling,
             'type_ticket_id'   => $this->type_ticket_id?->value(),
             'type_ticket'      => $this->type_ticket,
+            'festival_id'      => $this->festival_id?->value(),
         ];
     }
 

--- a/Backend/src/Ticket/CreateTickets/Repositories/InMemoryMySqlTicketsRepository.php
+++ b/Backend/src/Ticket/CreateTickets/Repositories/InMemoryMySqlTicketsRepository.php
@@ -234,7 +234,8 @@ class InMemoryMySqlTicketsRepository implements TicketsRepositoryInterface
                         'is_need_seedling' => $data['is_need_seedling'],
                         'type_ticket_id' => $data['type_ticket_id'],
                         'type_ticket' => $data['type_ticket'],
-                        'name' => $data['name']
+                        'name' => $data['name'],
+                        'festival_id' => $data['festival_id'],
                     ]);
             }
         } catch (\Exception) {

--- a/Backend/src/TicketType/Application/GetList/TicketTypeGetListFilter.php
+++ b/Backend/src/TicketType/Application/GetList/TicketTypeGetListFilter.php
@@ -13,6 +13,7 @@ class TicketTypeGetListFilter
         private ?string $name = null,
         private ?bool   $active = null,
         private ?bool   $is_live_ticket = null,
+        private ?bool   $is_parking = null,
         private ?Uuid   $festival_id = null
     )
     {
@@ -33,6 +34,11 @@ class TicketTypeGetListFilter
         return $this->is_live_ticket;
     }
 
+    public function getIsParking(): ?bool
+    {
+        return $this->is_parking;
+    }
+
     public static function fromState(array $data): self
     {
         $festivalId = null;
@@ -44,6 +50,7 @@ class TicketTypeGetListFilter
             $data['name'] ?? null,
             ($data['active'] ?? null) === null ? null : $data['active'] === 'true',
             ($data['is_live_ticket'] ?? null) === null ? null : $data['is_live_ticket'] === 'true',
+            ($data['is_parking'] ?? null) === null ? null : $data['is_parking'] === 'true',
             $festivalId,
         );
     }

--- a/Backend/src/TicketType/Dto/TicketTypeDto.php
+++ b/Backend/src/TicketType/Dto/TicketTypeDto.php
@@ -19,8 +19,9 @@ class TicketTypeDto extends AbstractionEntity implements Response
         protected int $sort,
         protected bool $active,
         protected bool $is_live_ticket,
+        protected bool $is_parking,
         protected FestivalDto $festival,
-        protected ?Uuid $questionnaireTypeId = null,
+        protected ?Uuid $questionnaire_type_id = null,
         protected ?int $groupLimit = null,
         protected ?Carbon $created_at = null,
         protected ?Carbon $updated_at = null,
@@ -36,7 +37,8 @@ class TicketTypeDto extends AbstractionEntity implements Response
             (int)($data['current_price'] ?? $data['price']),
             (int)$data['sort'],
             (bool)$data['active'],
-            (bool)$data['is_live_ticket'],
+            (bool)($data['is_live_ticket'] ?? false),
+            (bool)($data['is_parking'] ?? false),
             FestivalDto::fromState($data),
             empty($data['questionnaire_type_id']) ? null : new Uuid($data['questionnaire_type_id']),
             $data['groupLimit'] ?? null,
@@ -81,6 +83,6 @@ class TicketTypeDto extends AbstractionEntity implements Response
 
     public function getQuestionnaireTypeId(): ?Uuid
     {
-        return $this->questionnaireTypeId;
+        return $this->questionnaire_type_id;
     }
 }

--- a/Backend/src/TicketType/Repository/InMemoryTicketTypeRepository.php
+++ b/Backend/src/TicketType/Repository/InMemoryTicketTypeRepository.php
@@ -88,6 +88,11 @@ class InMemoryTicketTypeRepository implements TicketTypeRepositoryInterface
                 'value' => $filterQuery->getIsLiveTicket(),
             ],
             [
+                'field' => TicketTypesModel::TABLE . '.is_parking',
+                'operator' => FilterOperator::EQUAL,
+                'value' => $filterQuery->getIsParking(),
+            ],
+            [
                 'field' => TicketTypeFestivalModel::TABLE . '.festival_id',
                 'operator' => FilterOperator::EQUAL,
                 'value' => $filterQuery->getFestivalId()?->value(),

--- a/Baza/database/migrations/2026_05_11_130000_backfill_festival_id_in_el_tickets.php
+++ b/Baza/database/migrations/2026_05_11_130000_backfill_festival_id_in_el_tickets.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    private const FESTIVAL_ID = '9d679bcf-b438-4ddb-ac04-023fa9bff4b8';
+    private const KILTER_FROM = 7276;
+
+    /**
+     * Backfill festival_id для билетов, у которых поле осталось NULL из-за того,
+     * что в TicketResponse::toArrayForBaza() оно ранее не попадало в INSERT.
+     * Границу выставляем по kilter > 7276 — это диапазон текущего фестиваля.
+     */
+    public function up(): void
+    {
+        DB::table('el_tickets')
+            ->where('kilter', '>', self::KILTER_FROM)
+            ->whereNull('festival_id')
+            ->update(['festival_id' => self::FESTIVAL_ID]);
+    }
+
+    public function down(): void
+    {
+        DB::table('el_tickets')
+            ->where('kilter', '>', self::KILTER_FROM)
+            ->where('festival_id', '=', self::FESTIVAL_ID)
+            ->update(['festival_id' => null]);
+    }
+};

--- a/FrontEnd/src/components/BuyTicket/BuyTicket.vue
+++ b/FrontEnd/src/components/BuyTicket/BuyTicket.vue
@@ -119,8 +119,8 @@
                   </div>
 
                 </div>
-                <div class="pp2 row">Введи свои Имя и Фамилию или Имя и Фамилию ребёнка, если вносишь оргвзнос за ребёнка</div>
-                <div class="quest-item row" id="first-item-row">
+                <div class="pp2 row" v-show="!isParking">Введи свои Имя и Фамилию или Имя и Фамилию ребёнка, если вносишь оргвзнос за ребёнка</div>
+                <div class="quest-item row" id="first-item-row" v-show="!isParking">
                   <label for="name" style="display: none">Твои Имя и Фамилия или Имя и Фамилия ребёнка: *</label>
 
                   <div class="input-group" id="promo-input" v-show="!isNotNeedQuestionnaire">
@@ -135,7 +135,7 @@
                     />
                   </div>
                 </div>
-                <div class="row mt-3 mb-3" id="enter-guests">
+                <div class="row mt-3 mb-3" id="enter-guests" v-show="!isParking">
                   <div class="pp2">Введи данные дополнительных своих друзей, за которых ты хочешь внести оргвзнос:</div>
                   <div class="not-first-guest input-group mb-3">
 
@@ -166,6 +166,54 @@
                           id="basic-addon1"
                       >Добавить</span
                       >
+                    </div>
+                  </div>
+                </div>
+                <div class="row mt-3 mb-3" id="enter-cars" v-show="isParking">
+                  <div class="pp2">Введи данные автомобилей, для которых нужна парковка:</div>
+                  <div class="not-first-guest input-group mb-3">
+                    <input
+                        type="text"
+                        id="newCarNumber"
+                        class="form-control"
+                        placeholder="Гос. номер (например, А123АА777)"
+                        aria-label="Гос. номер автомобиля"
+                        v-model="newCarNumber"
+                        @blur="addParking"
+                    />
+                    <input
+                        type="text"
+                        id="newCarBrand"
+                        class="form-control"
+                        placeholder="Марка автомобиля"
+                        aria-label="Марка автомобиля"
+                        v-model="newCarBrand"
+                        @blur="addParking"
+                    />
+                    <input
+                        type="text"
+                        id="newDriverName"
+                        class="form-control"
+                        placeholder="ФИО водителя"
+                        aria-label="ФИО водителя"
+                        v-model="newDriverName"
+                        @blur="addParking"
+                    />
+                    <input
+                        type="email"
+                        id="newDriverEmail"
+                        class="form-control"
+                        placeholder="Email для отправки анкеты"
+                        aria-label="Email для отправки анкеты"
+                        v-model="newGuestEmail"
+                        @blur="addParking"
+                    />
+                    <div class="input-group-prepend">
+                      <span
+                          class="input-group-text btn"
+                          @click="addParking()"
+                          id="basic-addon1"
+                      >Добавить</span>
                     </div>
                   </div>
                 </div>
@@ -582,6 +630,9 @@ export default {
       masterName: '',
       newGuest: '',
       newGuestEmail: '',
+      newCarNumber: '',
+      newCarBrand: '',
+      newDriverName: '',
       isFirstGuestAdded: false,
       email: null,
       date: null,
@@ -619,6 +670,12 @@ export default {
     ]),
     ...mapGetters('appUser', ['isAuth', 'getEmail', 'getUserData']),
     ...mapGetters('appOrder', ['getError']),
+    /**
+     * Признак типа билета "парковка" — меняет форму ввода гостей на ввод данных автомобиля
+     */
+    isParking: function () {
+      return this.getSelectTicketType?.isParking === true;
+    },
     selectTypesOfPaymentIsBilling: function () {
       let typesOfPaymentList = this.getTypesOfPayment;
       if(this.selectTypesOfPayment !== null ) {
@@ -650,7 +707,7 @@ export default {
           (this.isAuth || this.email)
       )
 
-      if(!this.isNotNeedQuestionnaire) {
+      if(!this.isNotNeedQuestionnaire && !this.isParking) {
         result = result && this.masterName.length > 0;
       } else {
         result = result && this.guests.length > 0;
@@ -773,6 +830,27 @@ export default {
       }
     },
     /**
+     * Добавить парковочное место — гос. номер, марка и водитель склеиваются в одну строку value,
+     * чтобы backend получал привычный формат guests[].value/email без изменений.
+     */
+    addParking: function () {
+      if (
+          this.newCarNumber.length > 0 &&
+          this.newCarBrand.length > 0 &&
+          this.newDriverName.length > 0 &&
+          this.newGuestEmail.length > 0
+      ) {
+        this.guests.push({
+          value: this.newCarNumber + ' / ' + this.newCarBrand + ' / ' + this.newDriverName,
+          email: this.newGuestEmail,
+        });
+        this.newCarNumber = '';
+        this.newCarBrand = '';
+        this.newDriverName = '';
+        this.newGuestEmail = '';
+      }
+    },
+    /**
      * Удалить гостя
      * @param index
      */
@@ -825,6 +903,9 @@ export default {
       this.preload = false;
       this.newGuest = '';
       this.newGuestEmail = '';
+      this.newCarNumber = '';
+      this.newCarBrand = '';
+      this.newDriverName = '';
       this.email = this.getEmail;
       this.promoCode = null;
       this.day = null;

--- a/FrontEnd/src/components/TicketType/TicketTypeItem.vue
+++ b/FrontEnd/src/components/TicketType/TicketTypeItem.vue
@@ -112,6 +112,19 @@
                   <small class="form-text text-muted"> {{ getError('is_live_ticket') }}</small>
                 </div>
                 <div class="row mb-3">
+                  <label for="company" class="col-4 col-form-label">Для парковки:</label>
+                  <div class="col-8">
+                    <select class="form-select"
+                            v-model="isParking"
+                            id="validationDefault01">
+                      <option value=null>Выберите</option>
+                      <option value="false">Нет</option>
+                      <option value="true">Да</option>
+                    </select>
+                  </div>
+                  <small class="form-text text-muted"> {{ getError('is_parking') }}</small>
+                </div>
+                <div class="row mb-3">
                   <label for="company" class="col-4 col-form-label">Активность:</label>
                   <div class="col-8">
                     <select class="form-select"
@@ -197,6 +210,7 @@ export default {
       newSort: null,
       newActive: null,
       newIsLiveTicket: null,
+      newIsParking: null,
       newFestivalId: null,
       newDescription: null,
       newEmail: null,
@@ -328,10 +342,21 @@ export default {
         this.newIsLiveTicket = newValue;
       },
     },
+    isParking: {
+      get: function () {
+        if (this.newIsParking === null) {
+          return this.getItem.is_parking;
+        }
+        return this.newIsParking;
+      },
+      set: function (newValue) {
+        this.newIsParking = newValue;
+      },
+    },
     questionnaire_type_id: {
       get: function () {
         if (this.newQuestionnaireTypeId === null) {
-          return this.getItem.questionnaireTypeId;
+          return this.getItem.questionnaire_type_id;
         }
         return this.newQuestionnaireTypeId;
       },
@@ -358,6 +383,7 @@ export default {
         'sort': this.sortItem,
         'active': this.active,
         'is_live_ticket': this.isLiveTicket,
+        'is_parking': this.isParking,
         'festival_id': this.festival_id,
         'festival_pdf': this.festival_pdf,
         'festival_email': this.festival_email,


### PR DESCRIPTION
Парковка:
- Миграция add_is_parking_in_ticket_type (boolean флаг на ticket_type)
- Проброс is_parking/isParking через TicketTypeDto (CRUD и Festival/Response), фильтр, репозиторий, модели
- Форма редактирования: переключатель "Для парковки" (TicketTypeItem.vue)
- Форма покупки (BuyTicket.vue): при isParking вместо ФИО гостей показываются поля авто (гос. номер / марка / ФИО водителя / email), склеиваются в guests[].value одной строкой — backend не меняется

Сопутствующие фиксы:
- TicketTypeDto: $questionnaireTypeId → $questionnaire_type_id (camelCase свойство ломало insert в БД, колонка snake_case)
- TicketTypeDto::fromState: is_live_ticket теперь ?? false, не падает при создании без всех полей
- TicketResponse::toArrayForBaza: добавлено festival_id (был пропущен в white-list, поле никогда не уходило в el_tickets для всех типов билетов — обнаружено на парковке)
- setInBaza UPDATE: festival_id теперь обновляется
- Baza migration: backfill festival_id для kilter > 7276