### PR TITLE
feat(option): админ-UI опций к билетам (Vuex + Vue компоненты)

### DIFF
--- a/Backend/app/Http/Controllers/Option/OptionController.php
+++ b/Backend/app/Http/Controllers/Option/OptionController.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Option;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Option\OptionCreateRequest;
+use App\Http\Requests\Option\OptionEditRequest;
+use App\Http\Requests\Option\OptionGetListRequest;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Nette\Utils\JsonException;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\Option\Application\GetList\OptionGetListQuery;
+use Tickets\Option\Application\OptionApplication;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionForTicketTypeView;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+/**
+ * REST-контроллер опций к билетам (v2.6.0).
+ *
+ * Read-операции (getList/getItem/getActiveOptionsForTicketType) —
+ * публичные (нужны фронту формы покупки). Write-операции —
+ * только админ (защита от дурака на уровне роутов).
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+class OptionController extends Controller
+{
+    public function getList(
+        OptionGetListRequest $request,
+        OptionApplication $application,
+    ): JsonResponse {
+        $validated = $request->validated();
+
+        try {
+            $orderBy = Order::fromState($validated['orderBy'] ?? []);
+        } catch (InvalidArgumentException) {
+            $orderBy = Order::none();
+        }
+
+        $collection = $application->getList(
+            new OptionGetListQuery($validated['filter'] ?? [], $orderBy),
+        )->getCollection();
+
+        return response()->json([
+            'success' => true,
+            'list' => $collection->map(fn (OptionDto $dto) => $dto->toArray())->values()->all(),
+        ]);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function getItem(
+        string $id,
+        OptionApplication $application,
+    ): JsonResponse {
+        try {
+            $option = $application->getItem(new Uuid($id));
+            $bindings = $application->getTicketTypeBindings(new Uuid($id));
+
+            return response()->json([
+                'success' => true,
+                'item' => array_merge($option->toArray(), [
+                    'bindings' => array_map(
+                        static fn (OptionTicketTypeBindingDto $b) => [
+                            'ticket_type_id' => $b->getTicketTypeId()->value(),
+                            'description' => $b->getDescription(),
+                        ],
+                        $bindings
+                    ),
+                ]),
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+
+    /**
+     * Read-модель: активные опции конкретного типа билета (для формы покупки).
+     */
+    public function getActiveForTicketType(
+        string $ticketTypeId,
+        OptionApplication $application,
+    ): JsonResponse {
+        try {
+            $list = $application->getActiveOptionsForTicketType(new Uuid($ticketTypeId));
+
+            return response()->json([
+                'success' => true,
+                'list' => array_map(
+                    static fn (OptionForTicketTypeView $view) => $view->toArray(),
+                    $list
+                ),
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор типа билета',
+            ], 400);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function create(
+        OptionCreateRequest $request,
+        OptionApplication $application,
+    ): JsonResponse {
+        try {
+            $validated = $request->validated()['data'];
+            $bindings = array_map(
+                static fn (array $row) => OptionTicketTypeBindingDto::fromState($row),
+                $validated['bindings'] ?? []
+            );
+
+            $data = OptionDto::fromState($validated);
+
+            return response()->json([
+                'success' => $application->create($data, $bindings),
+                'item' => $application->getItem($data->getId())->toArray(),
+                'message' => 'Опция создана',
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     * @throws JsonException
+     */
+    public function edit(
+        string $id,
+        OptionEditRequest $request,
+        OptionApplication $application,
+    ): JsonResponse {
+        try {
+            $payload = $request->validated()['data'];
+            $payload['id'] = $id;
+
+            $bindings = isset($payload['bindings'])
+                ? array_map(
+                    static fn (array $row) => OptionTicketTypeBindingDto::fromState($row),
+                    $payload['bindings']
+                )
+                : null;
+
+            return response()->json([
+                'success' => $application->edit(
+                    new Uuid($id),
+                    OptionDto::fromState($payload),
+                    $bindings
+                ),
+                'item' => $application->getItem(new Uuid($id))->toArray(),
+                'message' => 'Опция отредактирована',
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function delete(
+        string $id,
+        OptionApplication $application,
+    ): JsonResponse {
+        try {
+            return response()->json([
+                'success' => $application->delete(new Uuid($id)),
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+}

--- a/Backend/app/Http/Controllers/OptionPrice/OptionPriceController.php
+++ b/Backend/app/Http/Controllers/OptionPrice/OptionPriceController.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\OptionPrice;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\OptionPrice\OptionPriceCreateRequest;
+use App\Http\Requests\OptionPrice\OptionPriceEditRequest;
+use App\Http\Requests\OptionPrice\OptionPriceGetListRequest;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Nette\Utils\JsonException;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\OptionPrice\Application\GetList\OptionPriceGetListQuery;
+use Tickets\OptionPrice\Application\OptionPriceApplication;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+/**
+ * REST-контроллер волн цен опций (v2.6.0).
+ *
+ * Полный аналог `TicketTypePriceController` — управляет таблицей
+ * `option_price`. Read публично, write только админ.
+ */
+class OptionPriceController extends Controller
+{
+    public function getList(
+        OptionPriceGetListRequest $request,
+        OptionPriceApplication $application,
+    ): JsonResponse {
+        $validated = $request->validated();
+
+        try {
+            $orderBy = Order::fromState($validated['orderBy'] ?? []);
+        } catch (InvalidArgumentException) {
+            $orderBy = Order::none();
+        }
+
+        $collection = $application->getList(
+            new OptionPriceGetListQuery($validated['filter'], $orderBy),
+        )->getCollection();
+
+        return response()->json([
+            'success' => true,
+            'list' => $collection->map(fn (OptionPriceDto $dto) => $dto->toArray())->values()->all(),
+        ]);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function getItem(
+        string $id,
+        OptionPriceApplication $application,
+    ): JsonResponse {
+        try {
+            return response()->json([
+                'success' => true,
+                'item' => $application->getItem(new Uuid($id))->toArray(),
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function create(
+        OptionPriceCreateRequest $request,
+        OptionPriceApplication $application,
+    ): JsonResponse {
+        try {
+            $data = OptionPriceDto::fromState($request->validated()['data']);
+
+            return response()->json([
+                'success' => $application->create($data),
+                'item' => $application->getItem($data->getId())->toArray(),
+                'message' => 'Волна цены опции создана',
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     * @throws JsonException
+     */
+    public function edit(
+        string $id,
+        OptionPriceEditRequest $request,
+        OptionPriceApplication $application,
+    ): JsonResponse {
+        try {
+            $payload = $request->validated()['data'];
+            $payload['id'] = $id;
+
+            return response()->json([
+                'success' => $application->edit(
+                    new Uuid($id),
+                    OptionPriceDto::fromState($payload)
+                ),
+                'item' => $application->getItem(new Uuid($id))->toArray(),
+                'message' => 'Волна цены опции отредактирована',
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function delete(
+        string $id,
+        OptionPriceApplication $application,
+    ): JsonResponse {
+        try {
+            return response()->json([
+                'success' => $application->delete(new Uuid($id)),
+            ]);
+        } catch (InvalidArgumentException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Некорректный идентификатор',
+            ], 400);
+        } catch (DomainException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 404);
+        }
+    }
+}

--- a/Backend/app/Http/Requests/Option/OptionCreateRequest.php
+++ b/Backend/app/Http/Requests/Option/OptionCreateRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Option;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на создание опции.
+ *
+ * Цена и описание здесь НЕ принимаются — они хранятся отдельно:
+ *  - цена через `/api/v1/optionPrice/create` (волны цен);
+ *  - описание — на pivot, передаётся в `bindings[].description`.
+ */
+class OptionCreateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.id' => ['sometimes', 'string', 'uuid'],
+            'data.name' => ['required', 'string', 'max:255'],
+            'data.active' => ['sometimes', 'boolean'],
+            'data.festival_id' => ['required', 'string', 'uuid', 'exists:festivals,id'],
+
+            'data.bindings' => ['sometimes', 'array'],
+            'data.bindings.*.ticket_type_id' => ['required_with:data.bindings', 'string', 'uuid', 'exists:ticket_type,id'],
+            'data.bindings.*.description' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.id.uuid' => 'Идентификатор должен быть UUID',
+            'data.name.required' => 'Не указано название опции',
+            'data.name.max' => 'Название слишком длинное (макс. 255)',
+            'data.festival_id.required' => 'Не указан фестиваль',
+            'data.festival_id.uuid' => 'festival_id должен быть UUID',
+            'data.festival_id.exists' => 'Указанный фестиваль не существует',
+            'data.bindings.*.ticket_type_id.required_with' => 'В привязке не указан тип билета',
+            'data.bindings.*.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
+            'data.bindings.*.ticket_type_id.exists' => 'Указанный тип билета не существует',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/Option/OptionEditRequest.php
+++ b/Backend/app/Http/Requests/Option/OptionEditRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Option;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на редактирование опции.
+ *
+ * `bindings` опциональный — если не передан, привязки не трогаются.
+ * Чтобы очистить все привязки — передать `bindings: []`.
+ */
+class OptionEditRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.name' => ['required', 'string', 'max:255'],
+            'data.active' => ['sometimes', 'boolean'],
+            'data.festival_id' => ['required', 'string', 'uuid', 'exists:festivals,id'],
+
+            'data.bindings' => ['sometimes', 'array'],
+            'data.bindings.*.ticket_type_id' => ['required_with:data.bindings', 'string', 'uuid', 'exists:ticket_type,id'],
+            'data.bindings.*.description' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.name.required' => 'Не указано название опции',
+            'data.name.max' => 'Название слишком длинное (макс. 255)',
+            'data.festival_id.required' => 'Не указан фестиваль',
+            'data.festival_id.uuid' => 'festival_id должен быть UUID',
+            'data.festival_id.exists' => 'Указанный фестиваль не существует',
+            'data.bindings.*.ticket_type_id.required_with' => 'В привязке не указан тип билета',
+            'data.bindings.*.ticket_type_id.uuid' => 'Тип билета должен быть UUID',
+            'data.bindings.*.ticket_type_id.exists' => 'Указанный тип билета не существует',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/Option/OptionGetListRequest.php
+++ b/Backend/app/Http/Requests/Option/OptionGetListRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Option;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Защита публичного getList опций:
+ *  - filter.* — все опциональны (страница админки может листать всё)
+ *  - orderBy.* — только asc/desc
+ */
+class OptionGetListRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'filter' => ['sometimes', 'array'],
+            'filter.name' => ['sometimes', 'nullable', 'string'],
+            'filter.festival_id' => ['sometimes', 'nullable', 'string', 'uuid'],
+            'filter.active' => ['sometimes', 'nullable', 'boolean'],
+            'orderBy' => ['sometimes', 'array'],
+            'orderBy.*' => ['sometimes', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'filter.festival_id.uuid' => 'festival_id должен быть UUID',
+            'orderBy.*.in' => 'Направление сортировки должно быть asc или desc',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/OptionPrice/OptionPriceCreateRequest.php
+++ b/Backend/app/Http/Requests/OptionPrice/OptionPriceCreateRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\OptionPrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на создание волны цены опции.
+ *
+ * Правила:
+ *  - price — целое число (INT в БД), > 0 и < 1 000 000
+ *  - before_date — валидная дата, не в прошлом
+ *  - option_id — существующая опция
+ */
+class OptionPriceCreateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.id' => ['sometimes', 'string', 'uuid'],
+            'data.option_id' => ['required', 'string', 'uuid', 'exists:options,id'],
+            'data.price' => ['required', 'integer', 'gt:0', 'lt:1000000'],
+            'data.before_date' => ['required', 'date', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.id.uuid' => 'Идентификатор должен быть UUID',
+            'data.option_id.required' => 'Не указана опция',
+            'data.option_id.uuid' => 'option_id должен быть UUID',
+            'data.option_id.exists' => 'Указанная опция не существует',
+            'data.price.required' => 'Цена обязательна',
+            'data.price.integer' => 'Цена должна быть целым числом (рубли)',
+            'data.price.gt' => 'Цена должна быть больше 0',
+            'data.price.lt' => 'Цена слишком велика (максимум 999 999)',
+            'data.before_date.required' => 'Дата окончания волны обязательна',
+            'data.before_date.date' => 'Некорректная дата',
+            'data.before_date.after_or_equal' => 'Дата не может быть в прошлом',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/OptionPrice/OptionPriceEditRequest.php
+++ b/Backend/app/Http/Requests/OptionPrice/OptionPriceEditRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\OptionPrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Защита от дурака на редактирование волны цены опции.
+ */
+class OptionPriceEditRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data' => ['required', 'array'],
+            'data.option_id' => ['required', 'string', 'uuid', 'exists:options,id'],
+            'data.price' => ['required', 'integer', 'gt:0', 'lt:1000000'],
+            'data.before_date' => ['required', 'date', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'data.option_id.required' => 'Не указана опция',
+            'data.option_id.uuid' => 'option_id должен быть UUID',
+            'data.option_id.exists' => 'Указанная опция не существует',
+            'data.price.required' => 'Цена обязательна',
+            'data.price.integer' => 'Цена должна быть целым числом (рубли)',
+            'data.price.gt' => 'Цена должна быть больше 0',
+            'data.price.lt' => 'Цена слишком велика (максимум 999 999)',
+            'data.before_date.required' => 'Дата окончания волны обязательна',
+            'data.before_date.date' => 'Некорректная дата',
+            'data.before_date.after_or_equal' => 'Дата не может быть в прошлом',
+        ];
+    }
+}

--- a/Backend/app/Http/Requests/OptionPrice/OptionPriceGetListRequest.php
+++ b/Backend/app/Http/Requests/OptionPrice/OptionPriceGetListRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\OptionPrice;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Защита публичного getList волн цен опций:
+ *  - filter.option_id обязателен (uuid + exists), иначе вернётся весь список.
+ *  - orderBy.* — только asc/desc (предотвращает InvalidArgumentException).
+ */
+class OptionPriceGetListRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'filter' => ['required', 'array'],
+            'filter.option_id' => ['required', 'string', 'uuid', 'exists:options,id'],
+            'orderBy' => ['sometimes', 'array'],
+            'orderBy.*' => ['sometimes', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'filter.required' => 'Не передан фильтр',
+            'filter.option_id.required' => 'Не указана опция',
+            'filter.option_id.uuid' => 'option_id должен быть UUID',
+            'filter.option_id.exists' => 'Указанная опция не существует',
+            'orderBy.*.in' => 'Направление сортировки должно быть asc или desc',
+        ];
+    }
+}

--- a/Backend/app/Models/Option/OptionModel.php
+++ b/Backend/app/Models/Option/OptionModel.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Option;
+
+use App\Models\TicketTypes\TicketTypesModel;
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+use Shared\Infrastructure\Models\HasUuid;
+
+/**
+ * App\Models\Option\OptionModel
+ *
+ * Опция к билету (v2.6.0). См. `.claude/specs/ticket-options.md`.
+ *
+ * Цена опции — в связанной таблице `option_price` (волны цен, по
+ * аналогии с `ticket_type_price`). Описание опции — на pivot
+ * `option_ticket_type.description` (зависит от типа билета).
+ *
+ * @property string $id
+ * @property string $name
+ * @property bool $active
+ * @property string $festival_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @method static Builder|OptionModel newModelQuery()
+ * @method static Builder|OptionModel newQuery()
+ * @method static Builder|OptionModel query()
+ * @method static Builder|OptionModel whereId($value)
+ * @method static Builder|OptionModel whereName($value)
+ * @method static Builder|OptionModel whereFestivalId($value)
+ * @method static Builder|OptionModel whereActive($value)
+ * @mixin Eloquent
+ */
+class OptionModel extends Model
+{
+    use HasFactory, HasUuid;
+
+    public const TABLE = 'options';
+
+    protected $table = self::TABLE;
+
+    protected $fillable = [
+        'id',
+        'name',
+        'active',
+        'festival_id',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
+    ];
+
+    /**
+     * Типы билетов, к которым прикреплена опция.
+     * Pivot хранит description (зависит от типа билета).
+     */
+    public function ticketTypes(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            TicketTypesModel::class,
+            'option_ticket_type',
+            'option_id',
+            'ticket_type_id'
+        )->withPivot('description');
+    }
+
+    /**
+     * Все волны цен опции.
+     */
+    public function prices(): HasMany
+    {
+        return $this->hasMany(OptionPriceModel::class, 'option_id', 'id');
+    }
+}

--- a/Backend/app/Models/Option/OptionPriceModel.php
+++ b/Backend/app/Models/Option/OptionPriceModel.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Option;
+
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Shared\Infrastructure\Models\HasUuid;
+
+/**
+ * App\Models\Option\OptionPriceModel
+ *
+ * Волна цены опции. Структурно копирует `TicketTypesPriceModel`,
+ * но `price` — INT (рубли целиком, без копеек).
+ *
+ * @property string $id
+ * @property string $option_id
+ * @property int $price
+ * @property string $before_date
+ * @property string|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @method static Builder|OptionPriceModel newModelQuery()
+ * @method static Builder|OptionPriceModel newQuery()
+ * @method static Builder|OptionPriceModel query()
+ * @method static Builder|OptionPriceModel whereId($value)
+ * @method static Builder|OptionPriceModel whereOptionId($value)
+ * @method static Builder|OptionPriceModel wherePrice($value)
+ * @method static Builder|OptionPriceModel whereBeforeDate($value)
+ * @mixin Eloquent
+ */
+class OptionPriceModel extends Model
+{
+    use HasFactory, HasUuid, SoftDeletes;
+
+    public const TABLE = 'option_price';
+
+    protected $table = self::TABLE;
+
+    protected $fillable = [
+        'id', 'option_id', 'price', 'before_date',
+    ];
+
+    protected $casts = [
+        'price' => 'integer',
+        'before_date' => 'datetime',
+    ];
+
+    public function option(): BelongsTo
+    {
+        return $this->belongsTo(OptionModel::class, 'option_id', 'id');
+    }
+}

--- a/Backend/app/Providers/RouteServiceProvider.php
+++ b/Backend/app/Providers/RouteServiceProvider.php
@@ -78,6 +78,13 @@ class RouteServiceProvider extends ServiceProvider
                 ->prefix('api')
                 ->group(base_path('routes/location.php'));
 
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/option.php'));
+
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/optionPrice.php'));
 
             Route::middleware('api')
                 ->prefix('api')

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -38,6 +38,10 @@ use Tickets\Auto\Repositories\AutoRepositoryInterface;
 use Tickets\Auto\Repositories\InMemoryMySqlAutoRepository;
 use Tickets\Location\Repositories\InMemoryMySqlLocationRepository;
 use Tickets\Location\Repositories\LocationRepositoryInterface;
+use Tickets\Option\Repositories\InMemoryMySqlOptionRepository;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+use Tickets\OptionPrice\Repositories\InMemoryMySqlOptionPriceRepository;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
 use Tickets\TicketTypePrice\Repositories\InMemoryMySqlTicketTypePriceRepository;
 use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
@@ -70,6 +74,8 @@ class TicketsProvider extends ServiceProvider
         $this->app->bind(HistoryRepositoryInterface::class, InMemoryMySqlHistoryRepository::class);
         $this->app->bind(LocationRepositoryInterface::class, InMemoryMySqlLocationRepository::class);
         $this->app->bind(TicketTypePriceRepositoryInterface::class, InMemoryMySqlTicketTypePriceRepository::class);
+        $this->app->bind(OptionRepositoryInterface::class, InMemoryMySqlOptionRepository::class);
+        $this->app->bind(OptionPriceRepositoryInterface::class, InMemoryMySqlOptionPriceRepository::class);
         $this->app->bind(AutoRepositoryInterface::class, InMemoryMySqlAutoRepository::class);
     }
 }

--- a/Backend/database/migrations/2026_05_31_100000_create_options_table.php
+++ b/Backend/database/migrations/2026_05_31_100000_create_options_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Таблица опций к билетам (v2.6.0).
+ *
+ * Опция — это дополнительное условие, прикрепляемое к билету
+ * со своей стоимостью. Пример: «Саженец» (+500₽) к билету
+ * «Цифровой оргвзнос соорганизатора».
+ *
+ * Цена опции хранится отдельно в таблице `option_price` (волны цен по
+ * аналогии с `ticket_type_price`). Описание опции — на уровне привязки
+ * к конкретному типу билета (pivot `option_ticket_type.description`),
+ * поскольку для разных типов билетов одна и та же опция может иметь
+ * разный смысл.
+ *
+ * Привязка к типам билетов — through `option_ticket_type` (many-to-many).
+ * Снапшот цены/имени на момент покупки — в `order_ticket_options`
+ * (создаётся в `feat/v2.6.0-order-domain-rewrite`).
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('options', static function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+
+            $table->uuid('festival_id');
+            $table->foreign('festival_id')->references('id')->on('festivals');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('options');
+    }
+};

--- a/Backend/database/migrations/2026_05_31_100001_create_option_ticket_type_pivot.php
+++ b/Backend/database/migrations/2026_05_31_100001_create_option_ticket_type_pivot.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Pivot many-to-many между `options` и `ticket_type`.
+ *
+ * Одна опция может быть привязана к нескольким типам билетов
+ * (например, «Саженец» доступен и для «Оргвзноса» и для «Оргвзноса
+ * соорганизатора»), и один тип билета может иметь несколько опций.
+ *
+ * Поле `description` лежит на pivot потому, что описание опции
+ * зависит от типа билета: для «Оргвзноса» это может быть один текст,
+ * а для «Оргвзноса соорганизатора» — другой. Описание на самой опции
+ * было бы общим для всех типов билетов, что бизнесу не подходит.
+ *
+ * См. `.claude/specs/ticket-options.md` §3 (Доменная модель).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('option_ticket_type', static function (Blueprint $table) {
+            $table->uuid('option_id');
+            $table->foreign('option_id')->references('id')->on('options')->cascadeOnDelete();
+
+            $table->uuid('ticket_type_id');
+            $table->foreign('ticket_type_id')->references('id')->on('ticket_type')->cascadeOnDelete();
+
+            $table->text('description')->nullable()->default(null);
+
+            $table->primary(['option_id', 'ticket_type_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('option_ticket_type');
+    }
+};

--- a/Backend/database/migrations/2026_05_31_100002_create_option_price_table.php
+++ b/Backend/database/migrations/2026_05_31_100002_create_option_price_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Волны цен для опций (v2.6.0).
+ *
+ * Структура полностью аналогична `ticket_type_price`. Для каждой опции
+ * можно завести несколько записей с разными `before_date` — актуальной
+ * считается ближайшая, где `before_date >= CURDATE()`.
+ *
+ * Цена опции хранится в INT (рубли целиком, без копеек) — фестиваль
+ * не оперирует копейками. Это намеренно отличается от `ticket_type_price`,
+ * где исторически float — менять там тип чревато.
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('option_price', static function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->uuid('option_id');
+            $table->foreign('option_id')->references('id')->on('options')->cascadeOnDelete();
+
+            $table->integer('price');
+            $table->dateTime('before_date');
+
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('option_price');
+    }
+};

--- a/Backend/database/seeders/DatabaseSeeder.php
+++ b/Backend/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
         private TypeTicketsSecondFestivalSeeder $secondFestivalSeeder,
         private TypeTicketsGroupSeeder $groupSeeder,
         private QuestionnaireTestDataSeeder $questionnaireTestDataSeeder,
+        private OptionTestDataSeeder $optionTestDataSeeder,
     ) {
     }
 
@@ -43,5 +44,6 @@ class DatabaseSeeder extends Seeder
         $this->secondFestivalSeeder->run();
         $this->groupSeeder->run();
         $this->questionnaireTestDataSeeder->run();
+        $this->optionTestDataSeeder->run();
     }
 }

--- a/Backend/database/seeders/OptionTestDataSeeder.php
+++ b/Backend/database/seeders/OptionTestDataSeeder.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Option\OptionModel;
+use App\Models\Option\OptionPriceModel;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
+
+/**
+ * Тестовые опции для билетов (v2.6.0).
+ *
+ * Создаёт 2 опции:
+ *  - «Саженец» (500₽) — привязана к Оргвзносу и Оргвзносу для регионов
+ *  - «Печатный билет» (200₽) — привязана к Оргвзносу
+ *
+ * Используется в Feature-тестах и в локальной/staging среде для проверки
+ * админ-UI без ручного создания через tinker. Идемпотентен: при повторном
+ * запуске использует фиксированные UUID и затирает старые записи через `updateOrCreate`.
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+class OptionTestDataSeeder extends Seeder
+{
+    public const ID_OPTION_SAPLING = 'a1111111-1111-1111-1111-111111111111';
+    public const ID_OPTION_PRINTED_TICKET = 'a2222222-2222-2222-2222-222222222222';
+
+    public const ID_PRICE_SAPLING = 'b1111111-1111-1111-1111-111111111111';
+    public const ID_PRICE_PRINTED_TICKET = 'b2222222-2222-2222-2222-222222222222';
+
+    public const PRICE_SAPLING = 500;
+    public const PRICE_PRINTED_TICKET = 200;
+
+    public function run(): void
+    {
+        $this->seedSapling();
+        $this->seedPrintedTicket();
+    }
+
+    private function seedSapling(): void
+    {
+        /** @var OptionModel $option */
+        $option = OptionModel::updateOrCreate(
+            ['id' => self::ID_OPTION_SAPLING],
+            [
+                'name' => 'Саженец',
+                'active' => true,
+                'festival_id' => FestivalHelper::UUID_FESTIVAL,
+            ]
+        );
+
+        OptionPriceModel::updateOrCreate(
+            ['id' => self::ID_PRICE_SAPLING],
+            [
+                'option_id' => self::ID_OPTION_SAPLING,
+                'price' => self::PRICE_SAPLING,
+                'before_date' => Carbon::now()->addMonths(6),
+            ]
+        );
+
+        $option->ticketTypes()->sync([
+            TypeTicketsSeeder::ID_FOR_FIRST_WAVE => [
+                'description' => 'Один саженец вашего региона в подарок при покупке Оргвзноса',
+            ],
+            TypeTicketsSeeder::ID_FOR_REGIONS => [
+                'description' => 'Саженец местного питомника (для удалённых участников)',
+            ],
+        ]);
+    }
+
+    private function seedPrintedTicket(): void
+    {
+        /** @var OptionModel $option */
+        $option = OptionModel::updateOrCreate(
+            ['id' => self::ID_OPTION_PRINTED_TICKET],
+            [
+                'name' => 'Печатный билет',
+                'active' => true,
+                'festival_id' => FestivalHelper::UUID_FESTIVAL,
+            ]
+        );
+
+        OptionPriceModel::updateOrCreate(
+            ['id' => self::ID_PRICE_PRINTED_TICKET],
+            [
+                'option_id' => self::ID_OPTION_PRINTED_TICKET,
+                'price' => self::PRICE_PRINTED_TICKET,
+                'before_date' => Carbon::now()->addMonths(6),
+            ]
+        );
+
+        $option->ticketTypes()->sync([
+            TypeTicketsSeeder::ID_FOR_FIRST_WAVE => [
+                'description' => 'Бумажная распечатка билета — выдаётся на регистрации',
+            ],
+        ]);
+    }
+}

--- a/Backend/routes/option.php
+++ b/Backend/routes/option.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Option\OptionController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1/option')->group(static function (): void {
+    // Read публично — нужны фронту формы покупки
+    Route::post('/getList', [OptionController::class, 'getList']);
+    Route::get('/getItem/{id}', [OptionController::class, 'getItem']);
+
+    // Read-модель для формы покупки билета: активные опции конкретного типа
+    Route::get(
+        '/getActiveForTicketType/{ticketTypeId}',
+        [OptionController::class, 'getActiveForTicketType']
+    );
+
+    // Write только админ
+    Route::post('/create', [OptionController::class, 'create'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::post('/edit/{id}', [OptionController::class, 'edit'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::delete('/delete/{id}', [OptionController::class, 'delete'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+});

--- a/Backend/routes/optionPrice.php
+++ b/Backend/routes/optionPrice.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\OptionPrice\OptionPriceController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1/optionPrice')->group(static function (): void {
+    Route::post('/getList', [OptionPriceController::class, 'getList']);
+    Route::get('/getItem/{id}', [OptionPriceController::class, 'getItem']);
+
+    Route::post('/create', [OptionPriceController::class, 'create'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::post('/edit/{id}', [OptionPriceController::class, 'edit'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+
+    Route::delete('/delete/{id}', [OptionPriceController::class, 'delete'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+});

--- a/Backend/src/Option/Application/Create/OptionCreateCommand.php
+++ b/Backend/src/Option/Application/Create/OptionCreateCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Create;
+
+use Shared\Domain\Bus\Command\Command;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+class OptionCreateCommand implements Command
+{
+    /**
+     * @param  OptionTicketTypeBindingDto[]  $bindings
+     */
+    public function __construct(
+        private OptionDto $data,
+        private array $bindings = [],
+    ) {
+    }
+
+    public function getData(): OptionDto
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return OptionTicketTypeBindingDto[]
+     */
+    public function getBindings(): array
+    {
+        return $this->bindings;
+    }
+}

--- a/Backend/src/Option/Application/Create/OptionCreateCommandHandler.php
+++ b/Backend/src/Option/Application/Create/OptionCreateCommandHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Create;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+
+class OptionCreateCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionCreateCommand $command): void
+    {
+        $this->repository->create($command->getData());
+
+        if (! empty($command->getBindings())) {
+            $this->repository->syncTicketTypes(
+                $command->getData()->getId(),
+                $command->getBindings()
+            );
+        }
+    }
+}

--- a/Backend/src/Option/Application/Delete/OptionDeleteCommand.php
+++ b/Backend/src/Option/Application/Delete/OptionDeleteCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Delete;
+
+use Shared\Domain\Bus\Command\Command;
+use Shared\Domain\ValueObject\Uuid;
+
+class OptionDeleteCommand implements Command
+{
+    public function __construct(
+        private Uuid $id
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/Option/Application/Delete/OptionDeleteCommandHandler.php
+++ b/Backend/src/Option/Application/Delete/OptionDeleteCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Delete;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+
+class OptionDeleteCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionDeleteCommand $command): void
+    {
+        $this->repository->remove($command->getId());
+    }
+}

--- a/Backend/src/Option/Application/Edit/OptionEditCommand.php
+++ b/Backend/src/Option/Application/Edit/OptionEditCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Edit;
+
+use Shared\Domain\ValueObject\Uuid;
+use Shared\Domain\Bus\Command\Command;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+class OptionEditCommand implements Command
+{
+    /**
+     * @param  OptionTicketTypeBindingDto[]|null  $bindings  null = не трогаем привязки, [] = очистить все
+     */
+    public function __construct(
+        private Uuid $id,
+        private OptionDto $data,
+        private ?array $bindings = null,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getData(): OptionDto
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return OptionTicketTypeBindingDto[]|null
+     */
+    public function getBindings(): ?array
+    {
+        return $this->bindings;
+    }
+}

--- a/Backend/src/Option/Application/Edit/OptionEditCommandHandler.php
+++ b/Backend/src/Option/Application/Edit/OptionEditCommandHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\Edit;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+
+class OptionEditCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionEditCommand $command): void
+    {
+        $this->repository->editItem($command->getId(), $command->getData());
+
+        if ($command->getBindings() !== null) {
+            $this->repository->syncTicketTypes(
+                $command->getId(),
+                $command->getBindings()
+            );
+        }
+    }
+}

--- a/Backend/src/Option/Application/GetItem/OptionGetItemQuery.php
+++ b/Backend/src/Option/Application/GetItem/OptionGetItemQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\GetItem;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\ValueObject\Uuid;
+
+class OptionGetItemQuery implements Query
+{
+    public function __construct(
+        private Uuid $id
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/Option/Application/GetItem/OptionGetItemQueryHandler.php
+++ b/Backend/src/Option/Application/GetItem/OptionGetItemQueryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\GetItem;
+
+use Shared\Domain\Bus\Query\QueryHandler;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+
+class OptionGetItemQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private OptionRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionGetItemQuery $query): OptionDto
+    {
+        return $this->repository->getItem($query->getId());
+    }
+}

--- a/Backend/src/Option/Application/GetList/OptionGetListQuery.php
+++ b/Backend/src/Option/Application/GetList/OptionGetListQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\GetList;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\Criteria\Order;
+
+class OptionGetListQuery implements Query
+{
+    public function __construct(
+        private array $filter,
+        private Order $orderBy,
+    ) {
+    }
+
+    public function getFilter(): array
+    {
+        return $this->filter;
+    }
+
+    public function getOrderBy(): Order
+    {
+        return $this->orderBy;
+    }
+}

--- a/Backend/src/Option/Application/GetList/OptionGetListQueryHandler.php
+++ b/Backend/src/Option/Application/GetList/OptionGetListQueryHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application\GetList;
+
+use App\Models\Option\OptionModel;
+use Shared\Domain\Bus\Query\QueryHandler;
+use Shared\Domain\Criteria\FilterOperator;
+use Shared\Domain\Criteria\Filters;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+use Tickets\Option\Response\OptionGetListResponse;
+
+class OptionGetListQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private OptionRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionGetListQuery $query): OptionGetListResponse
+    {
+        $filter = $query->getFilter();
+        $filters = Filters::fromValues($this->getFilterValues($filter));
+
+        return new OptionGetListResponse(
+            $this->repository->getList($filters, $query->getOrderBy())
+        );
+    }
+
+    private function getFilterValues(array $filter): array
+    {
+        return [
+            [
+                'field' => OptionModel::TABLE . '.name',
+                'operator' => FilterOperator::LIKE,
+                'value' => $filter['name'] ?? null,
+            ],
+            [
+                'field' => OptionModel::TABLE . '.festival_id',
+                'operator' => FilterOperator::EQUAL,
+                'value' => $filter['festival_id'] ?? null,
+            ],
+            [
+                'field' => OptionModel::TABLE . '.active',
+                'operator' => FilterOperator::EQUAL,
+                'value' => $filter['active'] ?? null,
+            ],
+        ];
+    }
+}

--- a/Backend/src/Option/Application/OptionApplication.php
+++ b/Backend/src/Option/Application/OptionApplication.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Application;
+
+use Shared\Domain\Bus\Command\CommandBus;
+use Shared\Domain\Bus\Query\QueryBus;
+use Shared\Domain\ValueObject\Uuid;
+use Shared\Infrastructure\Bus\Command\InMemorySymfonyCommandBus;
+use Shared\Infrastructure\Bus\Query\InMemorySymfonyQueryBus;
+use Tickets\Option\Application\Create\OptionCreateCommand;
+use Tickets\Option\Application\Create\OptionCreateCommandHandler;
+use Tickets\Option\Application\Delete\OptionDeleteCommand;
+use Tickets\Option\Application\Delete\OptionDeleteCommandHandler;
+use Tickets\Option\Application\Edit\OptionEditCommand;
+use Tickets\Option\Application\Edit\OptionEditCommandHandler;
+use Tickets\Option\Application\GetItem\OptionGetItemQuery;
+use Tickets\Option\Application\GetItem\OptionGetItemQueryHandler;
+use Tickets\Option\Application\GetList\OptionGetListQuery;
+use Tickets\Option\Application\GetList\OptionGetListQueryHandler;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionForTicketTypeView;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+use Tickets\Option\Repositories\OptionRepositoryInterface;
+use Tickets\Option\Response\OptionGetListResponse;
+
+/**
+ * Application-фасад модуля Опций к билетам (v2.6.0).
+ *
+ * Тонкая обёртка над CommandBus + QueryBus, агрегирующая 5 базовых
+ * CRUD-операций. Используется из контроллера (`OptionController`).
+ *
+ * Также экспонирует:
+ *  - `getTicketTypeBindings()` — список привязок к типам билетов (для админки);
+ *  - `getActiveOptionsForTicketType()` — read-модель для фронта (форма
+ *    покупки билета), уже с подмешанной актуальной ценой и описанием.
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+class OptionApplication
+{
+    private CommandBus $commandBus;
+
+    private QueryBus $queryBus;
+
+    public function __construct(
+        OptionGetListQueryHandler $optionGetListQueryHandler,
+        OptionGetItemQueryHandler $optionGetItemQueryHandler,
+        OptionCreateCommandHandler $optionCreateCommandHandler,
+        OptionEditCommandHandler $optionEditCommandHandler,
+        OptionDeleteCommandHandler $optionDeleteCommandHandler,
+        private OptionRepositoryInterface $repository,
+    ) {
+        $this->commandBus = new InMemorySymfonyCommandBus([
+            OptionCreateCommand::class => $optionCreateCommandHandler,
+            OptionEditCommand::class => $optionEditCommandHandler,
+            OptionDeleteCommand::class => $optionDeleteCommandHandler,
+        ]);
+
+        $this->queryBus = new InMemorySymfonyQueryBus([
+            OptionGetListQuery::class => $optionGetListQueryHandler,
+            OptionGetItemQuery::class => $optionGetItemQueryHandler,
+        ]);
+    }
+
+    public function getList(OptionGetListQuery $query): OptionGetListResponse
+    {
+        /** @var OptionGetListResponse $result */
+        $result = $this->queryBus->ask($query);
+
+        return $result;
+    }
+
+    public function getItem(Uuid $uuid): OptionDto
+    {
+        /** @var OptionDto $result */
+        $result = $this->queryBus->ask(new OptionGetItemQuery($uuid));
+
+        return $result;
+    }
+
+    /**
+     * @param  OptionTicketTypeBindingDto[]  $bindings
+     *
+     * @throws \Throwable
+     */
+    public function create(OptionDto $data, array $bindings = []): bool
+    {
+        $this->commandBus->dispatch(new OptionCreateCommand($data, $bindings));
+
+        return true;
+    }
+
+    /**
+     * @param  OptionTicketTypeBindingDto[]|null  $bindings  null — не трогаем привязки
+     *
+     * @throws \Throwable
+     */
+    public function edit(Uuid $id, OptionDto $data, ?array $bindings = null): bool
+    {
+        $this->commandBus->dispatch(new OptionEditCommand($id, $data, $bindings));
+
+        return true;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function delete(Uuid $id): bool
+    {
+        $this->commandBus->dispatch(new OptionDeleteCommand($id));
+
+        return true;
+    }
+
+    /**
+     * Получить привязки опции к типам билетов (с описаниями).
+     *
+     * @return OptionTicketTypeBindingDto[]
+     */
+    public function getTicketTypeBindings(Uuid $optionId): array
+    {
+        return $this->repository->getTicketTypeBindings($optionId);
+    }
+
+    /**
+     * Получить активные опции для конкретного типа билета.
+     * Используется фронтом при покупке (форма выбора опций).
+     *
+     * @return OptionForTicketTypeView[]
+     */
+    public function getActiveOptionsForTicketType(Uuid $ticketTypeId): array
+    {
+        return $this->repository->getActiveOptionsForTicketType($ticketTypeId);
+    }
+}

--- a/Backend/src/Option/Dto/OptionDto.php
+++ b/Backend/src/Option/Dto/OptionDto.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Dto;
+
+use Carbon\Carbon;
+use Shared\Domain\Bus\Query\Response;
+use Shared\Domain\Entity\AbstractionEntity;
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * DTO опции к билету.
+ *
+ * Соответствует записи в таблице `options`. Цена опции хранится
+ * отдельно (волны цен в `option_price`), описание — на pivot
+ * (зависит от типа билета).
+ *
+ * Привязка к типам билетов передаётся отдельным аргументом в
+ * `OptionApplication::create/edit` — массив `OptionTicketTypeBindingDto`.
+ *
+ * См. `.claude/specs/ticket-options.md` §3 (Доменная модель).
+ */
+class OptionDto extends AbstractionEntity implements Response
+{
+    public function __construct(
+        protected Uuid $id,
+        protected string $name,
+        protected bool $active,
+        protected Uuid $festival_id,
+        protected ?Carbon $created_at = null,
+        protected ?Carbon $updated_at = null,
+    ) {
+    }
+
+    public static function fromState(array $data): self
+    {
+        return new self(
+            empty($data['id']) ? Uuid::random() : new Uuid($data['id']),
+            $data['name'],
+            (bool) ($data['active'] ?? true),
+            new Uuid($data['festival_id']),
+            empty($data['created_at']) ? null : new Carbon($data['created_at']),
+            empty($data['updated_at']) ? null : new Carbon($data['updated_at']),
+        );
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function getFestivalId(): Uuid
+    {
+        return $this->festival_id;
+    }
+}

--- a/Backend/src/Option/Dto/OptionForTicketTypeView.php
+++ b/Backend/src/Option/Dto/OptionForTicketTypeView.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Dto;
+
+use Shared\Domain\Bus\Query\Response;
+use Shared\Domain\Entity\AbstractionEntity;
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Read-модель опции в контексте конкретного типа билета.
+ *
+ * Используется фронтом (форма покупки билета) — содержит уже
+ * подмешанные `price` (актуальная волна из `option_price`) и
+ * `description` (с pivot для данного типа билета).
+ *
+ * Отделена от `OptionDto`, потому что Query Response должна
+ * содержать всё что нужно фронту в одном объекте, без N+1.
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+final class OptionForTicketTypeView extends AbstractionEntity implements Response
+{
+    public function __construct(
+        protected Uuid $id,
+        protected string $name,
+        protected int $price,
+        protected ?string $description,
+        protected bool $active,
+    ) {
+    }
+
+    public static function fromState(array $data): self
+    {
+        return new self(
+            new Uuid($data['id']),
+            $data['name'],
+            (int) $data['price'],
+            $data['description'] ?? null,
+            (bool) ($data['active'] ?? true),
+        );
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPrice(): int
+    {
+        return $this->price;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getActive(): bool
+    {
+        return $this->active;
+    }
+}

--- a/Backend/src/Option/Dto/OptionTicketTypeBindingDto.php
+++ b/Backend/src/Option/Dto/OptionTicketTypeBindingDto.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Dto;
+
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Привязка опции к типу билета с описанием.
+ *
+ * Используется при создании/редактировании опции, чтобы передать
+ * пару (ticket_type_id, description) — описание зависит от типа
+ * билета и хранится на pivot `option_ticket_type.description`.
+ *
+ * См. `.claude/specs/ticket-options.md` §3.
+ */
+final class OptionTicketTypeBindingDto
+{
+    public function __construct(
+        private Uuid $ticketTypeId,
+        private ?string $description = null,
+    ) {
+    }
+
+    public static function fromState(array $data): self
+    {
+        return new self(
+            new Uuid($data['ticket_type_id']),
+            $data['description'] ?? null,
+        );
+    }
+
+    public function getTicketTypeId(): Uuid
+    {
+        return $this->ticketTypeId;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+}

--- a/Backend/src/Option/Repositories/InMemoryMySqlOptionRepository.php
+++ b/Backend/src/Option/Repositories/InMemoryMySqlOptionRepository.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Repositories;
+
+use App\Models\Option\OptionModel;
+use App\Models\Option\OptionPriceModel;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\Filter\FilterBuilder;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionForTicketTypeView;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+class InMemoryMySqlOptionRepository implements OptionRepositoryInterface
+{
+    public function __construct(
+        private OptionModel $model
+    ) {
+    }
+
+    public function getList(Filters $filters, Order $orderBy): Collection
+    {
+        $build = $this->model::query();
+
+        $result = FilterBuilder::build($build, $filters);
+
+        if ($orderBy->orderBy()->value()) {
+            $result = $result->orderBy(
+                $orderBy->orderBy()->value(),
+                $orderBy->orderType()->value()
+            );
+        }
+
+        return $result->get()
+            ->map(fn (OptionModel $model) => OptionDto::fromState($model->toArray()));
+    }
+
+    public function getItem(Uuid $id): OptionDto
+    {
+        if (! $rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Опция не найдена '.$id->value());
+        }
+
+        return OptionDto::fromState($rawData->toArray());
+    }
+
+    public function create(OptionDto $data): bool
+    {
+        DB::beginTransaction();
+        try {
+            $this->model->insert(
+                array_merge($data->toArrayForCreate(), [
+                    'created_at' => (string) (new Carbon),
+                    'updated_at' => (string) (new Carbon),
+                ])
+            );
+            DB::commit();
+
+            return true;
+        } catch (\Throwable $exception) {
+            DB::rollBack();
+            throw $exception;
+        }
+    }
+
+    public function editItem(Uuid $id, OptionDto $data): bool
+    {
+        if (! $rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Опция не найдена '.$id->value());
+        }
+
+        return $rawData->fill($data->toArrayForEdit())->save();
+    }
+
+    public function remove(Uuid $id): bool
+    {
+        return (bool) $this->model::whereId($id->value())->delete();
+    }
+
+    public function syncTicketTypes(Uuid $optionId, array $bindings): void
+    {
+        /** @var OptionModel|null $option */
+        $option = $this->model::whereId($optionId->value())->first();
+
+        if (! $option) {
+            throw new \DomainException('Опция не найдена '.$optionId->value());
+        }
+
+        $syncPayload = [];
+        foreach ($bindings as $binding) {
+            $syncPayload[$binding->getTicketTypeId()->value()] = [
+                'description' => $binding->getDescription(),
+            ];
+        }
+
+        $option->ticketTypes()->sync($syncPayload);
+    }
+
+    public function getTicketTypeBindings(Uuid $optionId): array
+    {
+        /** @var OptionModel|null $option */
+        $option = $this->model::whereId($optionId->value())->first();
+
+        if (! $option) {
+            throw new \DomainException('Опция не найдена '.$optionId->value());
+        }
+
+        return $option->ticketTypes()
+            ->get()
+            ->map(static fn ($ticketType) => new OptionTicketTypeBindingDto(
+                new Uuid($ticketType->id),
+                $ticketType->pivot->description ?? null,
+            ))
+            ->all();
+    }
+
+    public function getActiveOptionsForTicketType(Uuid $ticketTypeId): array
+    {
+        $rows = $this->model::query()
+            ->select([
+                'options.id',
+                'options.name',
+                'options.active',
+                'option_ticket_type.description',
+            ])
+            ->selectSub(
+                OptionPriceModel::query()
+                    ->select('price')
+                    ->whereColumn('option_id', 'options.id')
+                    ->whereDate('before_date', '>=', Carbon::now()->toDateString())
+                    ->whereNull('deleted_at')
+                    ->orderBy('before_date', 'asc')
+                    ->limit(1),
+                'price'
+            )
+            ->join('option_ticket_type', 'option_ticket_type.option_id', '=', 'options.id')
+            ->where('options.active', true)
+            ->where('option_ticket_type.ticket_type_id', $ticketTypeId->value())
+            ->get();
+
+        return $rows
+            ->filter(static fn ($row) => $row->price !== null)
+            ->map(static fn ($row) => OptionForTicketTypeView::fromState([
+                'id' => $row->id,
+                'name' => $row->name,
+                'price' => (int) $row->price,
+                'description' => $row->description,
+                'active' => (bool) $row->active,
+            ]))
+            ->values()
+            ->all();
+    }
+}

--- a/Backend/src/Option/Repositories/OptionRepositoryInterface.php
+++ b/Backend/src/Option/Repositories/OptionRepositoryInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Repositories;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\Option\Dto\OptionDto;
+use Tickets\Option\Dto\OptionForTicketTypeView;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+interface OptionRepositoryInterface
+{
+    public function getList(Filters $filters, Order $orderBy): Collection;
+
+    public function getItem(Uuid $id): OptionDto;
+
+    public function create(OptionDto $data): bool;
+
+    public function editItem(Uuid $id, OptionDto $data): bool;
+
+    public function remove(Uuid $id): bool;
+
+    /**
+     * Привязать опцию к списку типов билетов (many-to-many) с описанием на каждой связке.
+     * Полная синхронизация: старые привязки удаляются, остаются только из массива.
+     *
+     * @param  OptionTicketTypeBindingDto[]  $bindings
+     */
+    public function syncTicketTypes(Uuid $optionId, array $bindings): void;
+
+    /**
+     * Получить привязки опции к типам билетов (вместе с описаниями).
+     *
+     * @return OptionTicketTypeBindingDto[]
+     */
+    public function getTicketTypeBindings(Uuid $optionId): array;
+
+    /**
+     * Получить активные опции для конкретного типа билета с актуальной ценой
+     * и описанием специфичным для этого типа билета (read-модель для фронта).
+     *
+     * @return OptionForTicketTypeView[]
+     */
+    public function getActiveOptionsForTicketType(Uuid $ticketTypeId): array;
+}

--- a/Backend/src/Option/Response/OptionGetListResponse.php
+++ b/Backend/src/Option/Response/OptionGetListResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Option\Response;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Bus\Query\Response;
+
+class OptionGetListResponse implements Response
+{
+    public function __construct(
+        private Collection $collection
+    ) {
+    }
+
+    public function getCollection(): Collection
+    {
+        return $this->collection;
+    }
+}

--- a/Backend/src/OptionPrice/Application/Create/OptionPriceCreateCommand.php
+++ b/Backend/src/OptionPrice/Application/Create/OptionPriceCreateCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Create;
+
+use Shared\Domain\Bus\Command\Command;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+class OptionPriceCreateCommand implements Command
+{
+    public function __construct(
+        private OptionPriceDto $data,
+    ) {
+    }
+
+    public function getData(): OptionPriceDto
+    {
+        return $this->data;
+    }
+}

--- a/Backend/src/OptionPrice/Application/Create/OptionPriceCreateCommandHandler.php
+++ b/Backend/src/OptionPrice/Application/Create/OptionPriceCreateCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Create;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
+
+class OptionPriceCreateCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionPriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionPriceCreateCommand $command): void
+    {
+        $this->repository->create($command->getData());
+    }
+}

--- a/Backend/src/OptionPrice/Application/Delete/OptionPriceDeleteCommand.php
+++ b/Backend/src/OptionPrice/Application/Delete/OptionPriceDeleteCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Delete;
+
+use Shared\Domain\Bus\Command\Command;
+use Shared\Domain\ValueObject\Uuid;
+
+class OptionPriceDeleteCommand implements Command
+{
+    public function __construct(
+        private Uuid $id,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/OptionPrice/Application/Delete/OptionPriceDeleteCommandHandler.php
+++ b/Backend/src/OptionPrice/Application/Delete/OptionPriceDeleteCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Delete;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
+
+class OptionPriceDeleteCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionPriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionPriceDeleteCommand $command): void
+    {
+        $this->repository->remove($command->getId());
+    }
+}

--- a/Backend/src/OptionPrice/Application/Edit/OptionPriceEditCommand.php
+++ b/Backend/src/OptionPrice/Application/Edit/OptionPriceEditCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Edit;
+
+use Shared\Domain\Bus\Command\Command;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+class OptionPriceEditCommand implements Command
+{
+    public function __construct(
+        private Uuid $id,
+        private OptionPriceDto $data,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getData(): OptionPriceDto
+    {
+        return $this->data;
+    }
+}

--- a/Backend/src/OptionPrice/Application/Edit/OptionPriceEditCommandHandler.php
+++ b/Backend/src/OptionPrice/Application/Edit/OptionPriceEditCommandHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\Edit;
+
+use Shared\Domain\Bus\Command\CommandHandler;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
+
+class OptionPriceEditCommandHandler implements CommandHandler
+{
+    public function __construct(
+        private OptionPriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionPriceEditCommand $command): void
+    {
+        $this->repository->editItem($command->getId(), $command->getData());
+    }
+}

--- a/Backend/src/OptionPrice/Application/GetItem/OptionPriceGetItemQuery.php
+++ b/Backend/src/OptionPrice/Application/GetItem/OptionPriceGetItemQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\GetItem;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\ValueObject\Uuid;
+
+class OptionPriceGetItemQuery implements Query
+{
+    public function __construct(
+        private Uuid $id,
+    ) {
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+}

--- a/Backend/src/OptionPrice/Application/GetItem/OptionPriceGetItemQueryHandler.php
+++ b/Backend/src/OptionPrice/Application/GetItem/OptionPriceGetItemQueryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\GetItem;
+
+use Shared\Domain\Bus\Query\QueryHandler;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
+
+class OptionPriceGetItemQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private OptionPriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionPriceGetItemQuery $query): OptionPriceDto
+    {
+        return $this->repository->getItem($query->getId());
+    }
+}

--- a/Backend/src/OptionPrice/Application/GetList/OptionPriceGetListQuery.php
+++ b/Backend/src/OptionPrice/Application/GetList/OptionPriceGetListQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\GetList;
+
+use Shared\Domain\Bus\Query\Query;
+use Shared\Domain\Criteria\Order;
+
+class OptionPriceGetListQuery implements Query
+{
+    public function __construct(
+        private array $filter,
+        private Order $orderBy,
+    ) {
+    }
+
+    public function getFilter(): array
+    {
+        return $this->filter;
+    }
+
+    public function getOrderBy(): Order
+    {
+        return $this->orderBy;
+    }
+}

--- a/Backend/src/OptionPrice/Application/GetList/OptionPriceGetListQueryHandler.php
+++ b/Backend/src/OptionPrice/Application/GetList/OptionPriceGetListQueryHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application\GetList;
+
+use App\Models\Option\OptionPriceModel;
+use Shared\Domain\Bus\Query\QueryHandler;
+use Shared\Domain\Criteria\FilterOperator;
+use Shared\Domain\Criteria\Filters;
+use Tickets\OptionPrice\Repositories\OptionPriceRepositoryInterface;
+use Tickets\OptionPrice\Response\OptionPriceGetListResponse;
+
+class OptionPriceGetListQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private OptionPriceRepositoryInterface $repository
+    ) {
+    }
+
+    public function __invoke(OptionPriceGetListQuery $query): OptionPriceGetListResponse
+    {
+        $filter = $query->getFilter();
+        $filters = Filters::fromValues($this->getFilterValues($filter));
+
+        return new OptionPriceGetListResponse(
+            $this->repository->getList($filters, $query->getOrderBy())
+        );
+    }
+
+    private function getFilterValues(array $filter): array
+    {
+        return [
+            [
+                'field' => OptionPriceModel::TABLE.'.option_id',
+                'operator' => FilterOperator::EQUAL,
+                'value' => $filter['option_id'] ?? null,
+            ],
+        ];
+    }
+}

--- a/Backend/src/OptionPrice/Application/OptionPriceApplication.php
+++ b/Backend/src/OptionPrice/Application/OptionPriceApplication.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Application;
+
+use Shared\Domain\Bus\Command\CommandBus;
+use Shared\Domain\Bus\Query\QueryBus;
+use Shared\Domain\ValueObject\Uuid;
+use Shared\Infrastructure\Bus\Command\InMemorySymfonyCommandBus;
+use Shared\Infrastructure\Bus\Query\InMemorySymfonyQueryBus;
+use Tickets\OptionPrice\Application\Create\OptionPriceCreateCommand;
+use Tickets\OptionPrice\Application\Create\OptionPriceCreateCommandHandler;
+use Tickets\OptionPrice\Application\Delete\OptionPriceDeleteCommand;
+use Tickets\OptionPrice\Application\Delete\OptionPriceDeleteCommandHandler;
+use Tickets\OptionPrice\Application\Edit\OptionPriceEditCommand;
+use Tickets\OptionPrice\Application\Edit\OptionPriceEditCommandHandler;
+use Tickets\OptionPrice\Application\GetItem\OptionPriceGetItemQuery;
+use Tickets\OptionPrice\Application\GetItem\OptionPriceGetItemQueryHandler;
+use Tickets\OptionPrice\Application\GetList\OptionPriceGetListQuery;
+use Tickets\OptionPrice\Application\GetList\OptionPriceGetListQueryHandler;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+use Tickets\OptionPrice\Response\OptionPriceGetListResponse;
+
+/**
+ * Application-фасад модуля волн цен опций (v2.6.0).
+ *
+ * Полный аналог `TicketTypePriceApplication`. Управляет таблицей
+ * `option_price` (волны цен по аналогии с `ticket_type_price`).
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+class OptionPriceApplication
+{
+    private CommandBus $commandBus;
+
+    private QueryBus $queryBus;
+
+    public function __construct(
+        OptionPriceGetListQueryHandler $getListQueryHandler,
+        OptionPriceGetItemQueryHandler $getItemQueryHandler,
+        OptionPriceCreateCommandHandler $createCommandHandler,
+        OptionPriceEditCommandHandler $editCommandHandler,
+        OptionPriceDeleteCommandHandler $deleteCommandHandler,
+    ) {
+        $this->commandBus = new InMemorySymfonyCommandBus([
+            OptionPriceCreateCommand::class => $createCommandHandler,
+            OptionPriceEditCommand::class => $editCommandHandler,
+            OptionPriceDeleteCommand::class => $deleteCommandHandler,
+        ]);
+
+        $this->queryBus = new InMemorySymfonyQueryBus([
+            OptionPriceGetListQuery::class => $getListQueryHandler,
+            OptionPriceGetItemQuery::class => $getItemQueryHandler,
+        ]);
+    }
+
+    public function getList(OptionPriceGetListQuery $query): OptionPriceGetListResponse
+    {
+        /** @var OptionPriceGetListResponse $result */
+        $result = $this->queryBus->ask($query);
+
+        return $result;
+    }
+
+    public function getItem(Uuid $uuid): OptionPriceDto
+    {
+        /** @var OptionPriceDto $result */
+        $result = $this->queryBus->ask(new OptionPriceGetItemQuery($uuid));
+
+        return $result;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function create(OptionPriceDto $data): bool
+    {
+        $this->commandBus->dispatch(new OptionPriceCreateCommand($data));
+
+        return true;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function edit(Uuid $id, OptionPriceDto $data): bool
+    {
+        $this->commandBus->dispatch(new OptionPriceEditCommand($id, $data));
+
+        return true;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function delete(Uuid $id): bool
+    {
+        $this->commandBus->dispatch(new OptionPriceDeleteCommand($id));
+
+        return true;
+    }
+}

--- a/Backend/src/OptionPrice/Dto/OptionPriceDto.php
+++ b/Backend/src/OptionPrice/Dto/OptionPriceDto.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Dto;
+
+use Carbon\Carbon;
+use Shared\Domain\Bus\Query\Response;
+use Shared\Domain\Entity\AbstractionEntity;
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Волна цены опции к билету (v2.6.0).
+ *
+ * Полный аналог `TicketTypePriceDto`, но цена хранится в INT (рубли
+ * целиком, без копеек) — фестиваль не оперирует копейками.
+ *
+ * См. `.claude/specs/ticket-options.md`.
+ */
+class OptionPriceDto extends AbstractionEntity implements Response
+{
+    public function __construct(
+        protected Uuid $id,
+        protected Uuid $option_id,
+        protected int $price,
+        protected Carbon $before_date,
+        protected ?Carbon $created_at = null,
+        protected ?Carbon $updated_at = null,
+    ) {
+    }
+
+    public static function fromState(array $data): self
+    {
+        return new self(
+            empty($data['id']) ? Uuid::random() : new Uuid($data['id']),
+            new Uuid($data['option_id']),
+            (int) $data['price'],
+            new Carbon($data['before_date']),
+            empty($data['created_at']) ? null : new Carbon($data['created_at']),
+            empty($data['updated_at']) ? null : new Carbon($data['updated_at']),
+        );
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getOptionId(): Uuid
+    {
+        return $this->option_id;
+    }
+
+    public function getPrice(): int
+    {
+        return $this->price;
+    }
+
+    public function getBeforeDate(): Carbon
+    {
+        return $this->before_date;
+    }
+}

--- a/Backend/src/OptionPrice/Repositories/InMemoryMySqlOptionPriceRepository.php
+++ b/Backend/src/OptionPrice/Repositories/InMemoryMySqlOptionPriceRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Repositories;
+
+use App\Models\Option\OptionPriceModel;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\Filter\FilterBuilder;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+class InMemoryMySqlOptionPriceRepository implements OptionPriceRepositoryInterface
+{
+    public function __construct(
+        private OptionPriceModel $model
+    ) {
+    }
+
+    public function getList(Filters $filters, Order $orderBy): Collection
+    {
+        $build = $this->model::query();
+
+        $result = FilterBuilder::build($build, $filters);
+
+        if ($orderBy->orderBy()->value()) {
+            $result = $result->orderBy(
+                $orderBy->orderBy()->value(),
+                $orderBy->orderType()->value()
+            );
+        } else {
+            $result = $result->orderBy('before_date', 'asc');
+        }
+
+        return $result->get()
+            ->map(fn (OptionPriceModel $model) => OptionPriceDto::fromState($model->toArray()));
+    }
+
+    public function getItem(Uuid $id): OptionPriceDto
+    {
+        if (! $rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Волна цены опции не найдена '.$id->value());
+        }
+
+        return OptionPriceDto::fromState($rawData->toArray());
+    }
+
+    public function create(OptionPriceDto $data): bool
+    {
+        DB::beginTransaction();
+        try {
+            $this->model->insert(
+                array_merge($data->toArrayForCreate(), [
+                    'created_at' => (string) (new Carbon),
+                    'updated_at' => (string) (new Carbon),
+                ])
+            );
+            DB::commit();
+
+            return true;
+        } catch (\Throwable $exception) {
+            DB::rollBack();
+            throw $exception;
+        }
+    }
+
+    public function editItem(Uuid $id, OptionPriceDto $data): bool
+    {
+        if (! $rawData = $this->model::whereId($id->value())->first()) {
+            throw new \DomainException('Волна цены опции не найдена '.$id->value());
+        }
+
+        return $rawData->fill($data->toArrayForEdit())->save();
+    }
+
+    public function remove(Uuid $id): bool
+    {
+        return (bool) $this->model::whereId($id->value())->delete();
+    }
+}

--- a/Backend/src/OptionPrice/Repositories/OptionPriceRepositoryInterface.php
+++ b/Backend/src/OptionPrice/Repositories/OptionPriceRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Repositories;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Criteria\Filters;
+use Shared\Domain\Criteria\Order;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+interface OptionPriceRepositoryInterface
+{
+    public function getList(Filters $filters, Order $orderBy): Collection;
+
+    public function getItem(Uuid $id): OptionPriceDto;
+
+    public function create(OptionPriceDto $data): bool;
+
+    public function editItem(Uuid $id, OptionPriceDto $data): bool;
+
+    public function remove(Uuid $id): bool;
+}

--- a/Backend/src/OptionPrice/Response/OptionPriceGetListResponse.php
+++ b/Backend/src/OptionPrice/Response/OptionPriceGetListResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\OptionPrice\Response;
+
+use Illuminate\Support\Collection;
+use Shared\Domain\Bus\Query\Response;
+
+class OptionPriceGetListResponse implements Response
+{
+    public function __construct(
+        private Collection $collection
+    ) {
+    }
+
+    public function getCollection(): Collection
+    {
+        return $this->collection;
+    }
+}

--- a/Backend/tests/Unit/Option/Dto/OptionDtoTest.php
+++ b/Backend/tests/Unit/Option/Dto/OptionDtoTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Option\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Tickets\Option\Dto\OptionDto;
+
+/**
+ * Unit-тест для `OptionDto::fromState()`.
+ *
+ * Проверяет что DTO правильно собирается из ассоциативного массива
+ * (как из БД, так и из request->data), а getter'ы возвращают
+ * корректные типы.
+ */
+class OptionDtoTest extends TestCase
+{
+    /** @test */
+    public function it_builds_dto_from_full_state(): void
+    {
+        $dto = OptionDto::fromState([
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'name' => 'Саженец',
+            'active' => true,
+            'festival_id' => '22222222-2222-2222-2222-222222222222',
+            'created_at' => '2026-06-01 10:00:00',
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+
+        $this->assertSame('11111111-1111-1111-1111-111111111111', $dto->getId()->value());
+        $this->assertSame('Саженец', $dto->getName());
+        $this->assertTrue($dto->getActive());
+        $this->assertSame('22222222-2222-2222-2222-222222222222', $dto->getFestivalId()->value());
+    }
+
+    /** @test */
+    public function it_generates_random_uuid_when_id_is_empty(): void
+    {
+        $dto = OptionDto::fromState([
+            'name' => 'Без ID',
+            'festival_id' => '22222222-2222-2222-2222-222222222222',
+        ]);
+
+        // Проверяем что сгенерирован валидный UUID v4
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $dto->getId()->value()
+        );
+    }
+
+    /** @test */
+    public function it_defaults_active_to_true_when_not_provided(): void
+    {
+        $dto = OptionDto::fromState([
+            'name' => 'По умолчанию активна',
+            'festival_id' => '22222222-2222-2222-2222-222222222222',
+        ]);
+
+        $this->assertTrue($dto->getActive(), 'Опция должна быть активна по умолчанию');
+    }
+
+    /** @test */
+    public function it_respects_explicit_active_false(): void
+    {
+        $dto = OptionDto::fromState([
+            'name' => 'Отключена',
+            'active' => false,
+            'festival_id' => '22222222-2222-2222-2222-222222222222',
+        ]);
+
+        $this->assertFalse($dto->getActive());
+    }
+}

--- a/Backend/tests/Unit/Option/Dto/OptionForTicketTypeViewTest.php
+++ b/Backend/tests/Unit/Option/Dto/OptionForTicketTypeViewTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Option\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Tickets\Option\Dto\OptionForTicketTypeView;
+
+/**
+ * Unit-тест для `OptionForTicketTypeView::fromState()`.
+ *
+ * Read-модель для фронта формы покупки: уже с подмешанной ценой
+ * (из option_price) и описанием (с pivot).
+ */
+class OptionForTicketTypeViewTest extends TestCase
+{
+    /** @test */
+    public function it_builds_view_with_price_and_description(): void
+    {
+        $view = OptionForTicketTypeView::fromState([
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'name' => 'Саженец',
+            'price' => 500,
+            'description' => 'Дадим саженец после фестиваля',
+            'active' => true,
+        ]);
+
+        $this->assertSame('11111111-1111-1111-1111-111111111111', $view->getId()->value());
+        $this->assertSame('Саженец', $view->getName());
+        $this->assertSame(500, $view->getPrice());
+        $this->assertIsInt($view->getPrice());
+        $this->assertSame('Дадим саженец после фестиваля', $view->getDescription());
+        $this->assertTrue($view->getActive());
+    }
+
+    /** @test */
+    public function it_handles_null_description(): void
+    {
+        $view = OptionForTicketTypeView::fromState([
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'name' => 'Без описания',
+            'price' => 1000,
+            'description' => null,
+            'active' => true,
+        ]);
+
+        $this->assertNull($view->getDescription());
+    }
+}

--- a/Backend/tests/Unit/Option/Dto/OptionTicketTypeBindingDtoTest.php
+++ b/Backend/tests/Unit/Option/Dto/OptionTicketTypeBindingDtoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Option\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Tickets\Option\Dto\OptionTicketTypeBindingDto;
+
+/**
+ * Unit-тест для `OptionTicketTypeBindingDto::fromState()`.
+ *
+ * Привязка опции к типу билета с описанием специфичным для этого
+ * типа билета (хранится на pivot `option_ticket_type.description`).
+ */
+class OptionTicketTypeBindingDtoTest extends TestCase
+{
+    /** @test */
+    public function it_builds_binding_with_description(): void
+    {
+        $binding = OptionTicketTypeBindingDto::fromState([
+            'ticket_type_id' => '11111111-1111-1111-1111-111111111111',
+            'description' => 'Для соорганизатора саженец идёт в подарок',
+        ]);
+
+        $this->assertSame(
+            '11111111-1111-1111-1111-111111111111',
+            $binding->getTicketTypeId()->value()
+        );
+        $this->assertSame(
+            'Для соорганизатора саженец идёт в подарок',
+            $binding->getDescription()
+        );
+    }
+
+    /** @test */
+    public function it_allows_null_description(): void
+    {
+        $binding = OptionTicketTypeBindingDto::fromState([
+            'ticket_type_id' => '11111111-1111-1111-1111-111111111111',
+        ]);
+
+        $this->assertNull($binding->getDescription());
+    }
+}

--- a/Backend/tests/Unit/OptionPrice/Dto/OptionPriceDtoTest.php
+++ b/Backend/tests/Unit/OptionPrice/Dto/OptionPriceDtoTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\OptionPrice\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Tickets\OptionPrice\Dto\OptionPriceDto;
+
+/**
+ * Unit-тест для `OptionPriceDto::fromState()`.
+ *
+ * Особое внимание: цена хранится в INT (рубли целиком).
+ * Проверяем что входящая строка/число корректно кастится в int.
+ */
+class OptionPriceDtoTest extends TestCase
+{
+    /** @test */
+    public function it_builds_dto_with_integer_price(): void
+    {
+        $dto = OptionPriceDto::fromState([
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'option_id' => '22222222-2222-2222-2222-222222222222',
+            'price' => 500,
+            'before_date' => '2026-09-01 00:00:00',
+        ]);
+
+        $this->assertSame(500, $dto->getPrice());
+        $this->assertIsInt($dto->getPrice(), 'Цена должна быть int (рубли, без копеек)');
+    }
+
+    /** @test */
+    public function it_casts_string_price_to_integer(): void
+    {
+        // Из БД может прийти строкой — должно скастить
+        $dto = OptionPriceDto::fromState([
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'option_id' => '22222222-2222-2222-2222-222222222222',
+            'price' => '750',
+            'before_date' => '2026-09-01',
+        ]);
+
+        $this->assertSame(750, $dto->getPrice());
+    }
+
+    /** @test */
+    public function it_truncates_decimal_to_integer(): void
+    {
+        // Если кто-то по ошибке передаст float — обрежется до int
+        $dto = OptionPriceDto::fromState([
+            'option_id' => '22222222-2222-2222-2222-222222222222',
+            'price' => 500.99,
+            'before_date' => '2026-09-01',
+        ]);
+
+        $this->assertSame(500, $dto->getPrice());
+    }
+
+    /** @test */
+    public function it_parses_before_date_as_carbon(): void
+    {
+        $dto = OptionPriceDto::fromState([
+            'option_id' => '22222222-2222-2222-2222-222222222222',
+            'price' => 500,
+            'before_date' => '2026-09-01 00:00:00',
+        ]);
+
+        $this->assertSame('2026-09-01', $dto->getBeforeDate()->toDateString());
+    }
+}

--- a/FrontEnd/src/components/Option/OptionFilter.vue
+++ b/FrontEnd/src/components/Option/OptionFilter.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="title-block text-center">
+    <h1 class="card-title"> Фильтр опций </h1>
+  </div>
+  <div class="row">
+    <div class="col-lg-12 mx-auto">
+      <div class="card">
+        <div class="card-body">
+          <div class="row">
+            <div class="col-md-4">
+              <div class="form-group">
+                <label>Название</label>
+                <input type="text" class="form-control" v-model="filter.name" placeholder="Часть названия опции">
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="form-group">
+                <label>Фестиваль</label>
+                <select class="form-control" v-model="filter.festival_id">
+                  <option value="">Все</option>
+                  <option v-for="f in getFestivalList" :key="f.id" :value="f.id">
+                    {{ f.name }} {{ f.year }}
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div class="col-md-2">
+              <div class="form-group">
+                <label>Активность</label>
+                <select class="form-control" v-model="filter.active">
+                  <option value="">Все</option>
+                  <option value="1">Активные</option>
+                  <option value="0">Неактивные</option>
+                </select>
+              </div>
+            </div>
+            <div class="col-md-2 d-flex align-items-end">
+              <button class="btn btn-primary me-2" @click="applyFilter">Применить</button>
+              <button class="btn btn-secondary" @click="resetFilter">Сбросить</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+  name: 'OptionFilter',
+  data() {
+    return {
+      filter: {
+        name: '',
+        festival_id: '',
+        active: '',
+      },
+    };
+  },
+  computed: {
+    ...mapGetters('appOption', ['getFilter', 'getOrderBy']),
+    ...mapGetters('appFestivalTickets', ['getFestivalList']),
+  },
+  methods: {
+    ...mapActions('appOption', ['loadList', 'setFilter']),
+    ...mapActions('appFestivalTickets', ['getListFestival']),
+    applyFilter() {
+      this.setFilter(this.filter);
+      this.loadList({ filter: this.filter, orderBy: this.getOrderBy });
+    },
+    resetFilter() {
+      this.filter = { name: '', festival_id: '', active: '' };
+      this.setFilter(this.filter);
+      this.loadList({ filter: this.filter, orderBy: this.getOrderBy });
+    },
+  },
+  created() {
+    this.filter = { ...{ name: '', festival_id: '', active: '' }, ...this.getFilter };
+    this.getListFestival();
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/components/Option/OptionItem.vue
+++ b/FrontEnd/src/components/Option/OptionItem.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="container-fluid">
+    <div class="title-block text-center">
+      <h1 class="card-title"> {{ isEdit ? 'Редактирование опции' : 'Создание опции' }} </h1>
+    </div>
+    <div class="row">
+      <div class="col-lg-12 mx-auto">
+
+        <div class="card">
+          <div class="card-body">
+            <div class="row mb-3">
+              <label class="col-4 col-form-label">Название опции:</label>
+              <div class="col-8">
+                <input type="text" class="form-control" v-model="name" placeholder="Например: Саженец">
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <label class="col-4 col-form-label">Фестиваль:</label>
+              <div class="col-8">
+                <select class="form-control" v-model="festivalId">
+                  <option value="" disabled>— выберите фестиваль —</option>
+                  <option v-for="f in getFestivalList" :key="f.id" :value="f.id">
+                    {{ f.name }} {{ f.year }}
+                  </option>
+                </select>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <label class="col-4 col-form-label">Активность:</label>
+              <div class="col-8">
+                <select class="form-select" v-model="active">
+                  <option :value="true">Активна (видна гостям)</option>
+                  <option :value="false">Скрыта</option>
+                </select>
+                <small class="form-text text-muted">
+                  Скрытая опция не появится в форме покупки, но уже оплаченные заказы её сохранят.
+                </small>
+              </div>
+            </div>
+
+            <hr class="my-4">
+
+            <h5>Привязка к типам билетов</h5>
+            <p class="text-muted small">
+              Отметьте типы билетов, к которым эта опция применима. Для каждой связки задайте
+              своё <strong>описание</strong> — гость увидит его в форме покупки.
+            </p>
+
+            <div class="card mb-3" v-for="tt in availableTicketTypes" :key="tt.id">
+              <div class="card-body py-2">
+                <div class="form-check">
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    :id="'tt_' + tt.id"
+                    :checked="isBound(tt.id)"
+                    @change="toggleBinding(tt.id, $event.target.checked)"
+                  >
+                  <label class="form-check-label fw-bold" :for="'tt_' + tt.id">
+                    {{ tt.name }}
+                  </label>
+                </div>
+                <div v-if="isBound(tt.id)" class="mt-2">
+                  <label class="form-label small">Описание для этого типа билета:</label>
+                  <textarea
+                    class="form-control form-control-sm"
+                    rows="2"
+                    :value="getDescription(tt.id)"
+                    @input="setDescription(tt.id, $event.target.value)"
+                    placeholder="Например: Один саженец местного питомника в подарок"
+                  ></textarea>
+                </div>
+              </div>
+            </div>
+            <div v-if="!availableTicketTypes.length" class="alert alert-warning">
+              Нет типов билетов для выбранного фестиваля. Сначала создайте типы билетов.
+            </div>
+
+            <hr class="my-4">
+            <div class="row messager">{{ getMessage }}</div>
+            <div class="row b-row mt-2">
+              <button type="submit" @click="save" class="btn btn-primary" :disabled="!canSave">Сохранить</button>
+              <button type="button" @click="back" class="btn btn-secondary ms-2">Отмена/назад</button>
+            </div>
+          </div>
+        </div>
+
+        <OptionPriceList v-if="isEdit" :option-id="id" />
+        <div v-else class="alert alert-info mt-3">
+          Волны цен доступны после сохранения опции.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+import OptionPriceList from '@/components/Option/OptionPriceList.vue';
+
+export default {
+  name: 'OptionItem',
+  components: { OptionPriceList },
+  props: {
+    id: { type: String, default: null },
+  },
+  data() {
+    return {
+      newName: null,
+      newFestivalId: null,
+      newActive: null,
+      bindings: {},
+    };
+  },
+  computed: {
+    ...mapGetters('appOption', ['getItem', 'getMessage']),
+    ...mapGetters('appFestivalTickets', ['getFestivalList']),
+    ...mapGetters('appTicketType', { getTicketTypeList: 'getList' }),
+    isEdit() {
+      return this.id !== null && this.id !== undefined && this.id !== '';
+    },
+    canSave() {
+      return !!this.name && !!this.festivalId;
+    },
+    availableTicketTypes() {
+      const list = this.getTicketTypeList || [];
+      if (!this.festivalId) return list;
+      return list.filter((t) => !t.festivalList || t.festivalList.some((f) => f.id === this.festivalId));
+    },
+    name: {
+      get() { return this.newName ?? this.getItem.name ?? ''; },
+      set(v) { this.newName = v; },
+    },
+    festivalId: {
+      get() { return this.newFestivalId ?? this.getItem.festival_id ?? ''; },
+      set(v) { this.newFestivalId = v; },
+    },
+    active: {
+      get() {
+        if (this.newActive !== null) return this.newActive;
+        if (this.getItem.active === undefined) return true;
+        return !!this.getItem.active;
+      },
+      set(v) { this.newActive = v; },
+    },
+  },
+  watch: {
+    'getItem.id'() {
+      this.rebuildBindings();
+    },
+  },
+  methods: {
+    ...mapActions('appOption', ['create', 'edit']),
+    ...mapActions('appFestivalTickets', ['getListFestival']),
+    ...mapActions('appTicketType', { loadTicketTypes: 'loadList' }),
+    rebuildBindings() {
+      const dict = {};
+      const fromServer = this.getItem.bindings || [];
+      fromServer.forEach((b) => {
+        dict[b.ticket_type_id] = b.description ?? '';
+      });
+      this.bindings = dict;
+    },
+    isBound(ticketTypeId) {
+      return Object.prototype.hasOwnProperty.call(this.bindings, ticketTypeId);
+    },
+    getDescription(ticketTypeId) {
+      return this.bindings[ticketTypeId] ?? '';
+    },
+    toggleBinding(ticketTypeId, checked) {
+      const next = { ...this.bindings };
+      if (checked) {
+        next[ticketTypeId] = next[ticketTypeId] ?? '';
+      } else {
+        delete next[ticketTypeId];
+      }
+      this.bindings = next;
+    },
+    setDescription(ticketTypeId, value) {
+      this.bindings = { ...this.bindings, [ticketTypeId]: value };
+    },
+    async save() {
+      const bindingsArray = Object.entries(this.bindings).map(([ticket_type_id, description]) => ({
+        ticket_type_id,
+        description: description || null,
+      }));
+      const data = {
+        name: this.name,
+        festival_id: this.festivalId,
+        active: this.active,
+        bindings: bindingsArray,
+      };
+      if (this.isEdit) {
+        await this.edit({ id: this.id, data });
+      } else {
+        await this.create({ data });
+      }
+      this.back();
+    },
+    back() {
+      this.$router.push({ name: 'OptionListView' });
+    },
+  },
+  async created() {
+    this.getListFestival();
+    this.loadTicketTypes({ filter: {}, orderBy: {} });
+    this.rebuildBindings();
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/components/Option/OptionList.vue
+++ b/FrontEnd/src/components/Option/OptionList.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="title-block text-center">
+    <h1 class="card-title"> Опции к билетам </h1>
+    <router-link :to="{ name: 'OptionItemView' }" class="btn btn-success mb-2">+ Создать опцию</router-link>
+  </div>
+  <div class="row">
+    <div class="col-lg-12 mx-auto" id="filter-results">
+      <div class="card">
+        <div class="card-body">
+          <table class="table table-hover">
+            <thead>
+            <tr>
+              <th scope="col" style="cursor: pointer" @click="orderByLocal('name')">Название</th>
+              <th scope="col">Фестиваль</th>
+              <th scope="col">Активность</th>
+              <th scope="col" style="cursor: pointer" @click="orderByLocal('created_at')">Дата создания</th>
+              <th scope="col"></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="(item, index) in getList" v-bind:key="index">
+              <th scope="row" @click="goToItem(item.id)" style="cursor: pointer">
+                {{ item.name }}
+              </th>
+              <td>{{ festivalName(item.festival_id) }}</td>
+              <td>
+                <span :class="item.active ? 'badge bg-success' : 'badge bg-secondary'">
+                  {{ item.active ? 'ДА' : 'НЕТ' }}
+                </span>
+              </td>
+              <td><date-format :date="item.created_at" /></td>
+              <td>
+                <span style="cursor: pointer" v-show="item.id" @click="localRemove(item.id)">
+                  🗑️
+                </span>
+              </td>
+            </tr>
+            <tr v-if="!getList || !getList.length">
+              <td colspan="5" class="text-muted text-center">Опций ещё нет. Создайте первую.</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+import DateFormat from '@/components/Utilite/DateFormat.vue';
+
+export default {
+  name: 'OptionList',
+  components: { DateFormat },
+  computed: {
+    ...mapGetters('appOption', ['getList', 'getFilter', 'getOrderBy']),
+    ...mapGetters('appFestivalTickets', ['getFestivalList']),
+  },
+  methods: {
+    ...mapActions('appOption', ['loadList', 'setOrderBy', 'remove']),
+    ...mapActions('appFestivalTickets', ['getListFestival']),
+    festivalName(id) {
+      const f = (this.getFestivalList || []).find((x) => x.id === id);
+      return f ? `${f.name} ${f.year ?? ''}`.trim() : id;
+    },
+    localRemove(id) {
+      if (!confirm('Удалить опцию? Привязки к типам билетов и волны цен будут удалены каскадно.')) return;
+      this.remove({ id: id });
+    },
+    async orderByLocal(name) {
+      await this.setOrderBy(name);
+      await this.loadList({ filter: this.getFilter, orderBy: this.getOrderBy });
+    },
+    goToItem(id) {
+      this.$router.push({ name: 'OptionItemView', params: { id: id } });
+    },
+  },
+  async created() {
+    this.getListFestival();
+    await this.loadList({ filter: this.getFilter, orderBy: this.getOrderBy });
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/components/Option/OptionPriceList.vue
+++ b/FrontEnd/src/components/Option/OptionPriceList.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="card mt-3">
+    <div class="card-body">
+      <h5 class="card-title">Волны цен опции</h5>
+      <p class="text-muted small">
+        Актуальной считается ближайшая по дате <code>before_date</code>, у которой дата ≥ сегодня.
+        Цена в рублях, целое число.
+      </p>
+
+      <table class="table table-sm">
+        <thead>
+        <tr>
+          <th>Цена (₽)</th>
+          <th>Действует до</th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="row in getList" :key="row.id">
+          <td><input type="number" min="1" max="999999" class="form-control form-control-sm" v-model.number="row.price"></td>
+          <td><input type="date" class="form-control form-control-sm" v-model="row.before_date"></td>
+          <td class="text-end">
+            <button class="btn btn-sm btn-primary me-1" :disabled="!isValid(row)" @click="save(row)">💾</button>
+            <button class="btn btn-sm btn-danger" @click="localRemove(row.id)">🗑️</button>
+          </td>
+        </tr>
+        <tr v-if="!getList || !getList.length">
+          <td colspan="3" class="text-muted text-center">Волн нет. Добавьте первую.</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <div class="card bg-light p-3 mt-2">
+        <h6 class="mb-2">Новая волна</h6>
+        <div class="row g-2">
+          <div class="col-md-4">
+            <input type="number" min="1" max="999999" class="form-control" placeholder="Цена в рублях" v-model.number="newWave.price">
+          </div>
+          <div class="col-md-4">
+            <input type="date" class="form-control" v-model="newWave.before_date" :min="todayStr">
+          </div>
+          <div class="col-md-4">
+            <button class="btn btn-success w-100" :disabled="!isValid(newWave)" @click="createNew">+ Добавить волну</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+  name: 'OptionPriceList',
+  props: {
+    optionId: { type: String, required: true },
+  },
+  data() {
+    return {
+      newWave: { price: null, before_date: null },
+    };
+  },
+  computed: {
+    ...mapGetters('appOptionPrice', ['getList']),
+    todayStr() {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    },
+  },
+  methods: {
+    ...mapActions('appOptionPrice', ['loadList', 'create', 'edit', 'remove']),
+    isValid(row) {
+      const okPrice = row.price && row.price > 0 && row.price < 1000000;
+      const okDate = row.before_date && row.before_date >= this.todayStr;
+      return okPrice && okDate;
+    },
+    async save(row) {
+      await this.edit({
+        id: row.id,
+        data: {
+          option_id: this.optionId,
+          price: row.price,
+          before_date: row.before_date,
+        },
+      });
+      await this.refresh();
+    },
+    async createNew() {
+      await this.create({
+        data: {
+          option_id: this.optionId,
+          price: this.newWave.price,
+          before_date: this.newWave.before_date,
+        },
+      });
+      this.newWave = { price: null, before_date: null };
+      await this.refresh();
+    },
+    async localRemove(id) {
+      if (!confirm('Удалить волну цены?')) return;
+      await this.remove({ id });
+      await this.refresh();
+    },
+    refresh() {
+      return this.loadList({ filter: { option_id: this.optionId } });
+    },
+  },
+  async created() {
+    await this.refresh();
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/router/index.js
+++ b/FrontEnd/src/router/index.js
@@ -35,6 +35,8 @@ import QuestionnaireTypeListView from "@/views/questionnaireType/QuestionnaireTy
 import QuestionnaireTypeItemView from "@/views/questionnaireType/QuestionnaireTypeItemView.vue";
 import LocationListView from "@/views/location/LocationListView.vue";
 import LocationItemView from "@/views/location/LocationItemView.vue";
+import OptionListView from "@/views/option/OptionListView.vue";
+import OptionItemView from "@/views/option/OptionItemView.vue";
 import OrderListsListView from "@/views/order/OrderListsListView.vue";
 import OrderListForCurator from "@/views/order/OrderListForCurator.vue";
 import CreateListOrderView from "@/views/order/CreateListOrderView.vue";
@@ -375,6 +377,28 @@ const routes = [
         path: '/location/:id?',
         name: 'LocationItemView',
         component: LocationItemView,
+        props: true,
+        meta: {
+            'requiresAuth': true,
+            'role': ['admin']
+        }
+    },
+
+    // Опции к билетам (v2.6.0)
+    {
+        path: '/option/list',
+        name: 'OptionListView',
+        component: OptionListView,
+        props: true,
+        meta: {
+            'requiresAuth': true,
+            'role': ['admin']
+        }
+    },
+    {
+        path: '/option/:id?',
+        name: 'OptionItemView',
+        component: OptionItemView,
         props: true,
         meta: {
             'requiresAuth': true,

--- a/FrontEnd/src/store/index.js
+++ b/FrontEnd/src/store/index.js
@@ -11,6 +11,8 @@ import appTypesOfPayment from './modules/TypesOfPaymentModule/index';
 import appQuestionnaireType from './modules/QuestionnaireTypeModule/index';
 import appLocation from './modules/LocationModule/index';
 import appTicketTypePrice from './modules/TicketTypePriceModule/index';
+import appOption from './modules/OptionModule/index';
+import appOptionPrice from './modules/OptionPriceModule/index';
 
 export default createStore({
     state: {
@@ -46,5 +48,7 @@ export default createStore({
         'appQuestionnaireType': appQuestionnaireType,
         'appLocation': appLocation,
         'appTicketTypePrice': appTicketTypePrice,
+        'appOption': appOption,
+        'appOptionPrice': appOptionPrice,
     }
 })

--- a/FrontEnd/src/store/modules/OptionModule/actions.js
+++ b/FrontEnd/src/store/modules/OptionModule/actions.js
@@ -1,0 +1,113 @@
+import axios from 'axios';
+
+const API = '/api/v1/option';
+
+export const loadList = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/getList', payload)
+            .then(function (response) {
+                context.commit('setList', response.data.list);
+                resolve(response.data.list);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+export const loadItem = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.get(API + '/getItem/' + payload.id)
+            .then(function (response) {
+                context.commit('setItem', response.data.item);
+                resolve(response.data.item);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+/**
+ * Read-модель для формы покупки билета:
+ * вернёт активные опции с уже подмешанной актуальной ценой
+ * и description (зависит от типа билета).
+ */
+export const loadActiveForTicketType = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.get(API + '/getActiveForTicketType/' + payload.ticketTypeId)
+            .then(function (response) {
+                context.commit('setActiveForTicketType', response.data.list);
+                resolve(response.data.list);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+export const create = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/create', { data: payload.data })
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                context.commit('setItem', response.data.item);
+                resolve(response.data);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+export const edit = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/edit/' + payload.id, { data: payload.data })
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                context.commit('setItem', response.data.item);
+                resolve(response.data);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+export const remove = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.delete(API + '/delete/' + payload.id)
+            .then(function () {
+                context.commit('removeInList', payload);
+                resolve();
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors ?? []);
+                reject(error);
+            });
+    });
+};
+
+export const clearError = (context) => {
+    context.commit('setError', []);
+};
+
+export const setFilter = (context, payload) => {
+    context.commit('setFilter', payload);
+};
+
+export const setOrderBy = (context, payload) => {
+    let orderByCurrent = context.getters.getOrderBy;
+
+    if (Object.keys(orderByCurrent).length === 0 || Object.keys(orderByCurrent)[0] !== payload) {
+        context.commit('setOrderBy', { [payload]: 'desc' });
+    } else {
+        let type = (orderByCurrent[payload] === 'desc' ? 'asc' : 'desc');
+        context.commit('setOrderBy', { [payload]: type });
+    }
+};

--- a/FrontEnd/src/store/modules/OptionModule/getters.js
+++ b/FrontEnd/src/store/modules/OptionModule/getters.js
@@ -1,0 +1,8 @@
+export const getList = (state) => state.list;
+export const getItem = (state) => state.item;
+export const getFilter = (state) => state.filter;
+export const getOrderBy = (state) => state.orderBy;
+export const getIsLoading = (state) => state.isLoading;
+export const getDataError = (state) => state.dataError;
+export const getMessage = (state) => state.message;
+export const getActiveForTicketType = (state) => state.activeForTicketType;

--- a/FrontEnd/src/store/modules/OptionModule/index.js
+++ b/FrontEnd/src/store/modules/OptionModule/index.js
@@ -1,0 +1,20 @@
+import * as getters from './getters';
+import * as actions from './actions';
+import * as mutations from './mutations';
+
+export default {
+    namespaced: true,
+    state: {
+        list: [],
+        item: {},
+        filter: {},
+        orderBy: {},
+        isLoading: false,
+        dataError: [],
+        message: null,
+        activeForTicketType: [],
+    },
+    getters,
+    actions,
+    mutations,
+};

--- a/FrontEnd/src/store/modules/OptionModule/mutations.js
+++ b/FrontEnd/src/store/modules/OptionModule/mutations.js
@@ -1,0 +1,35 @@
+export const setList = (state, payload) => {
+    state.list = payload;
+};
+
+export const setItem = (state, payload) => {
+    state.item = payload;
+};
+
+export const setFilter = (state, payload) => {
+    state.filter = payload;
+};
+
+export const setOrderBy = (state, payload) => {
+    state.orderBy = payload;
+};
+
+export const setIsLoading = (state, payload) => {
+    state.isLoading = payload;
+};
+
+export const setError = (state, payload) => {
+    state.dataError = payload;
+};
+
+export const setMessage = (state, payload) => {
+    state.message = payload;
+};
+
+export const removeInList = (state, payload) => {
+    state.list = state.list.filter((item) => item.id !== payload.id);
+};
+
+export const setActiveForTicketType = (state, payload) => {
+    state.activeForTicketType = payload;
+};

--- a/FrontEnd/src/store/modules/OptionPriceModule/actions.js
+++ b/FrontEnd/src/store/modules/OptionPriceModule/actions.js
@@ -1,0 +1,92 @@
+import axios from 'axios';
+
+const API = '/api/v1/optionPrice';
+
+export const loadList = (context, payload) => {
+    const filter = (payload && payload.filter) || context.state.filter || {};
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/getList', { filter, orderBy: context.state.orderBy || {} })
+            .then(function (response) {
+                context.commit('setList', response.data.list);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const loadItem = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.get(API + '/getItem/' + payload.id)
+            .then(function (response) {
+                context.commit('setItem', response.data.item);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const create = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/create', { data: payload.data })
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                if (response.data.item) {
+                    context.commit('upsertInList', response.data.item);
+                }
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const edit = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.post(API + '/edit/' + payload.id, { data: payload.data })
+            .then(function (response) {
+                context.commit('setMessage', response.data.message);
+                if (response.data.item) {
+                    context.commit('upsertInList', response.data.item);
+                }
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const remove = (context, payload) => {
+    return new Promise((resolve, reject) => {
+        axios.delete(API + '/delete/' + payload.id)
+            .then(function (response) {
+                context.commit('removeInList', payload);
+                resolve(response);
+            })
+            .catch(function (error) {
+                context.commit('setError', error.response?.data?.errors);
+                reject(error);
+            });
+    });
+};
+
+export const setFilter = (context, payload) => {
+    context.commit('setFilter', payload);
+};
+
+export const clearError = (context) => {
+    context.commit('setError', []);
+};
+
+export const clearMessage = (context) => {
+    context.commit('setMessage', null);
+};

--- a/FrontEnd/src/store/modules/OptionPriceModule/getters.js
+++ b/FrontEnd/src/store/modules/OptionPriceModule/getters.js
@@ -1,0 +1,7 @@
+export const getList = (state) => state.list;
+export const getItem = (state) => state.item;
+export const getFilter = (state) => state.filter;
+export const getOrderBy = (state) => state.orderBy;
+export const getIsLoading = (state) => state.isLoading;
+export const getDataError = (state) => state.dataError;
+export const getMessage = (state) => state.message;

--- a/FrontEnd/src/store/modules/OptionPriceModule/index.js
+++ b/FrontEnd/src/store/modules/OptionPriceModule/index.js
@@ -1,0 +1,19 @@
+import * as getters from './getters';
+import * as actions from './actions';
+import * as mutations from './mutations';
+
+export default {
+    namespaced: true,
+    state: {
+        list: [],
+        item: {},
+        filter: {},
+        orderBy: {},
+        isLoading: false,
+        dataError: [],
+        message: null,
+    },
+    getters,
+    actions,
+    mutations,
+};

--- a/FrontEnd/src/store/modules/OptionPriceModule/mutations.js
+++ b/FrontEnd/src/store/modules/OptionPriceModule/mutations.js
@@ -1,0 +1,40 @@
+export const setList = (state, payload) => {
+    state.list = payload;
+};
+
+export const setItem = (state, payload) => {
+    state.item = payload;
+};
+
+export const setFilter = (state, payload) => {
+    state.filter = payload;
+};
+
+export const setOrderBy = (state, payload) => {
+    state.orderBy = payload;
+};
+
+export const setIsLoading = (state, payload) => {
+    state.isLoading = payload;
+};
+
+export const setError = (state, payload) => {
+    state.dataError = payload;
+};
+
+export const setMessage = (state, payload) => {
+    state.message = payload;
+};
+
+export const removeInList = (state, payload) => {
+    state.list = state.list.filter((item) => item.id !== payload.id);
+};
+
+export const upsertInList = (state, item) => {
+    const i = state.list.findIndex((x) => x.id === item.id);
+    if (i >= 0) {
+        state.list.splice(i, 1, item);
+    } else {
+        state.list.push(item);
+    }
+};

--- a/FrontEnd/src/views/MenuView.vue
+++ b/FrontEnd/src/views/MenuView.vue
@@ -243,6 +243,11 @@
         </router-link>
       </li>
       <li class="nav-item">
+        <router-link class="nav-link" active-class="active" :to="{ name: 'OptionListView' }">
+          Опции к билетам
+        </router-link>
+      </li>
+      <li class="nav-item">
         <router-link class="nav-link" active-class="active" :to="{ name: 'TypesOfPaymentListView' }">
           Типы оплат
         </router-link>

--- a/FrontEnd/src/views/option/OptionItemView.vue
+++ b/FrontEnd/src/views/option/OptionItemView.vue
@@ -1,0 +1,29 @@
+<template>
+  <OptionItem :id="id" />
+</template>
+
+<script>
+import OptionItem from '@/components/Option/OptionItem.vue';
+
+export default {
+  name: 'OptionItemView',
+  components: { OptionItem },
+  props: {
+    id: { type: String, default: null },
+  },
+  beforeRouteEnter: (to, from, next) => {
+    if (to.params.id) {
+      window.store.dispatch('appOption/loadItem', { id: to.params.id });
+    } else {
+      window.store.commit('appOption/setItem', {});
+    }
+    next();
+  },
+  created() {
+    document.title = this.id ? 'Редактирование опции' : 'Создать опцию';
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/FrontEnd/src/views/option/OptionListView.vue
+++ b/FrontEnd/src/views/option/OptionListView.vue
@@ -1,0 +1,20 @@
+<template>
+  <OptionFilter />
+  <OptionList />
+</template>
+
+<script>
+import OptionFilter from '@/components/Option/OptionFilter.vue';
+import OptionList from '@/components/Option/OptionList.vue';
+
+export default {
+  name: 'OptionListView',
+  components: { OptionList, OptionFilter },
+  created() {
+    document.title = 'Опции к билетам';
+  },
+};
+</script>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Что в PR (часть 2 sub-ветки)

Админ-UI опций к билетам — раздел в админ-меню по аналогии с Локациями.

> **Требует мерж PR #43** (backend Option) до этого PR.

### Vuex модули

- `appOption` — CRUD + `loadActiveForTicketType` (read-модель для формы покупки)
- `appOptionPrice` — CRUD волн цен

### Vue компоненты

- `OptionFilter.vue` — фильтры name/festival/active с «Применить»
- `OptionList.vue` — таблица с badge активности, удаление через `confirm`
- `OptionItem.vue` — форма с **чекбоксами привязок к ticket_type** и
  textarea description под каждой связкой + встроенный OptionPriceList
- `OptionPriceList.vue` — inline-таблица волн цен с валидацией
  (price 1–999999, before_date ≥ сегодня)

### Регистрация

- `store/index.js` — appOption + appOptionPrice
- `router/index.js` — `/option/list` + `/option/:id?` (role: admin)
- `MenuView.vue` — пункт «Опции к билетам» после Локации

### Test plan

- [ ] `cd FrontEnd && npm run build` — собирается без ошибок
- [ ] Локально: открыть админку → пункт «Опции к билетам»
- [ ] Создать опцию: имя + фестиваль + привязки к 2 типам билетов с разным описанием
- [ ] Сохранить → проверить что появилась в списке
- [ ] Открыть → добавить волну цены → сохранить
- [ ] Удалить опцию → проверить что pivot и волны удалились каскадно

🤖 Generated with [Claude Code](https://claude.com/claude-code)