### PR TITLE
[order] запись истории при смене цены заказа

### DIFF
--- a/Backend/app/Console/Commands/FixFriendlyPricesCommand.php
+++ b/Backend/app/Console/Commands/FixFriendlyPricesCommand.php
@@ -7,9 +7,11 @@ namespace App\Console\Commands;
 use App\Models\Ordering\OrderTicketModel;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use Shared\Domain\ValueObject\Uuid;
 use Symfony\Component\Console\Command\Command as CommandAlias;
 use Throwable;
+use Tickets\History\Domain\ActorType;
+use Tickets\Order\OrderTicket\Application\ChangeOrderPrice\ChangeOrderPrice;
 
 /**
  * Корректирует завышенные суммы Friendly-заказов.
@@ -18,12 +20,12 @@ use Throwable;
  *   - заказ создан до 12 мая 2026 включительно → 5900 ₽ за билет
  *   - заказ создан с 13 мая 2026                → 6500 ₽ за билет
  *
- * Если фактическая сумма > (count * корректная_цена) — заменяем на правильную.
+ * Если фактическая сумма > (count * корректная_цена) — заменяет на правильную
+ * через готовый ChangeOrderPrice Application. Запись в domain_history
+ * происходит внутри ChangeOrderPriceCommandHandler — здесь дополнительно не пишем,
+ * иначе будет задвоение.
  *
  * Защита от случайной правки: по умолчанию dry-run, реально пишет только с --apply.
- *
- * Одноразовый скрипт фикса — по решению автора работаем с моделью напрямую
- * (как в существующих командах AddPriceForTypeTicket / CheckCreateTicket).
  */
 class FixFriendlyPricesCommand extends Command
 {
@@ -41,7 +43,7 @@ class FixFriendlyPricesCommand extends Command
     private const PRICE_BEFORE = 5900;
     private const PRICE_AFTER  = 6500;
 
-    public function handle(): int
+    public function handle(ChangeOrderPrice $changeOrderPrice): int
     {
         $apply = (bool)$this->option('apply');
         $cutoff = Carbon::parse(self::PRICE_WAVE_CUTOFF);
@@ -74,7 +76,7 @@ class FixFriendlyPricesCommand extends Command
                     'count'        => $count,
                     'price_was'    => (float)$order->price,
                     'unit_correct' => $correctUnitPrice,
-                    'price_correct'=> $correctTotal,
+                    'price_correct'=> (float)$correctTotal,
                     'diff'         => (float)$order->price - $correctTotal,
                 ];
             }
