### PR TITLE
release: зафиксировать v2.5.0 — 2026-05-29

### DIFF
--- a/.claude/docs/BOARD.md
+++ b/.claude/docs/BOARD.md
@@ -11,7 +11,7 @@
 
 | Версия | Срок | Главное | Статус |
 |--------|------|---------|--------|
-| **2.5.0** | конец мая — начало июня 2026 | Старт версионирования, базовый CI, новые агенты, healthcheck воркера, очистка от Friendly-приложения | 🔄 В работе |
+| **2.5.0** | 2026-05-29 | Старт версионирования, базовый CI, новые агенты, healthcheck воркера, очистка от Friendly-приложения | ✅ Выпущена |
 | **2.5.1** | патч | Починка PHPUnit | ⏳ Запланировано |
 | **2.6.0** | июнь 2026 | SSL для ноутбука-сканера, offline docker-compose, CD staging | ⏳ Запланировано |
 | **2.7.0** | июль 2026 | Loki + Grafana, audit + воронка покупки, CD prod tag-based | ⏳ Запланировано |
@@ -23,23 +23,9 @@
 
 ---
 
-## 🔄 Текущая работа (v2.5.0)
+## 🔄 Текущая работа
 
-| Задача | Ответственный | Статус |
-|--------|---------------|--------|
-| Папка `.claude/docs/process/` + импорты в CLAUDE.md | scrum-master | ✅ |
-| `RELEASES.md` (SemVer + branching + DoD + roadmap) | scrum-master | ✅ |
-| `CHANGELOG.md` (русский, Keep a Changelog) | scrum-master | ✅ |
-| Обновление `BOARD.md` (этот файл) | scrum-master | 🔄 |
-| Обновление `TECH_DEBT.md` (приоритеты + TD3-TD8) | scrum-master | ⏳ |
-| Очистка документации от Friendly-приложения | technical-writer | ⏳ |
-| Создание агента scrum-master | claude | ⏳ |
-| Создание агента security-engineer | claude | ⏳ |
-| husky + commitlint (мягкий warning, 3 приложения) | devops-engineer | ⏳ |
-| Healthcheck воркера в `docker-compose.yml` (прод) | devops-engineer | ⏳ |
-| Базовый CI на GitHub Actions | devops-engineer | ⏳ |
-| Подсчёт сломанных PHPUnit-тестов → TECH_DEBT | auto-tester | ⏳ |
-| Тег `v2.5.0` + GitHub Release | scrum-master | ⏳ |
+_Сейчас нет активного спринта. Следующий — v2.5.1 (патч с продолжением починки PHPUnit для Baza Risky-теста и созданием сидеров)._
 
 ---
 
@@ -73,6 +59,29 @@
 ---
 
 ## ✅ Сделано
