### PR TITLE
feat(order): авто-одобрение заказа по заголовку AutoPayment на /api/v…

### DIFF
--- a/.claude/docs/API.md
+++ b/.claude/docs/API.md
@@ -200,6 +200,13 @@
 ### POST `/api/v1/order/create`
 **Middleware:** публичный
 
+**Заголовки (опциональные):**
+- `AutoPayment: <token>` — авто-одобрение заказа. Токен сравнивается с `AUTO_PAYMENT_TOKEN` (см. `config/services.php → auto_payment.token`).
+  - Заголовок **не передан** → заказ создаётся в `NEW` (штатный flow).
+  - Заголовок передан, токен **совпал** и `types_of_payment.is_billing = false` → после создания заказ сразу переводится в `PAID` через `ChangeStatus` (запускается `ProcessCreateTicket` + email с PDF). В `domain_history.actor_type` пишется `auto_payment`, `actor_id = null`.
+  - Заголовок передан, токен совпал, но `types_of_payment.is_billing = true` → заголовок **игнорируется**, заказ остаётся в `NEW` (биллинговый flow управляет статусом сам через webhook `/api/v1/order/succes`).
+  - Заголовок передан, токен **не совпал** (или `AUTO_PAYMENT_TOKEN` пуст) → `403 { "success": false, "message": "Неверный токен авто-одобрения" }`, заказ **не** создаётся.
+
 **Request:**
 ```json
 {
@@ -229,6 +236,14 @@
 {
   "success": true,
   "message": "Мы удачно зарегистрировали ваш заказ..."
+}
+```
+
+**Response 403 (битый токен авто-одобрения):**
+```json
+{
+  "success": false,
+  "message": "Неверный токен авто-одобрения"
 }
 ```
 

--- a/.claude/docs/BOARD.md
+++ b/.claude/docs/BOARD.md
@@ -21,6 +21,16 @@
 - **В работе:** 0
 - **Критичных проблем:** 2 (Тесты, Воркер)
 
+### ✅ Сделано 2026-05-15
+**Авто-одобрение заказа по заголовку `AutoPayment` на `POST /api/v1/order/create`.**
+- Конфиг: `AUTO_PAYMENT_TOKEN` в `.env.example` + `config/services.php → auto_payment.token`
+- `ActorType::AUTO_PAYMENT` (`auto_payment`) добавлен в `Backend/src/History/Domain/ActorType.php`
+- `TypesOfPaymentDto::isBilling()` — геттер для проверки биллингового способа оплаты
+- `OrderTickets::create()` — проверка заголовка `AutoPayment` до создания: невалидный токен → `403`, валидный + не-биллинговый способ оплаты → после `createAndSave` вызывается `ChangeStatus` с `Status::PAID` (запускается `ProcessCreateTicket` + email с PDF); биллинговый способ — заголовок игнорируется
+- Сравнение токенов через `hash_equals` (защита от timing-attack)
+- Документация: `API.md` (раздел `/api/v1/order/create` — заголовки и поведение), `BUSINESS_RULES.md` (§1 Роли для смены статуса), `DOMAIN.md` (ActorType)
+- 🌿 ветка `feat/auto-payment-token`
+
 ### ✅ Сделано 2026-05-10
 **CRUD для волн цен типа билета (`ticket_type_price`).**
 - Backend модуль `Backend/src/TicketTypePrice/` (DTO, Repository + Interface, Application, Create/Edit/Delete/GetList/GetItem handlers)

--- a/.claude/docs/BUSINESS_RULES.md
+++ b/.claude/docs/BUSINESS_RULES.md
@@ -73,6 +73,7 @@
 
 - Обычные/Live статусы (PAID/CANCEL/PAID_FOR_LIVE/LIVE_TICKET_ISSUED/DIFFICULTIES_AROSE и пр.): `seller`, `admin`, `pusher`
 - List-статусы (APPROVE_LIST / CANCEL_LIST / DIFFICULTIES_AROSE_LIST): только `admin`, `manager`
+- **Авто-одобрение (без авторизации)**: `POST /api/v1/order/create` с заголовком `AutoPayment: <AUTO_PAYMENT_TOKEN>` сразу переводит свежесозданный заказ `NEW → PAID` (через тот же `ChangeStatus`). Только для не-биллинговых способов оплаты (`types_of_payment.is_billing = false`). В историю пишется `actor_type = auto_payment`. Если токен невалиден — `403`, заказ не создаётся.
 
 ---
 

