### PR TITLE
chore(release): v2.5.1 docs catch-up — CHANGELOG/BOARD/TECH_DEBT

### DIFF
--- a/.claude/docs/BOARD.md
+++ b/.claude/docs/BOARD.md
@@ -12,7 +12,7 @@
 | Версия | Срок | Главное | Статус |
 |--------|------|---------|--------|
 | **2.5.0** | 2026-05-29 | Старт версионирования, базовый CI, новые агенты, healthcheck воркера, очистка от Friendly-приложения | ✅ Выпущена |
-| **2.5.1** | патч | Починка PHPUnit | ⏳ Запланировано |
+| **2.5.1** | 2026-05-29 | Baza сидеры/factory, миграции синхронизированы со схемой прода, чистый PHPUnit Baza, spec истории билета | ✅ Выпущена |
 | **2.6.0** | июнь 2026 | SSL для ноутбука-сканера, offline docker-compose, CD staging | ⏳ Запланировано |
 | **2.7.0** | июль 2026 | Loki + Grafana, audit + воронка покупки, CD prod tag-based | ⏳ Запланировано |
 | **2.8.0** | август 2026 | Laravel 11 part 1 (staging), упаковка SPA для офлайн-сканера | ⏳ Запланировано |
@@ -25,7 +25,7 @@
 
 ## 🔄 Текущая работа
 
-_Сейчас нет активного спринта. Следующий — v2.5.1 (патч с продолжением починки PHPUnit для Baza Risky-теста и созданием сидеров)._
+_Сейчас нет активного спринта. Следующий — v2.6.0 (SSL для ноутбука-сканера, offline docker-compose bundle, CD staging). Старт — после встречи с бизнесом 2026-05-30 и определения приоритетов._
 
 ---
 
@@ -33,8 +33,8 @@ _Сейчас нет активного спринта. Следующий — v
 
 | Задача | Ответственный | Куда |
 |--------|---------------|------|
-| **Race Condition воркера** — внедрить Healthcheck в docker-compose | devops-engineer | v2.5.0 |
-| **Починка Unit-тестов** (PDO/Connection ошибки) | auto-tester | v2.5.1 |
+| **Race Condition воркера** — внедрить Healthcheck в docker-compose | devops-engineer | v2.5.0 ✅ |
+| **Починка Unit-тестов** (PDO/Connection ошибки) | auto-tester | v2.5.0 + v2.5.1 ✅ |
 | **Очистка документации от Friendly-приложения** | technical-writer | v2.5.0 |
 | **Обновление Laravel 9 → 11** (заблокировано до 1 июня) | tech-lead | v2.8.0 + v2.9.0 |
 
@@ -59,6 +59,26 @@ _Сейчас нет активного спринта. Следующий — v
 ---
 
 ## ✅ Сделано
