### PR TITLE
chore(infra): self-hosted GHA runner + workflow deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,116 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  Деплой на staging-стенд (77.222.32.244)
+#
+#  Гибрид:
+#   - test:    GHA-hosted runner (быстрые проверки — кэшируемые, бесплатные минуты)
+#   - deploy:  self-hosted runner на staging (для git pull + docker compose)
+#
+#  Триггеры:
+#   - push в ветку `staging` (после merge feature → staging) → auto-deploy
+#   - workflow_dispatch — ручной запуск из UI
+#
+#  Окружение:
+#   - Self-hosted runner работает под пользователем `deploy` на сервере
+#   - Имеет sudo на: docker, systemctl restart, git -C /var/www/systo
+#   - Репозиторий уже склонирован в /var/www/systo (делает setup-runner.sh)
+#
+#  Что НЕ делает на этом этапе (TODO в отдельных PR):
+#   - Не разворачивает docker compose — нет docker-compose.staging.yml ещё
+#   - Не делает healthcheck — нет endpoint'а пока
+#   - Не уведомляет о результате — Telegram-канал v2.7.0
+# ─────────────────────────────────────────────────────────────────────────────
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ветка или тег для деплоя (по умолчанию — staging)'
+        required: false
+        default: 'staging'
+
+concurrency:
+  # Не давать двум деплоям бежать одновременно на одном сервере
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  # ─── Стадия 1: быстрые проверки на GHA-hosted (cache-friendly) ──────────────
+  pre-deploy-check:
+    name: Pre-deploy checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref_name }}
+
+      - name: Verify infra/staging exists
+        run: |
+          test -d infra/staging || (echo "::error::infra/staging отсутствует — нечего деплоить" && exit 1)
+          echo "✓ infra/staging on board"
+
+      - name: Verify no secrets in commit
+        run: |
+          # Базовая проверка — на staging НЕ должно быть hardcoded secrets
+          # (полная проверка делается в ci.yml через Security audit)
+          if git log --format="%H" -n 5 | xargs -I{} git show {} | grep -iE "(api_key|secret_key|password)\s*=\s*['\"][^'\"]{8,}" 2>/dev/null; then
+            echo "::warning::Возможно секрет в последних коммитах — проверь вручную"
+          fi
+          echo "✓ No obvious secrets"
+
+  # ─── Стадия 2: деплой на self-hosted ────────────────────────────────────────
+  deploy:
+    name: Deploy to staging server
+    needs: pre-deploy-check
+    runs-on: [self-hosted, staging]
+    timeout-minutes: 15
+    env:
+      PROJECT_DIR: /var/www/systo
+      BRANCH: ${{ github.event.inputs.ref || github.ref_name }}
+
+    steps:
+      - name: Show runner info
+        run: |
+          echo "Runner:    $(hostname)"
+          echo "User:      $(whoami)"
+          echo "PWD:       $(pwd)"
+          echo "Branch:    $BRANCH"
+          echo "Project:   $PROJECT_DIR"
+
+      - name: Ensure project directory exists
+        run: |
+          if [[ ! -d "$PROJECT_DIR/.git" ]]; then
+            echo "::error::$PROJECT_DIR/.git не найден. Запусти setup-runner.sh для bootstrap."
+            exit 1
+          fi
+          echo "✓ Project directory ok"
+
+      - name: Pull latest code
+        run: |
+          sudo git -C "$PROJECT_DIR" fetch --all --prune
+          sudo git -C "$PROJECT_DIR" checkout "$BRANCH"
+          sudo git -C "$PROJECT_DIR" reset --hard "origin/$BRANCH"
+          echo ""
+          echo "✓ Pulled to $(sudo git -C "$PROJECT_DIR" rev-parse --short HEAD)"
+
+      - name: Show deployed commit
+        run: |
+          sudo git -C "$PROJECT_DIR" log -1 --pretty=format:"%h %s%n%nAuthor: %an <%ae>%nDate:   %ad" --date=short
+
+      - name: TODO Deploy containers
+        run: |
+          # На этом этапе у нас ещё нет docker-compose.staging.yml.
+          # Следующий PR добавит его и заменит этот шаг на:
+          #   sudo docker compose -f docker-compose.staging.yml up -d --build
+          #   sudo docker compose -f docker-compose.staging.yml exec -T php-solarSysto php artisan migrate --force
+          echo "::warning::TODO: добавить docker compose шаг в следующем PR"
+          echo "Текущее состояние Docker:"
+          sudo docker ps --format "  {{.Names}}\t{{.Status}}"
+
+      - name: TODO Healthcheck
+        run: |
+          echo "::warning::TODO: добавить healthcheck (curl на /api/health) в следующем PR"

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -5,11 +5,17 @@
 
 ## Состав
 