--- a/.claude/docs/DOMAIN.md
+++ b/.claude/docs/DOMAIN.md
@@ -242,6 +242,12 @@ class Questionnaire extends AggregateRoot {
 | **SaveHistoryDto** | `History/Dto/` | `aggregateId` (string), `event` (HistoryEventInterface), `actorId` (?string), `actorType` (string) |
 | **DomainHistoryDto** | `History/Dto/` | `aggregateId` (string), `aggregateType` (string), `eventName` (string), `payload` (array), `actorId` (?string), `actorType` (string), `occurredAt` (Carbon) |
 
+**ActorType** (`History/Domain/ActorType.php`) — типы инициаторов событий в `domain_history.actor_type`:
+- `user` — действие выполнил пользователь (актер берётся из `Auth::id()`)
+- `system` — системное действие (фоновые задачи, события)
+- `artisan` — действие из artisan-команды (CLI)
+- `auto_payment` — авто-одобрение заказа на `POST /api/v1/order/create` по валидному заголовку `AutoPayment` (`actorId` пишется `null`)
+
 ---
 
 ## Domain Events

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -76,6 +76,9 @@ KEY_PASSWORD_BILLING=
 
 KEY_LIVE_TICKET=d41d8cd98f00b204
 
+# Токен авто-одобрения заказа (POST /api/v1/order/create, заголовок "AutoPayment")
+AUTO_PAYMENT_TOKEN=
+
 SENTRY_ENABLE_LOGS=true
 LOG_CHANNEL=stack
 LOG_STACK=single,sentry_logs

--- a/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
+++ b/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
@@ -19,6 +19,8 @@ use Shared\Domain\ValueObject\Uuid;
 use Throwable;
 use Tickets\Festival\Application\GetTicketType\GetTicketType;
 use Tickets\History\Application\GetHistory\GetOrderHistory;
+use Tickets\History\Domain\ActorType;
+use Tickets\TypesOfPayment\Application\TypesOfPaymentApplication;
 use Tickets\Order\OrderTicket\Application\AddComment\AddComment;
 use Tickets\Order\OrderTicket\Application\ChangeOrderPrice\ChangeOrderPrice;
 use Tickets\Order\OrderTicket\Application\ChangeStatus\ChangeStatus;
@@ -57,6 +59,7 @@ class OrderTickets extends Controller
         private ChangeTicket       $changeTicket,
         private GetOrderHistory    $getOrderHistory,
         private \Tickets\Auto\Application\AutoApplication $autoApplication,
+        private TypesOfPaymentApplication $typesOfPaymentApplication,
        // private Billing            $billing,
     )
     {
@@ -67,8 +70,24 @@ class OrderTickets extends Controller
      *
      * @throws Throwable
      */
-    public function create(CreateOrderTicketsRequest $createOrderTicketsRequest): JsonResponse
+    public function create(CreateOrderTicketsRequest $createOrderTicketsRequest, Request $request): JsonResponse
     {
+        // Авто-одобрение: проверяем заголовок до любых действий.
+        // Если заголовок передан, но токен не совпадает с конфигом — сразу 403.
+        $autoPaymentHeader = $request->headers->get('AutoPayment');
+        $autoPaymentToken  = config('services.auto_payment.token');
+        $isAutoPayment     = false;
+
+        if ($autoPaymentHeader !== null) {
+            if (empty($autoPaymentToken) || !hash_equals((string) $autoPaymentToken, $autoPaymentHeader)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Неверный токен авто-одобрения',
+                ], 403);
+            }
+            $isAutoPayment = true;
+        }
+
         try {
             // Создание или получение пользователя по email
             $userId = new Uuid($this->accountApplication->creatingOrGetAccountId(
@@ -116,6 +135,23 @@ class OrderTickets extends Controller
                     $userId,
                     $createOrderTicketsRequest->comment
                 );
+            }
+
+            // Авто-одобрение заказа: только для не-биллинговых способов оплаты.
+            // Для биллинговых (СБП и т.п.) заголовок игнорируем — заказ остаётся в NEW и идёт штатным flow.
+            if ($isAutoPayment) {
+                $typesOfPayment = $this->typesOfPaymentApplication->getItem(
+                    new Uuid($createOrderTicketsRequest->types_of_payment_id)
+                );
+
+                if (!$typesOfPayment->isBilling()) {
+                    $this->chanceStatus->change(
+                        $orderTicketDto->getId(),
+                        new Status(Status::PAID),
+                        $userId,
+                        actorType: ActorType::AUTO_PAYMENT,
+                    );
+                }
             }
 
             return response()->json([

--- a/Backend/config/services.php
+++ b/Backend/config/services.php
@@ -31,4 +31,10 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    // Авто-одобрение заказа на /api/v1/order/create по заголовку "AutoPayment".
+    // Если токен пустой — фича выключена.
+    'auto_payment' => [
+        'token' => env('AUTO_PAYMENT_TOKEN'),
+    ],
+
 ];

--- a/Backend/src/History/Domain/ActorType.php
+++ b/Backend/src/History/Domain/ActorType.php
@@ -6,7 +6,9 @@ namespace Tickets\History\Domain;
 
 final class ActorType
 {
-    public const USER    = 'user';
-    public const SYSTEM  = 'system';
-    public const ARTISAN = 'artisan';
+    public const USER         = 'user';
+    public const SYSTEM       = 'system';
+    public const ARTISAN      = 'artisan';
+    // Автоматическое одобрение заказа по заголовку AutoPayment на /api/v1/order/create
+    public const AUTO_PAYMENT = 'auto_payment';
 }

--- a/Backend/src/TypesOfPayment/Dto/TypesOfPaymentDto.php
+++ b/Backend/src/TypesOfPayment/Dto/TypesOfPaymentDto.php
@@ -97,4 +97,9 @@ class TypesOfPaymentDto extends AbstractionEntity implements Response
     {
         return $this->email;
     }
+
+    public function isBilling(): bool
+    {
+        return $this->is_billing;
+    }
 }


### PR DESCRIPTION
…1/order/create

- Конфиг AUTO_PAYMENT_TOKEN (.env.example + config/services.auto_payment.token)
- ActorType::AUTO_PAYMENT для записи в domain_history
- TypesOfPaymentDto::isBilling() — геттер для проверки биллингового способа
- OrderTickets::create(): проверка заголовка AutoPayment до создания заказа (битый токен -> 403, валидный + не-биллинговый способ -> сразу PAID через ChangeStatus; биллинговый способ -> заголовок игнорируется)
- hash_equals для защиты от timing-attack
- Документация: API.md, BUSINESS_RULES.md, DOMAIN.md, BOARD.md