+
+### 2026-05-29 — v2.5.1 «Baza-сидеры и чистый PHPUnit»
+
+**Патч-релиз вечером того же дня. TD-2 закрыт.**
+
+- 🏷️ Тег: `v2.5.1`
+- 📜 [CHANGELOG.md §2.5.1](../../CHANGELOG.md)
+- 🌿 Ветки: `feat/v2.5.1-baza-seeders` (#36 — код), `chore/backport-v2.5.0-changelog` (#37 — backport CHANGELOG v2.5.0), `chore/release-v2.5.1-docs` (#38 — финальная документация v2.5.1)
+- 📦 Релиз: GitHub Release (см. https://github.com/ShaevMV/systo/releases/tag/v2.5.1)
+
+**Что вошло:**
+- Чистый PHPUnit Baza: было 2 skipped + 1 risky → стало **8 тестов, 10 ассертов, 0 проблем**
+- `ChangesFactory` + `ChangesTestDataSeeder` + `RefreshDatabase` в `ChangesTest`
+- Отдельная тестовая БД `baza_test` (фиксация в `phpunit.xml`)
+- Шаг `php artisan migrate --force` в CI job `test-baza`
+- 2 миграции синхронизации со схемой прода: `festival_id` в `el_tickets`, `festival_id` + `count_auto_tickets` в `changes` (с `Schema::hasColumn()` — на проде безопасно)
+- Спецификация фичи «История билета» (`.claude/specs/ticket-history.md`, 465 строк) — кандидат в v2.7.0/v2.8.0
+
+**Заметки по релизу:**
+- Из-за неправильно смерженного PR #36 (вместо PR #37 backport) в истории `master` остался WIP-коммит `29ea36e4`. Решение: backport-PR #37 + catch-up PR #38 с финальной документацией.
 
 ### 2026-05-29 — v2.5.0 «Старт версионирования» 🎉
 

--- a/.claude/docs/TECH_DEBT.md
+++ b/.claude/docs/TECH_DEBT.md
@@ -12,9 +12,9 @@
 
 | ID | Описание | Кто ведёт | Куда направлено |
 |----|----------|-----------|-----------------|
-| TD-1 | **Race Condition воркера** — воркер стартует раньше БД (commit → rollback → disconnect). Внедрить healthcheck на MySQL + `depends_on: service_healthy` в `docker-compose.yml` (только прод) | devops-engineer | **v2.5.0** |
-| TD-2 | **Починка PHPUnit-тестов** — ошибки PDO/Connection. Сначала запустить и подсчитать количество сломанных, потом чинить. Использовать отдельную БД `systo_test` | auto-tester | **v2.5.1** (патч) |
-| TD-3 | **Очистка документации от Friendly-приложения** — Friendly как микросервис удалён, осталось 3 приложения. Очистить CLAUDE.md, API.md, DOMAIN.md, CONVENTIONS.md, PROJECT_MEMORY.md. Friendly как тип заказа (роль `pusher`, поле `friendly_id`) — сохранить | technical-writer | **v2.5.0** |
+| ✅ TD-1 | **Race Condition воркера** — закрыт в v2.5.0 (healthcheck mysql + worker `depends_on: service_healthy` в prod-compose). | devops-engineer | ✅ **v2.5.0** |
+| ✅ TD-2 | **Починка PHPUnit-тестов** — закрыт в v2.5.0 (Backend 55/0) + v2.5.1 (Baza 8/0/0 ассертов). Чистый прогон через `baza_test` БД + фикстуры. | auto-tester | ✅ **v2.5.0 + v2.5.1** |
+| ✅ TD-3 | **Очистка документации от Friendly-приложения** — закрыт в v2.5.0. Friendly как тип заказа (роль `pusher`, поле `friendly_id`) сохранён в Backend. | technical-writer | ✅ **v2.5.0** |
 | TD-4 | **Обновление Laravel 9 → 11** на всех 3 приложениях (Backend, Baza, FrontEnd). Заблокировано до 1 июня (после фестиваля) | tech-lead | **v2.8.0 (staging) + v2.9.0 (прод)** |
 
 ---
@@ -126,3 +126,4 @@ Telegram-бот анкет (`http://77.222.60.58:8000`) — **сторонний
 | 2026-04-12 | Закрыт пункт: «Фильтрация festivalId в Vuex store OrderModule» |
 | 2026-05-10 | Добавлен пункт: «Единый паттерн для `Order::none()` в фильтрах списков» |
 | 2026-05-28 | Полная актуализация: расставлены приоритеты с ID, добавлены TD-3 (очистка Friendly), TD-6 (альтернатива Telegram), TD-7 (152-ФЗ), TD-8 (место на VPS), TD-15 (mobile отдельный SPA). Привязка к версиям v2.5.0 → v2.9.0 |
+| 2026-05-29 | Закрыты TD-1 (Race Condition воркера, v2.5.0), TD-3 (очистка Friendly, v2.5.0), TD-2 (PHPUnit Backend+Baza, v2.5.0+v2.5.1). Помечены ✅ |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,68 @@
 
 ## [Unreleased]
 
-_(пока пусто — все изменения вошли в [2.5.0])_
+_(пока пусто — все изменения вошли в [2.5.1])_
+
+---
+
+## [2.5.1] — 2026-05-29
+
+**Патч после v2.5.0.** Починка PHPUnit Baza — теперь 0 errors / 0 skipped / 0 risky. Чистый тестовый прогон через `baza_test` БД с фикстурами. Заодно — фикс расхождения миграций со схемой прода (две колонки добавлены руками без миграций). Подготовлена спецификация фичи «История билета» как кандидат в backlog.
+
+### Added (Добавлено)
+
+- **Спецификация фичи «История билета»** (`.claude/specs/ticket-history.md`, 465 строк) — кандидат в backlog v2.7.0–v2.8.0. 10 типов событий, 10 user stories, рекомендация по архитектуре (общий `domain_history` с агрегатом `ticket`), гибридная синхронизация Baza↔Backend для офлайн-режима. 10 открытых вопросов для пользователя.
+- **ChangesFactory** (`Baza/database/factories/`) — factory для модели `ChangesModel` с состояниями `closed()` и `forUsers(array)`
+- **ChangesTestDataSeeder** (`Baza/database/seeders/`) — сидер для интеграционных тестов: вызывает `UsersTableSeeder` + создаёт открытую смену для admin (user_id=1)
+- **Отдельная тестовая БД `baza_test`** через `phpunit.xml` (`DB_DATABASE=baza_test`) — `RefreshDatabase` пересоздаёт схему на каждом прогоне, не трогая локальную `baza`
+- **Шаг `php artisan migrate --force`** в CI job `test-baza` (до прогона PHPUnit) — на свежем CI runner'е миграций раньше не было
+- `Baza/tests/Feature/.gitkeep` — пустая папка для будущих feature-тестов (phpunit.xml требует существования директории)
+- **HasFactory trait + `newFactory()`** в `App\Models\ChangesModel`
+
+### Changed (Изменено)
+
+- **`Baza/tests/Unit/ChangesTest`** — переписан под интеграционный режим:
+  - 3 теста с реальной БД: `test_get_changes_id_returns_open_shift_for_admin`, `test_get_changes_id_throws_for_user_without_shift`, `test_get_report_returns_response_with_seeded_shift`
+  - `RefreshDatabase` trait + `$this->seed(ChangesTestDataSeeder::class)` в setUp
+  - Убран `markTestSkipped` с обоих исходных тестов
+- **`Baza/tests/Unit/SearchServiceTest`** — добавлен `assertInstanceOf(SearchResponse::class)` (раньше был Risky из-за отсутствия ассертов)
+
+### Fixed (Исправлено)
+
+- **Синхронизация миграций со схемой прода (TD-2 follow-up)** — добавлены 2 миграции для колонок, которые на проде/локалке заведены руками:
+  - `2026_05_11_125000_add_festival_id_to_el_tickets_table` — `festival_id` (uuid, nullable) в `el_tickets`. Без неё backfill-миграция `2026_05_11_130000_backfill_festival_id_in_el_tickets` падала на чистой БД с `Column not found`
+  - `2026_05_29_180000_add_festival_id_and_count_auto_to_changes_table` — `festival_id` и `count_auto_tickets` в `changes`
+  - Обе миграции используют `Schema::hasColumn()` — на проде ничего не сломают, лишь зарегистрируются в таблице `migrations`
+- **PHPUnit Baza:** было 2 skipped + 1 risky → стало **8 тестов, 10 ассертов, 0 проблем**. TD-2 закрыт.
+
+### Breaking Changes
+
+Нет. Патч-релиз.
+
+### Migration Guide
+
+Для разработчиков:
+
+```bash
+# Создать тестовую БД (один раз)
+docker exec php-baza php -r "
+\$pdo = new PDO('mysql:host=database', 'root', 'common404');
+\$pdo->exec('CREATE DATABASE IF NOT EXISTS baza_test CHARACTER SET utf8mb4');
+"
+
+# Прогон миграций на тест-БД
+docker exec -e DB_DATABASE=baza_test php-baza php artisan migrate --force
+
+# Прогон тестов
+docker exec php-baza ./vendor/bin/phpunit --testdox
+```
+
+Для прода:
+- Миграции безопасны (используют `Schema::hasColumn()`), но фактически не добавят ничего — колонки уже существуют. Запись о миграции в `migrations` появится при следующем `php artisan migrate`.
+
+### Заметки по релизу
+
+Из-за неправильно смерженного PR #36 (вместо backport-PR #37 пользователь сначала смержил feat/v2.5.1-baza-seeders с WIP-коммитом) в истории `master` оказался коммит `29ea36e4 wip: v2.5.1 baza-seeders draft (will be squashed)`. Это разовая аномалия, для следующих релизов будет жёстко следить за порядком: backport-ветка после релиза идёт ПЕРВОЙ.
 
 ---
 
@@ -92,5 +153,6 @@ make test          # все тесты
 
 ---
 
-[Unreleased]: https://github.com/ShaevMV/systo/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/ShaevMV/systo/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/ShaevMV/systo/releases/tag/v2.5.1
 [2.5.0]: https://github.com/ShaevMV/systo/releases/tag/v2.5.0


### PR DESCRIPTION
Код v2.5.1 уже на master через PR #36 + backport через PR #37. Этот PR закрывает разрыв документации:

- CHANGELOG.md: добавлена секция [2.5.1] — 2026-05-29 (Added/Changed/Fixed/ Migration Guide/заметки по релизу), обновлены ссылки на сравнения и тег
- BOARD.md: v2.5.1 помечена ✅ Выпущена, добавлена запись в Сделано, обновлена 'Текущая работа' под v2.6.0
- TECH_DEBT.md: TD-1, TD-2, TD-3 помечены закрытыми с привязкой к версиям, запись в историю изменений

После мержа этого PR — тег v2.5.1 + GitHub Release.