-- `setup-deploy-user.sh` — скрипт первой настройки: создаёт пользователя
-  `deploy` для CD, настраивает sudoers, готовит директорию проекта.
+- `setup-deploy-user.sh` — создаёт пользователя `deploy` для CD,
+  настраивает sudoers, готовит директорию проекта.
 - `setup-swap.sh` — опциональный swap-файл (рекомендуется при RAM ≤ 2 ГБ).
-- (далее) `setup-runner.sh` — установка GitHub Actions self-hosted runner
+- `setup-runner.sh` — устанавливает self-hosted GitHub Actions runner
+  как systemd service.
+- (далее) `setup-project.sh` — bootstrap проекта в /var/www/systo (git clone)
 - (далее) `docker-compose.staging.yml` — конфигурация контейнеров staging
+
+## Workflow
+
+- `.github/workflows/deploy-staging.yml` — auto-deploy при push в ветку `staging`
 
 ## Текущий staging-сервер
 
@@ -70,7 +76,44 @@ ssh root@77.222.32.244 "bash /tmp/setup-deploy-user.sh '$(cat ~/.ssh/gha_deploy.
 > ⚠️ Скрипт идемпотентен — можно запускать повторно без вреда. Каждое уже
 > сделанное действие будет пропущено.
 
-### 5. Проверка
+### 5. Установка self-hosted GitHub Actions runner
+
+Runner подхватывает job-ы с лейблом `staging` из workflow `deploy-staging.yml`.
+
+С локальной машины:
+
+```bash
+# Получить одноразовый registration-token (валиден 1 час)
+TOKEN=$(gh api -X POST repos/ShaevMV/systo/actions/runners/registration-token --jq .token)
+
+# Скопировать скрипт
+scp infra/staging/setup-runner.sh root@77.222.32.244:/tmp/
+
+# Запустить (от root — нужен для systemd unit, внутри сам делает sudo -u deploy)
+ssh root@77.222.32.244 "bash /tmp/setup-runner.sh https://github.com/ShaevMV/systo '$TOKEN'"
+```
+
+После запуска:
+- В `Settings → Actions → Runners` появится `staging-systo` со статусом `Idle`
+- Логи: `ssh root@... 'sudo journalctl -u actions.runner.*.service -f'`
+
+### 6. Bootstrap проекта (один раз, **до первого деплоя**)
+
+Runner работает в `/home/deploy/actions-runner/_work`, но проект разворачиваем
+в `/var/www/systo` (созданном `setup-deploy-user.sh`). Первый клон делается
+вручную как `deploy`:
+
+```bash
+ssh -i ~/.ssh/gha_deploy deploy@77.222.32.244
+cd /var/www/systo
+git clone https://github.com/ShaevMV/systo.git .
+git checkout staging  # ветка должна существовать в репо
+exit
+```
+
+После — workflow сам делает `sudo git pull` при каждом push в staging.
+
+### 7. Проверка
 
 С локальной машины:
 