@@ -118,16 +120,16 @@ class FixFriendlyPricesCommand extends Command
         $applied = 0;
         $failed = 0;
         foreach ($toFix as $item) {
-            DB::beginTransaction();
             try {
-                $order = OrderTicketModel::query()->find($item['id']);
-                $order->price = $item['price_correct'];
-                $order->discount = 0;
-                $order->save();
-                DB::commit();
+                $changeOrderPrice->change(
+                    orderId:   new Uuid($item['id']),
+                    price:     $item['price_correct'],
+                    adminId:   null,
+                    actorType: ActorType::ARTISAN,
+                    reason:    'orders:fix-friendly-prices (artisan-команда фикса завышенных сумм)',
+                );
                 $applied++;
             } catch (Throwable $e) {
-                DB::rollBack();
                 $failed++;
                 $this->error('Ошибка на заказе ' . $item['id'] . ': ' . $e->getMessage());
             }

--- a/Backend/src/History/Domain/Event/OrderPriceChangedEvent.php
+++ b/Backend/src/History/Domain/Event/OrderPriceChangedEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\History\Domain\Event;
+
+use Tickets\History\Domain\HistoryEventInterface;
+
+final class OrderPriceChangedEvent implements HistoryEventInterface
+{
+    public function __construct(
+        private float   $fromPrice,
+        private float   $toPrice,
+        private ?string $reason = null,
+    ) {
+    }
+
+    public function getAggregateType(): string
+    {
+        return 'order';
+    }
+
+    public function getEventName(): string
+    {
+        return 'price_changed';
+    }
+
+    public function getPayload(): array
+    {
+        return array_filter([
+            'from'   => $this->fromPrice,
+            'to'     => $this->toPrice,
+            'reason' => $this->reason,
+        ], fn($v) => $v !== null);
+    }
+}

--- a/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPrice.php
+++ b/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPrice.php
@@ -7,6 +7,7 @@ namespace Tickets\Order\OrderTicket\Application\ChangeOrderPrice;
 use Shared\Domain\ValueObject\Uuid;
 use Shared\Infrastructure\Bus\Command\InMemorySymfonyCommandBus;
 use Throwable;
+use Tickets\History\Domain\ActorType;
 
 class ChangeOrderPrice
 {
@@ -22,12 +23,19 @@ class ChangeOrderPrice
     /**
      * @throws Throwable
      */
-    public function change(Uuid $orderId, float $price, Uuid $adminId): void
-    {
+    public function change(
+        Uuid    $orderId,
+        float   $price,
+        ?Uuid   $adminId   = null,
+        string  $actorType = ActorType::USER,
+        ?string $reason    = null,
+    ): void {
         $this->commandBus->dispatch(new ChangeOrderPriceCommand(
             $orderId,
             $price,
-            $adminId
+            $adminId,
+            $actorType,
+            $reason,
         ));
     }
 }

--- a/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPriceCommand.php
+++ b/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPriceCommand.php
@@ -6,13 +6,16 @@ namespace Tickets\Order\OrderTicket\Application\ChangeOrderPrice;
 
 use Shared\Domain\Bus\Command\Command;
 use Shared\Domain\ValueObject\Uuid;
+use Tickets\History\Domain\ActorType;
 
 class ChangeOrderPriceCommand implements Command
 {
     public function __construct(
-        public Uuid $orderId,
-        public float $price,
-        public Uuid $adminId,
+        public Uuid    $orderId,
+        public float   $price,
+        public ?Uuid   $adminId   = null,
+        public string  $actorType = ActorType::USER,
+        public ?string $reason    = null,
     ) {
     }
 
@@ -26,8 +29,18 @@ class ChangeOrderPriceCommand implements Command
         return $this->price;
     }
 
-    public function getAdminId(): Uuid
+    public function getAdminId(): ?Uuid
     {
         return $this->adminId;
+    }
+
+    public function getActorType(): string
+    {
+        return $this->actorType;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
     }
 }

--- a/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPriceCommandHandler.php
+++ b/Backend/src/Order/OrderTicket/Application/ChangeOrderPrice/ChangeOrderPriceCommandHandler.php
@@ -5,18 +5,24 @@ declare(strict_types=1);
 namespace Tickets\Order\OrderTicket\Application\ChangeOrderPrice;
 
 use DomainException;
+use Illuminate\Support\Facades\DB;
 use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\History\Domain\Event\OrderPriceChangedEvent;
+use Tickets\History\Dto\SaveHistoryDto;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
 use Tickets\Order\OrderTicket\Repositories\OrderTicketRepositoryInterface;
 
 class ChangeOrderPriceCommandHandler implements CommandHandler
 {
     public function __construct(
         private OrderTicketRepositoryInterface $orderTicketRepository,
+        private HistoryRepositoryInterface     $historyRepository,
     ) {
     }
 
     /**
      * @throws DomainException
+     * @throws \Throwable
      */
     public function __invoke(ChangeOrderPriceCommand $command): void
     {
@@ -29,9 +35,29 @@ class ChangeOrderPriceCommandHandler implements CommandHandler
             throw new DomainException('Цена должна быть больше нуля');
         }
 
-        $this->orderTicketRepository->changePrice(
-            $command->getOrderId(),
-            $command->getPrice()
-        );
+        $fromPrice = (float)$orderTicketDto->getPriceDto()->getTotalPrice();
+        $toPrice   = (float)$command->getPrice();
+
+        // Атомарно: смена цены + запись в domain_history. История пишется
+        // ровно в одном месте — этом handler — чтобы исключить задвоение между
+        // разными вызовами changePrice (контроллер /order/changePrice, artisan-команды и т.п.).
+        // Если caller хочет идемпотентность — он сам фильтрует на своей стороне.
+        DB::transaction(function () use ($command, $fromPrice, $toPrice): void {
+            $this->orderTicketRepository->changePrice(
+                $command->getOrderId(),
+                $toPrice
+            );
+
+            $this->historyRepository->save(new SaveHistoryDto(
+                aggregateId: $command->getOrderId()->value(),
+                event: new OrderPriceChangedEvent(
+                    fromPrice: $fromPrice,
+                    toPrice:   $toPrice,
+                    reason:    $command->getReason(),
+                ),
+                actorId:   $command->getAdminId()?->value(),
+                actorType: $command->getActorType(),
+            ));
+        });
     }
 }


### PR DESCRIPTION
ChangeOrderPriceCommandHandler теперь пишет событие OrderPriceChangedEvent в domain_history атомарно (в одной транзакции с repo->changePrice). Бонус: контроллер /order/changePrice (admin) тоже начинает писать историю, без правок самого контроллера.

ChangeOrderPriceCommand расширен опциональными actorType (default USER), reason (default null); adminId стал nullable — нужно для вызовов из artisan. Сигнатура ChangeOrderPrice::change() обратно-совместима с контроллером.

FixFriendlyPricesCommand теперь тонкая: использует ChangeOrderPrice::change() с actorType=ARTISAN, своей записи истории не делает — задвоения нет.

Защита от задвоения:
- история пишется ровно в одном месте (handler)
- price меняется ровно в одном месте (handler через repo)
- DB::transaction обнимает обе записи (атомарно)
- caller отвечает за идемпотентность: команда фильтрует уже исправленные