+
+### 2026-05-29 — v2.5.0 «Старт версионирования» 🎉
+
+**Первая официальная версия проекта. Фундамент процесса релизов и инфраструктуры.**
+
+- 🏷️ Тег: `v2.5.0`
+- 📜 [CHANGELOG.md §2.5.0](../../CHANGELOG.md)
+- 🌿 PR: feat/v2.5.0-foundation → master (#35), 16 коммитов
+- 📦 Релиз: GitHub Release (см. https://github.com/ShaevMV/systo/releases/tag/v2.5.0)
+
+**Что вошло:**
+- Процесс релизов: `RELEASES.md` (SemVer + branching + DoD + roadmap), `CHANGELOG.md`
+- CI на GitHub Actions: 7 параллельных job (lint Backend/Baza/Frontend, build, audit, PHPUnit Backend/Baza), MySQL service, кэш, триггеры push + PR
+- husky + commitlint (мягкий warning, conventional commits)
+- Makefile: 30+ целей с группами + `make help`
+- Агенты команды: `scrum-master`, `security-engineer`
+- Материалы к встрече с организаторами 2026-05-30
+- Очистка документации от Friendly-приложения (и косвенно от List)
+- TD-1 закрыт (Race Condition воркера на проде через healthcheck)
+- TD-2 закрыт частично (Backend 55 тестов 0 ошибок, Baza 7 тестов 0 ошибок 2 skipped)
+- TD-3 закрыт (cleanup от Friendly + List)
+- Починка docker-compose.prod.yml (удалены мёртвые phpFriendly, phpList, database)
+- Починка Baza/composer.lock (endroid/qr-code добавлен)
 
 ### 2026-05-15 — Авто-одобрение заказа
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,86 @@
 
 ## [Unreleased]
 
-### Added (Добавлено)
-
-- Введён `CHANGELOG.md` (формат Keep a Changelog 1.1.0, русский язык)
-- Создана папка `.claude/docs/process/` с документом `RELEASES.md` — правила версионирования, branching, Definition of Done, roadmap 2.5.0 → 3.0.0-alpha
-- Создан агент `scrum-master` — отвечает за релизы, SemVer-теги, CHANGELOG, GitHub Releases, sprint planning, backlog grooming, retrospective, definition of done
-- Создан агент `security-engineer` — отвечает за 152-ФЗ compliance, audit-логи, аудит JWT/middleware, аудит секретов, pentesting публичных API
-- Добавлен импорт `@.claude/docs/process/RELEASES.md` в `CLAUDE.md`
-
-### Changed (Изменено)
-
-- Документация очищена от упоминаний приложения Friendly (Friendly как отдельный микросервис удалён из монорепо, осталось 3 приложения: Backend, Baza, FrontEnd). Friendly как тип заказа (роль `pusher`, поле `friendly_id`) сохранён внутри Backend.
-
-### Запланировано в [2.5.0]
-
-- husky + commitlint (мягкий режим, warning) на Backend / Baza / FrontEnd
-- Healthcheck воркера в `docker-compose.yml` (фикс известного Race Condition)
-- Базовый CI на GitHub Actions: Pint + ESLint + npm build + composer/npm audit + PHPUnit с `continue-on-error`
-- Подсчёт сломанных PHPUnit-тестов, фиксация в `TECH_DEBT.md`
-- Тег `v2.5.0` + GitHub Release
+_(пока пусто — все изменения вошли в [2.5.0])_
 
 ---
 
-[Unreleased]: https://github.com/shaevmv/systo/compare/HEAD...HEAD
+## [2.5.0] — 2026-05-29
+
+**Старт версионирования проекта Systo.** Первая официальная версия. Запущен полноценный процесс релизов: SemVer, ветки, Definition of Done, CI на GitHub Actions, CHANGELOG. Команда расширена двумя новыми агентами. Починены тесты Backend и Baza. Очищены мёртвые сервисы в prod-инфраструктуре. Подготовлены материалы к встрече с организаторами фестиваля.
+
+### Added (Добавлено)
+
+- **Процесс релизов:** `.claude/docs/process/RELEASES.md` — SemVer, branching, Definition of Done, roadmap версий 2.5.0 → 3.0.0-alpha, шаблон release notes, чек-лист релиза, привязка к фестивалям
+- **CHANGELOG.md** — формат Keep a Changelog 1.1.0, RU
+- **CI на GitHub Actions** (`.github/workflows/ci.yml`): 7 параллельных job — lint Backend/Baza/Frontend, build Frontend, audit, PHPUnit Backend, PHPUnit Baza. MySQL service в test-job-ах, кэш composer и npm. Триггеры: push в master + feat/** + fix/**, PR на master
+- **husky + commitlint** в корне монорепо (мягкий warning, conventional commits)
+- **Makefile** — расширен с 3 до 30+ целей с группами и `make help` (цветной вывод, описания)
+- **Новые агенты команды:**
+  - `scrum-master` — Scrum Master + Release Manager, Scrum-of-One
+  - `security-engineer` — 152-ФЗ compliance, audit-логи, аудит JWT/middleware, аудит секретов, pentesting публичных API
+- **Материалы к встрече с бизнесом 2026-05-30** в `.claude/meetings/2026-05-30/`:
+  - Отчёт о фестивале
+  - Roadmap для бизнеса на 6 этапов
+  - 50+ вопросов в 10 блоках
+- В `CLAUDE.md` добавлен раздел «Процессы» и импорт `RELEASES.md`
+
+### Changed (Изменено)
+
+- **CLAUDE.md** — Friendly убран из таблицы компонентов (3 приложения вместо 4)
+- **BOARD.md** — добавлен Roadmap-блок версий 2.5.0 → 3.0.0-α + текущая работа
+- **TECH_DEBT.md** — расставлены приоритеты с ID (TD-1 … TD-22), привязка к версиям
+- **Makefile семантика:** `up` теперь только поднимает, `build` делает docker build (раньше `up` делал `--build`); `build` фронта переименован в `build-frontend`. TTY fix для не-интерактивных команд
+- **docker-compose.prod.yml** — добавлены healthcheck mysql + worker `depends_on: service_healthy` + `restart: unless-stopped`
+
+### Removed (Удалено)
+
+- `.github/workflows/laravel.yml` — старый сломанный workflow (PHP 8.0, ветка dev, sqlite, неправильные пути)
+- Мёртвые сервисы в `docker-compose.prod.yml`: `phpFriendly`, `phpList`, `database` (mysql 5.7 для удалённого Friendly)
+- Volume mounts `./Friendly` и `./List` в nginx и worker
+- ENV переменные `ENV_DRUG_*`, `ENV_SPISOK_*` в `.env.example`
+- Baza `Feature/ExampleTest` — auto-generated welcome page тест
+
+### Fixed (Исправлено)
+
+- **Race Condition воркера на проде (TD-1)** — воркер ждёт healthy mysql через healthcheck + `depends_on: service_healthy`
+- **PHPUnit Backend (TD-2 часть 1):**
+  - `ChangeOrderPriceTest` — добавлен `HistoryRepositoryInterface` mock (конструктор handler требовал 2 аргумента, тест передавал 1)
+  - Тест переведён на `Tests\TestCase` (Laravel) — для работы `DB::transaction`
+  - Было: 4 errors. Стало: **0 errors, 55 тестов, 4 skipped (намеренно — ChangeStatusTest требует view-шаблонов для PDF)**
+- **PHPUnit Baza (TD-2 часть 2):**
+  - `DefineServiceTest` — переписан под актуальные форматы ссылок (старые `'0020'`, `'sS50065'`, `'ff30049'` больше не поддерживаются в `DefineService`)
+  - `ChangesTest` — методы помечены `markTestSkipped` с пояснением (требуют сидеров для Baza)
+  - Было: 2 errors + 1 failure. Стало: **0 errors, 7 тестов, 2 skipped**
+- **Документация очищена от Friendly-приложения (TD-3)** — Friendly как тип заказа сохранён в Backend
+- **Baza/composer.lock** — синхронизирован с composer.json (endroid/qr-code был в .json, но не в .lock)
+
+### Security (Безопасность)
+
+- Введён агент `security-engineer` с активным режимом — даёт советы по безопасности при изменениях в коде
+
+### Breaking Changes
+
+Нет. Это MINOR-релиз, все изменения обратно совместимы.
+
+Изменение семантики `make up` (раньше делал `--build`, теперь нет) задокументировано в Makefile help, для старого поведения есть `make up-build`.
+
+### Migration Guide
+
+Для разработчиков после `git pull master`:
+
+```bash
+# Активировать husky-хуки для commitlint
+npm install
+
+# Использовать новые make-цели
+make help          # увидишь все цели с описанием
+make up            # поднять dev-окружение
+make build         # билд образов
+make test          # все тесты
+```
+
+---
+
+[Unreleased]: https://github.com/ShaevMV/systo/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/ShaevMV/systo/releases/tag/v2.5.0


### PR DESCRIPTION
- CHANGELOG.md: перенесено [Unreleased] → [2.5.0] — 2026-05-29 с детализацией Added/Changed/Removed/Fixed/Security
- BOARD.md: · roadmap v2.5.0 помечен ✅ Выпущена · блок "Текущая работа" очищен (следующий спринт v2.5.1) · в "Сделано" добавлена секция v2.5.0 со ссылками на CHANGELOG, PR #35, GitHub Release

Версия 2.5.0 готова к тегированию. Тег v2.5.0 будет поставлен на этом коммите.