--- a/infra/staging/setup-runner.sh
+++ b/infra/staging/setup-runner.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  setup-runner.sh
+#  Устанавливает self-hosted GitHub Actions runner на staging-сервере.
+#
+#  Runner работает от имени пользователя `deploy` (создан скриптом
+#  setup-deploy-user.sh). Регистрируется как systemd service —
+#  автозапуск после ребута.
+#
+#  Запускать на сервере КАК ROOT (нужно для установки systemd unit):
+#      bash setup-runner.sh <REPO_URL> <REGISTRATION_TOKEN> [LABEL]
+#
+#  Где:
+#    REPO_URL           — https://github.com/ShaevMV/systo
+#    REGISTRATION_TOKEN — одноразовый токен, валиден ~1 час.
+#                         Получить:
+#                           - UI: Settings → Actions → Runners → New self-hosted runner
+#                           - CLI: gh api -X POST repos/<owner>/<repo>/actions/runners/registration-token --jq .token
+#    LABEL              — default "staging" (плюс автоматически self-hosted/linux/x64)
+#
+#  Пример запуска с локальной машины (одной командой):
+#      TOKEN=$(gh api -X POST repos/ShaevMV/systo/actions/runners/registration-token --jq .token)
+#      scp infra/staging/setup-runner.sh root@77.222.32.244:/tmp/
+#      ssh root@77.222.32.244 "bash /tmp/setup-runner.sh https://github.com/ShaevMV/systo '$TOKEN'"
+#
+#  Идемпотентен:
+#   - повторный запуск с новым токеном перерегистрирует runner с тем же именем
+#   - systemd service обновляется без ошибок
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO_URL="${1:-}"
+REG_TOKEN="${2:-}"
+LABEL="${3:-staging}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.334.0}"
+RUNNER_NAME="${RUNNER_NAME:-staging-systo}"
+
+DEPLOY_USER="deploy"
+DEPLOY_HOME="/home/${DEPLOY_USER}"
+RUNNER_DIR="${DEPLOY_HOME}/actions-runner"
+ARCH="linux-x64"
+
+log()  { echo -e "\033[1;34m[runner]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[warn]\033[0m   $*" >&2; }
+err()  { echo -e "\033[1;31m[err]\033[0m    $*" >&2; exit 1; }
+
+# ─── Sanity ───────────────────────────────────────────────────────────────────
+[[ "$EUID" -eq 0 ]] || err "Запускать от root (нужно для systemd-сервиса)"
+id "$DEPLOY_USER" >/dev/null 2>&1 || err "Пользователя '$DEPLOY_USER' нет — сначала запусти setup-deploy-user.sh"
+[[ -n "$REPO_URL"  ]] || err "Не передан REPO_URL (1-й аргумент)"
+[[ -n "$REG_TOKEN" ]] || err "Не передан REGISTRATION_TOKEN (2-й аргумент). См. README §Runner."
+[[ "$REPO_URL" =~ ^https://github\.com/ ]] || err "REPO_URL должен начинаться с https://github.com/ (получено: $REPO_URL)"
+
+# ─── 1. Зависимости ───────────────────────────────────────────────────────────
+log "Проверяю зависимости…"
+MISSING=()
+for cmd in curl tar systemctl; do
+    command -v "$cmd" >/dev/null 2>&1 || MISSING+=("$cmd")
+done
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    log "Устанавливаю недостающее: ${MISSING[*]}"
+    apt-get update -qq
+    apt-get install -y -qq "${MISSING[@]}"
+fi
+
+# .NET / runtime зависимости для runner (актуально для Ubuntu 24.04)
+# Список из официальной доки: https://github.com/actions/runner/blob/main/docs/start/envlinux.md
+log "Устанавливаю runtime-зависимости runner (если не установлены)…"
+apt-get install -y -qq \
+    libicu74 \
+    libssl3 \
+    libstdc++6 \
+    zlib1g \
+    2>/dev/null || warn "Не все пакеты установились — на 24.04 может потребоваться libicu74"
+
+# ─── 2. Скачать runner ────────────────────────────────────────────────────────
+log "Готовлю директорию ${RUNNER_DIR}…"
+install -d -o "$DEPLOY_USER" -g "$DEPLOY_USER" "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+TARBALL="actions-runner-${ARCH}-${RUNNER_VERSION}.tar.gz"
+URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}"
+
+if [[ -f "config.sh" ]]; then
+    log "✓ Runner уже распакован — пропускаю скачивание"
+else
+    log "Скачиваю ${TARBALL}…"
+    sudo -u "$DEPLOY_USER" curl -fsSL -o "$TARBALL" "$URL"
+    log "Распаковываю…"
+    sudo -u "$DEPLOY_USER" tar xzf "$TARBALL"
+    sudo -u "$DEPLOY_USER" rm -f "$TARBALL"
+    log "✓ Runner распакован"
+fi
+
+# ─── 3. Остановить старый сервис (если был) ───────────────────────────────────
+if [[ -f /etc/systemd/system/actions.runner.*.service ]] 2>/dev/null \
+   || systemctl list-units --all --type=service 2>/dev/null | grep -q "actions.runner"; then
+    OLD_SVC="$(systemctl list-units --all --type=service --no-pager --no-legend 2>/dev/null | grep -oE 'actions\.runner\.[^ ]+\.service' | head -1 || true)"
+    if [[ -n "$OLD_SVC" ]]; then
+        log "Останавливаю старый сервис $OLD_SVC (для переконфигурации)…"
+        systemctl stop "$OLD_SVC" 2>/dev/null || true
+    fi
+fi
+
+# Сбросить старую регистрацию (если была)
+if [[ -f "$RUNNER_DIR/.runner" ]]; then
+    log "Удаляю старую регистрацию…"
+    sudo -u "$DEPLOY_USER" "$RUNNER_DIR/config.sh" remove --token "$REG_TOKEN" 2>/dev/null \
+        || warn "Не смог снять старую регистрацию через API (возможно токен другой). Удаляю файлы."
+    rm -f "$RUNNER_DIR/.runner" "$RUNNER_DIR/.credentials" "$RUNNER_DIR/.credentials_rsaparams"
+fi
+
+# ─── 4. Зарегистрировать ──────────────────────────────────────────────────────
+log "Регистрирую runner '${RUNNER_NAME}' с лейблами 'self-hosted,linux,x64,${LABEL}'…"
+sudo -u "$DEPLOY_USER" "$RUNNER_DIR/config.sh" \
+    --url "$REPO_URL" \
+    --token "$REG_TOKEN" \
+    --name "$RUNNER_NAME" \
+    --labels "$LABEL" \
+    --work "_work" \
+    --unattended \
+    --replace
+log "✓ Runner зарегистрирован"
+
+# ─── 5. Установить systemd-сервис ─────────────────────────────────────────────
+log "Устанавливаю systemd-сервис (от имени root)…"
+cd "$RUNNER_DIR"
+./svc.sh install "$DEPLOY_USER"
+./svc.sh start
+sleep 2
+./svc.sh status
+
+# ─── 6. Итог ──────────────────────────────────────────────────────────────────
+echo ""
+log "════════════════════════════════════════════════════════"
+log "  Runner установлен и запущен."
+log "════════════════════════════════════════════════════════"
+echo ""
+echo "  Версия runner:    $RUNNER_VERSION"
+echo "  Имя:              $RUNNER_NAME"
+echo "  Лейблы:           self-hosted, linux, x64, $LABEL"
+echo "  Директория:       $RUNNER_DIR"
+echo "  Под пользователем:$DEPLOY_USER"
+echo ""
+echo "  Проверь в GitHub UI:"
+echo "    Settings → Actions → Runners → должен появиться '$RUNNER_NAME' (Idle)"
+echo ""
+echo "  Управление сервисом:"
+echo "    sudo systemctl status  actions.runner.*.service"
+echo "    sudo systemctl restart actions.runner.*.service"
+echo "    sudo journalctl -u     actions.runner.*.service -f"


### PR DESCRIPTION
## Что в PR

Завершение настройки CD-пайплайна на staging-сервере (продолжение PR #42).

### Новое

- **\`infra/staging/setup-runner.sh\`** — установка self-hosted GitHub Actions
  runner v2.334.0 как systemd-сервиса под пользователем \`deploy\`.
- **\`.github/workflows/deploy-staging.yml\`** — гибридный workflow:
  - **pre-deploy-check** на GHA-hosted (Ubuntu-latest) — быстрые валидации
  - **deploy** на self-hosted runner с лейблом \`staging\` — \`git pull\` в \`/var/www/systo\`
  - \`concurrency: deploy-staging\` — защита от двух одновременных деплоев

### Архитектура

\`\`\`
Push в ветку staging
        │
        ▼
GHA-hosted (ubuntu-latest)
  └─ Проверка наличия infra/staging
  └─ Быстрый grep на секреты в последних коммитах
        │
        ▼ (needs:)
Self-hosted runner на 77.222.32.244 (label: staging)
  └─ sudo git -C /var/www/systo fetch + checkout + reset --hard
  └─ TODO: docker compose up -d --build  (в след. PR)
  └─ TODO: healthcheck                    (в след. PR)
\`\`\`

### Что НЕ в этом PR (TODO в коде, отдельные PR'ы)

- \`docker-compose.staging.yml\` — конфигурация контейнеров для staging
- \`setup-project.sh\` — автоматический \`git clone\` /var/www/systo
- Healthcheck endpoint и проверка после деплоя
- Telegram-нотификации (v2.7.0)

## Test plan

- [ ] Реви скриптов (особенно sudoers-чувствительные шаги)
- [ ] Получить registration-token: \`gh api -X POST repos/ShaevMV/systo/actions/runners/registration-token --jq .token\`
- [ ] Скопировать и запустить \`setup-runner.sh\` на сервере
- [ ] В Settings → Actions → Runners → видеть \`staging-systo\` в статусе Idle
- [ ] Bootstrap проекта: \`ssh deploy@... && cd /var/www/systo && git clone .\`
- [ ] Создать ветку \`staging\` в репо (любым merge или \`git push -u origin master:staging\`)
- [ ] Trigger workflow вручную через UI → стадия deploy должна пройти

🤖 Generated with [Claude Code](https://claude.com/claude-code)