### PR TITLE
[baza] composer audit: игнорируем advisories Laravel 9

### DIFF
--- a/Baza/composer.json
+++ b/Baza/composer.json
@@ -68,6 +68,12 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-8qx3-n5y5-vvnd": "Laravel 9 — миграция на 11 запланирована после 1 июня 2026 (см. TECH_DEBT.md)",
+                "PKSA-w7xr-vk7n-rstm": "Laravel 9 — миграция на 11 запланирована после 1 июня 2026 (см. TECH_DEBT.md)"
+            }
         }
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
Composer 2.7+ блокирует установку пакетов с security advisories. Laravel 9 имеет PKSA-8qx3-n5y5-vvnd и PKSA-w7xr-vk7n-rstm — это блокировало composer install в Docker.

Временный bypass через config.audit.ignore с явным списком и комментариями. Остальные advisories продолжат проверяться.

Полностью решится миграцией на Laravel 11 (запланирована после 1 июня 2026, см. TECH_DEBT.md).