### PR TITLE
chore(infra): host nginx reverse proxy + SSL + basic auth для 5 поддоменов

### DIFF
--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -10,8 +10,26 @@
 - `setup-swap.sh` — опциональный swap-файл (рекомендуется при RAM ≤ 2 ГБ).
 - `setup-runner.sh` — устанавливает self-hosted GitHub Actions runner
   как systemd service.
-- (далее) `setup-project.sh` — bootstrap проекта в /var/www/systo (git clone)
+- `setup-host-nginx.sh` — настраивает host nginx как reverse proxy
+  для 5 поддоменов.
+- `setup-basic-auth.sh` — создаёт `.htpasswd` для phpMyAdmin и Mailpit.
+- `setup-ssl.sh` — Let's Encrypt SSL через certbot для всех 5 поддоменов.
+- `nginx/sites-available/*.conf` — шаблоны nginx server-блоков.
 - (далее) `docker-compose.staging.yml` — конфигурация контейнеров staging
+
+## Архитектура поддоменов
+
+```
+[Internet:80/443]
+       │
+  [HOST NGINX] (Let's Encrypt SSL)
+       │
+       ├─ staging.spaceofjoy.ru          → 127.0.0.1:8080  Frontend (Vue SPA)
+       ├─ api.staging.spaceofjoy.ru      → 127.0.0.1:8081  Backend (Laravel)
+       ├─ vhod.staging.spaceofjoy.ru     → 127.0.0.1:8082  Baza (Laravel)
+       ├─ pma.staging.spaceofjoy.ru      → 127.0.0.1:8083  phpMyAdmin   + basic auth
+       └─ mail.staging.spaceofjoy.ru     → 127.0.0.1:8084  Mailpit      + basic auth
+```
 
 ## Workflow
 
@@ -113,7 +131,51 @@ exit
 
 После — workflow сам делает `sudo git pull` при каждом push в staging.
 
-### 7. Проверка
+### 7. Host nginx как reverse proxy (5 поддоменов)
+
+**Перед запуском убедись что DNS распространился:**
+
+```bash
+for sub in '' api. vhod. pma. mail.; do
+  echo -n "${sub}staging.spaceofjoy.ru: "
+  dig +short ${sub}staging.spaceofjoy.ru @8.8.8.8
+done
+# Должно вернуть 77.222.32.244 пять раз
+```
+
+Запуск:
+
+```bash
+# Локально — нужна вся директория infra/staging (включая nginx/sites-available/)
+scp -r infra/staging root@77.222.32.244:/tmp/
+ssh root@77.222.32.244 'bash /tmp/staging/setup-host-nginx.sh'
+```
+
+После — все 5 поддоменов на 80 порту, но возвращают 502 (контейнеры ещё нет).
+
+### 8. Basic auth для phpMyAdmin и Mailpit
+
+```bash
+ssh root@77.222.32.244 'bash /tmp/staging/setup-basic-auth.sh admin'
+# Введёшь пароль (без эха). Запиши его — пригодится для входа в pma/mail.
+```
+
+### 9. SSL через Let's Encrypt
+
+```bash
+ssh root@77.222.32.244 'bash /tmp/staging/setup-ssl.sh твой-email@example.com'
+```
+
+Скрипт сам:
+- Проверит распространение DNS
+- Проверит доступность `/.well-known/acme-challenge/`
+- Запросит сертификаты для всех 5 поддоменов
+- Настроит HTTP → HTTPS редирект
+- Включит auto-renew через `certbot.timer`
+
+Сертификаты обновляются автоматически за 30 дней до истечения.
+
+### 10. Проверка
 
 С локальной машины:
 

--- a/infra/staging/nginx/sites-available/api.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/api.staging.spaceofjoy.ru.conf
@@ -1,0 +1,32 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  api.staging.spaceofjoy.ru → Backend Laravel (контейнер на 127.0.0.1:8081)
+#
+#  CORS-заголовки добавляет само приложение через middleware.
+#  Здесь только проксирование.
+# ─────────────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.staging.spaceofjoy.ru;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass         http://127.0.0.1:8081;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;     # Долгие операции (генерация PDF, рассылка)
+        proxy_send_timeout 120s;
+    }
+
+    # Загрузка PDF / email-аттачментов
+    client_max_body_size 30M;
+
+    access_log /var/log/nginx/api.staging.spaceofjoy.ru.access.log;
+    error_log  /var/log/nginx/api.staging.spaceofjoy.ru.error.log;
+}

--- a/infra/staging/nginx/sites-available/mail.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/mail.staging.spaceofjoy.ru.conf
@@ -1,0 +1,40 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  mail.staging.spaceofjoy.ru → Mailpit (контейнер на 127.0.0.1:8084)
+#
+#  Перехватчик email — все письма приложения попадают сюда, не уходят реально.
+#  Защищено basic auth.
+#
+#  Backend/Baza используют SMTP-настройки:
+#    MAIL_HOST=mailpit-staging
+#    MAIL_PORT=1025
+#    MAIL_ENCRYPTION=null
+# ─────────────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name mail.staging.spaceofjoy.ru;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        auth_basic            "Staging tools — restricted";
+        auth_basic_user_file  /etc/nginx/auth/staging-tools.htpasswd;
+
+        proxy_pass            http://127.0.0.1:8084;
+        proxy_http_version    1.1;
+        proxy_set_header      Host              $host;
+        proxy_set_header      X-Real-IP         $remote_addr;
+        proxy_set_header      X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto $scheme;
+
+        # WebSocket для live-обновления списка писем в UI Mailpit
+        proxy_set_header      Upgrade           $http_upgrade;
+        proxy_set_header      Connection        "upgrade";
+        proxy_read_timeout    3600s;
+    }
+
+    access_log /var/log/nginx/mail.staging.spaceofjoy.ru.access.log;
+    error_log  /var/log/nginx/mail.staging.spaceofjoy.ru.error.log;
+}

--- a/infra/staging/nginx/sites-available/pma.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/pma.staging.spaceofjoy.ru.conf
@@ -1,0 +1,34 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  pma.staging.spaceofjoy.ru → phpMyAdmin (контейнер на 127.0.0.1:8083)
+#
+#  Защищено basic auth — `.htpasswd` создаётся скриптом setup-basic-auth.sh.
+#  Внутри phpMyAdmin тоже спрашивает логин/пароль БД.
+# ─────────────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name pma.staging.spaceofjoy.ru;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        auth_basic            "Staging tools — restricted";
+        auth_basic_user_file  /etc/nginx/auth/staging-tools.htpasswd;
+
+        proxy_pass            http://127.0.0.1:8083;
+        proxy_http_version    1.1;
+        proxy_set_header      Host              $host;
+        proxy_set_header      X-Real-IP         $remote_addr;
+        proxy_set_header      X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto $scheme;
+        proxy_read_timeout    60s;
+    }
+
+    # Для импорта больших дампов
+    client_max_body_size 100M;
+
+    access_log /var/log/nginx/pma.staging.spaceofjoy.ru.access.log;
+    error_log  /var/log/nginx/pma.staging.spaceofjoy.ru.error.log;
+}

--- a/infra/staging/nginx/sites-available/staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/staging.spaceofjoy.ru.conf
@@ -1,0 +1,34 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  staging.spaceofjoy.ru → Frontend (Vue SPA build, контейнер на 127.0.0.1:8080)
+#
+#  HTTP → 301 → HTTPS (после установки SSL через certbot).
+#  До установки SSL — работает на 80 порту.
+# ─────────────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name staging.spaceofjoy.ru;
+
+    # Для certbot http-challenge (renew)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_read_timeout 60s;
+    }
+
+    # Размер запросов (для загрузки файлов / PDF билетов)
+    client_max_body_size 20M;
+
+    access_log /var/log/nginx/staging.spaceofjoy.ru.access.log;
+    error_log  /var/log/nginx/staging.spaceofjoy.ru.error.log;
+}

--- a/infra/staging/nginx/sites-available/vhod.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/vhod.staging.spaceofjoy.ru.conf
@@ -1,0 +1,30 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  vhod.staging.spaceofjoy.ru → Baza (Laravel, контейнер на 127.0.0.1:8082)
+#
+#  Сервис аутентификации. На проде — baza.spaceofjoy.ru.
+#  Backend ходит сюда через APP_BAZA_URL.
+# ─────────────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    listen [::]:80;
+    server_name vhod.staging.spaceofjoy.ru;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass         http://127.0.0.1:8082;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    client_max_body_size 10M;
+
+    access_log /var/log/nginx/vhod.staging.spaceofjoy.ru.access.log;
+    error_log  /var/log/nginx/vhod.staging.spaceofjoy.ru.error.log;
+}

--- a/infra/staging/setup-basic-auth.sh
+++ b/infra/staging/setup-basic-auth.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  setup-basic-auth.sh
+#  Создаёт пользователя в /etc/nginx/auth/staging-tools.htpasswd
+#  для защиты phpMyAdmin и Mailpit.
+#
+#  Запускать на сервере как root:
+#      bash setup-basic-auth.sh [USERNAME]
+#
+#  Если USERNAME не передан — спросит интерактивно.
+#  Пароль читается из stdin (без эха).
+#
+#  Идемпотентен — можно перезапускать для смены пароля или добавления юзера.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+HTPASSWD_DIR="/etc/nginx/auth"
+HTPASSWD_FILE="$HTPASSWD_DIR/staging-tools.htpasswd"
+
+log()  { echo -e "\033[1;34m[auth]\033[0m $*"; }
+err()  { echo -e "\033[1;31m[err]\033[0m  $*" >&2; exit 1; }
+
+# ─── Sanity ───────────────────────────────────────────────────────────────────
+[[ "$EUID" -eq 0 ]] || err "Запускать от root"
+
+# Установить apache2-utils (даёт htpasswd) если ещё нет
+if ! command -v htpasswd >/dev/null; then
+    log "Устанавливаю apache2-utils (для команды htpasswd)…"
+    apt-get update -qq
+    apt-get install -y -qq apache2-utils
+fi
+
+# ─── Запросить логин/пароль ───────────────────────────────────────────────────
+USERNAME="${1:-}"
+if [[ -z "$USERNAME" ]]; then
+    read -rp "Логин для basic auth: " USERNAME
+fi
+[[ -n "$USERNAME" ]] || err "Логин не может быть пустым"
+[[ "$USERNAME" =~ ^[a-zA-Z0-9_-]+$ ]] || err "Логин может содержать только a-z, A-Z, 0-9, _, -"
+
+# ─── Создать или обновить ─────────────────────────────────────────────────────
+install -d -m 755 "$HTPASSWD_DIR"
+
+if [[ -f "$HTPASSWD_FILE" ]] && grep -q "^${USERNAME}:" "$HTPASSWD_FILE"; then
+    log "Пользователь '$USERNAME' уже есть — обновляю пароль"
+else
+    log "Добавляю нового пользователя '$USERNAME'"
+fi
+
+# -B = bcrypt (сильнее crypt по умолчанию), -c = создать файл если нет
+if [[ -f "$HTPASSWD_FILE" ]] && [[ -s "$HTPASSWD_FILE" ]]; then
+    htpasswd -B "$HTPASSWD_FILE" "$USERNAME"
+else
+    htpasswd -B -c "$HTPASSWD_FILE" "$USERNAME"
+fi
+
+chown root:www-data "$HTPASSWD_FILE"
+chmod 640 "$HTPASSWD_FILE"
+
+log "✓ htpasswd обновлён: $HTPASSWD_FILE"
+
+# Reload nginx чтобы новый htpasswd подхватился (обычно не нужен, но на всякий)
+if systemctl is-active --quiet nginx; then
+    systemctl reload nginx
+    log "✓ nginx reloaded"
+fi
+
+echo ""
+log "Готово."
+echo ""
+echo "  Файл:           $HTPASSWD_FILE"
+echo "  Пользователей:  $(wc -l < "$HTPASSWD_FILE")"
+echo ""
+echo "  Тест:"
+echo "    curl -u $USERNAME http://pma.staging.spaceofjoy.ru/"
+echo "    curl -u $USERNAME http://mail.staging.spaceofjoy.ru/"

--- a/infra/staging/setup-host-nginx.sh
+++ b/infra/staging/setup-host-nginx.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  setup-host-nginx.sh
+#  Настраивает host-nginx на staging как reverse proxy для 5 поддоменов.
+#
+#  Что делает:
+#    1. Бэкапит существующий default-конфиг
+#    2. Копирует наши server-блоки из infra/staging/nginx/sites-available/
+#    3. Создаёт symlinks в /etc/nginx/sites-enabled/
+#    4. Удаляет default (если он мешает)
+#    5. Готовит директорию /var/www/certbot для http-challenge SSL
+#    6. nginx -t (проверка) → systemctl reload
+#
+#  Запускать на сервере как root (без аргументов):
+#      bash setup-host-nginx.sh
+#
+#  Идемпотентен:
+#    - Бэкап делается только если ещё не было
+#    - Конфиги перезаписываются (можно править и перезапускать)
+#    - Symlinks обновляются
+#
+#  ВАЖНО:
+#    - DNS-записи должны уже распространиться (5 поддоменов → 77.222.32.244)
+#    - Этот скрипт настраивает только HTTP (порт 80).
+#      SSL ставится отдельным шагом — setup-ssl.sh.
+#    - Контейнеры на 8080-8084 ещё не запущены → upstream вернёт 502,
+#      это норма до следующего PR (docker-compose.staging.yml).
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NGINX_SITES_AVAILABLE="/etc/nginx/sites-available"
+NGINX_SITES_ENABLED="/etc/nginx/sites-enabled"
+BACKUP_DIR="/etc/nginx/backups/$(date +%Y%m%d-%H%M%S)"
+CERTBOT_WEBROOT="/var/www/certbot"
+
+SITES=(
+    "staging.spaceofjoy.ru"
+    "api.staging.spaceofjoy.ru"
+    "vhod.staging.spaceofjoy.ru"
+    "pma.staging.spaceofjoy.ru"
+    "mail.staging.spaceofjoy.ru"
+)
+
+log()  { echo -e "\033[1;34m[nginx]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[warn]\033[0m  $*" >&2; }
+err()  { echo -e "\033[1;31m[err]\033[0m   $*" >&2; exit 1; }
+
+# ─── Sanity ───────────────────────────────────────────────────────────────────
+[[ "$EUID" -eq 0 ]] || err "Запускать от root"
+command -v nginx >/dev/null || err "nginx не установлен"
+
+# Проверка что скрипт запускается из infra/staging/ (или содержит nginx/sites-available)
+CONF_SRC_DIR="${SCRIPT_DIR}/nginx/sites-available"
+if [[ ! -d "$CONF_SRC_DIR" ]]; then
+    err "Не найдена директория с конфигами: $CONF_SRC_DIR. Скопируй infra/staging целиком на сервер."
+fi
+
+# ─── 1. Бэкап ─────────────────────────────────────────────────────────────────
+log "Создаю бэкап текущей конфигурации в $BACKUP_DIR"
+mkdir -p "$BACKUP_DIR"
+cp -a "$NGINX_SITES_AVAILABLE" "$BACKUP_DIR/sites-available" 2>/dev/null || true
+cp -a "$NGINX_SITES_ENABLED"   "$BACKUP_DIR/sites-enabled"   2>/dev/null || true
+
+# ─── 2. Создать webroot для certbot ──────────────────────────────────────────
+log "Создаю $CERTBOT_WEBROOT для будущего ACME-challenge"
+mkdir -p "$CERTBOT_WEBROOT/.well-known/acme-challenge"
+chown -R www-data:www-data "$CERTBOT_WEBROOT"
+
+# ─── 3. Копируем конфиги ──────────────────────────────────────────────────────
+log "Копирую server-блоки в $NGINX_SITES_AVAILABLE"
+for site in "${SITES[@]}"; do
+    src="$CONF_SRC_DIR/${site}.conf"
+    dst="$NGINX_SITES_AVAILABLE/${site}.conf"
+    if [[ ! -f "$src" ]]; then
+        err "Нет конфига: $src"
+    fi
+    install -m 644 "$src" "$dst"
+    log "  ✓ $dst"
+done
+
+# ─── 4. Symlinks в sites-enabled ──────────────────────────────────────────────
+log "Активирую сайты (symlinks в $NGINX_SITES_ENABLED)"
+for site in "${SITES[@]}"; do
+    target="$NGINX_SITES_AVAILABLE/${site}.conf"
+    link="$NGINX_SITES_ENABLED/${site}.conf"
+    if [[ -L "$link" ]]; then
+        rm -f "$link"
+    fi
+    ln -s "$target" "$link"
+    log "  ✓ $link"
+done
+
+# ─── 5. Удалить default-конфиг (если есть) ────────────────────────────────────
+DEFAULT_LINK="$NGINX_SITES_ENABLED/default"
+if [[ -L "$DEFAULT_LINK" ]] || [[ -f "$DEFAULT_LINK" ]]; then
+    log "Удаляю default-конфиг (заглушку 'Welcome to nginx!')"
+    rm -f "$DEFAULT_LINK"
+fi
+
+# ─── 6. Создать пустой htpasswd-stub (чтобы nginx -t прошёл до setup-basic-auth) ─
+HTPASSWD_DIR="/etc/nginx/auth"
+HTPASSWD_FILE="$HTPASSWD_DIR/staging-tools.htpasswd"
+if [[ ! -f "$HTPASSWD_FILE" ]]; then
+    log "Создаю пустой htpasswd-stub (заполнится через setup-basic-auth.sh)"
+    install -d -m 755 "$HTPASSWD_DIR"
+    : > "$HTPASSWD_FILE"
+    chown root:www-data "$HTPASSWD_FILE"
+    chmod 640 "$HTPASSWD_FILE"
+    warn "phpMyAdmin и Mailpit недоступны до запуска setup-basic-auth.sh (пустой пароль = всех блочит)"
+fi
+
+# ─── 7. Проверка nginx -t и reload ────────────────────────────────────────────
+log "Проверка конфигурации nginx -t…"
+if ! nginx -t 2>&1; then
+    err "nginx -t упал. Откатывай из $BACKUP_DIR или правь конфиги."
+fi
+
+log "Reload nginx…"
+systemctl reload nginx
+log "✓ nginx перезагружен"
+
+# ─── 8. Итог ──────────────────────────────────────────────────────────────────
+echo ""
+log "════════════════════════════════════════════════════════"
+log "  Host nginx настроен как reverse proxy."
+log "════════════════════════════════════════════════════════"
+echo ""
+echo "  Активные сайты:"
+for site in "${SITES[@]}"; do
+    echo "    http://$site/"
+done
+echo ""
+echo "  Бэкап старой конфигурации:  $BACKUP_DIR"
+echo ""
+echo "  Следующие шаги:"
+echo "    1. bash setup-basic-auth.sh             # пароль для pma и mail"
+echo "    2. bash setup-ssl.sh                    # Let's Encrypt SSL"
+echo "    3. Развернуть docker compose staging   # следующий PR — контейнеры на 8080-8084"
+echo ""
+echo "  Сейчас все 5 поддоменов возвращают 502 Bad Gateway —"
+echo "  это нормально, контейнеры ещё не запущены."

--- a/infra/staging/setup-ssl.sh
+++ b/infra/staging/setup-ssl.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  setup-ssl.sh
+#  Устанавливает Let's Encrypt SSL для всех 5 поддоменов через certbot.
+#
+#  Использует http-challenge (без DNS) — нужно чтобы:
+#    - DNS уже резолвился (5 A-записей → 77.222.32.244)
+#    - host nginx уже слушал 80 порт с server_name на наши поддомены
+#    - /var/www/certbot/.well-known/acme-challenge/ был доступен
+#
+#  Если что-то из этого не готово — certbot вернёт fail и ничего не сломает
+#  (nginx-конфиги останутся как есть).
+#
+#  Запускать на сервере как root:
+#      bash setup-ssl.sh <admin-email>
+#
+#  Где admin-email — куда Let's Encrypt будет слать уведомления об истечении.
+#  Сертификаты автоматически продлеваются раз в 60 дней через systemd-таймер
+#  certbot.timer (включён по умолчанию при установке).
+#
+#  Идемпотентен:
+#    - Если сертификат уже есть — не запрашивает заново
+#    - Если истекает скоро — продлевает
+#    - Если конфиги уже изменены certbot'ом — не дублирует HTTPS-блоки
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ADMIN_EMAIL="${1:-}"
+DOMAINS=(
+    "staging.spaceofjoy.ru"
+    "api.staging.spaceofjoy.ru"
+    "vhod.staging.spaceofjoy.ru"
+    "pma.staging.spaceofjoy.ru"
+    "mail.staging.spaceofjoy.ru"
+)
+
+log()  { echo -e "\033[1;34m[ssl]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[warn]\033[0m $*" >&2; }
+err()  { echo -e "\033[1;31m[err]\033[0m  $*" >&2; exit 1; }
+
+# ─── Sanity ───────────────────────────────────────────────────────────────────
+[[ "$EUID" -eq 0 ]] || err "Запускать от root"
+[[ -n "$ADMIN_EMAIL" ]] || err "Передай email для Let's Encrypt: bash $0 you@example.com"
+[[ "$ADMIN_EMAIL" =~ ^[^@]+@[^@]+\.[^@]+$ ]] || err "Не похоже на email: $ADMIN_EMAIL"
+
+# ─── 1. Установка certbot + python3-certbot-nginx ─────────────────────────────
+if ! command -v certbot >/dev/null; then
+    log "Устанавливаю certbot…"
+    apt-get update -qq
+    apt-get install -y -qq certbot python3-certbot-nginx
+fi
+
+# ─── 2. Проверка DNS ──────────────────────────────────────────────────────────
+log "Проверяю распространение DNS…"
+SERVER_IP="$(curl -s -4 https://api.ipify.org || hostname -I | awk '{print $1}')"
+log "  IP этого сервера:  $SERVER_IP"
+DNS_OK=true
+for d in "${DOMAINS[@]}"; do
+    RESOLVED="$(dig +short "$d" @8.8.8.8 | head -1)"
+    if [[ "$RESOLVED" == "$SERVER_IP" ]]; then
+        log "  ✓ $d → $RESOLVED"
+    else
+        warn "  ✗ $d → '$RESOLVED' (ожидалось $SERVER_IP)"
+        DNS_OK=false
+    fi
+done
+if [[ "$DNS_OK" == false ]]; then
+    err "DNS не распространился для всех поддоменов. Жди 5-10 минут после создания A-записей."
+fi
+
+# ─── 3. Проверка что nginx слушает 80 и отдаёт ACME-challenge ─────────────────
+log "Проверяю что /.well-known доступен через HTTP…"
+mkdir -p /var/www/certbot/.well-known/acme-challenge
+TEST_FILE="test-$(date +%s)"
+echo "ok" > "/var/www/certbot/.well-known/acme-challenge/${TEST_FILE}"
+
+for d in "${DOMAINS[@]}"; do
+    if curl -fsSL "http://${d}/.well-known/acme-challenge/${TEST_FILE}" | grep -q "^ok$"; then
+        log "  ✓ $d → ACME challenge доступен"
+    else
+        rm -f "/var/www/certbot/.well-known/acme-challenge/${TEST_FILE}"
+        err "$d не отдаёт /.well-known/acme-challenge/. Проверь setup-host-nginx.sh."
+    fi
+done
+rm -f "/var/www/certbot/.well-known/acme-challenge/${TEST_FILE}"
+
+# ─── 4. Запрос сертификатов ───────────────────────────────────────────────────
+# Каждому домену — отдельный сертификат (проще управление).
+# Можно одной командой выпустить SAN, но при добавлении/удалении домена
+# нужно перевыпускать целиком — менее гибко.
+log "Запрашиваю сертификаты Let's Encrypt…"
+CERTBOT_ARGS=(
+    --nginx
+    --non-interactive
+    --agree-tos
+    --email "$ADMIN_EMAIL"
+    --redirect          # HTTP → HTTPS автоматически
+    --no-eff-email
+)
+
+for d in "${DOMAINS[@]}"; do
+    log "  Запрашиваю $d…"
+    if certbot certificates 2>/dev/null | grep -A1 "Domains:" | grep -qE "(^|[ ])${d}([ ]|$)"; then
+        log "    ✓ Уже выпущен — пропускаю (certbot.timer обновит автоматически)"
+    else
+        certbot "${CERTBOT_ARGS[@]}" -d "$d"
+    fi
+done
+
+# ─── 5. Auto-renew systemd-таймер ─────────────────────────────────────────────
+if systemctl is-enabled --quiet certbot.timer 2>/dev/null; then
+    log "✓ certbot.timer активен — auto-renew работает"
+else
+    log "Включаю certbot.timer"
+    systemctl enable --now certbot.timer
+fi
+
+# ─── 6. Итог ──────────────────────────────────────────────────────────────────
+echo ""
+log "════════════════════════════════════════════════════════"
+log "  SSL установлен и настроен."
+log "════════════════════════════════════════════════════════"
+echo ""
+echo "  Сертификаты:"
+certbot certificates 2>/dev/null | grep -E "(Certificate Name|Domains|Expiry)" | sed 's/^/    /'
+echo ""
+echo "  HTTPS URL'ы:"
+for d in "${DOMAINS[@]}"; do
+    echo "    https://$d/"
+done
+echo ""
+echo "  Auto-renew:  systemctl list-timers certbot.timer"
+echo "  Тест renew:  certbot renew --dry-run"


### PR DESCRIPTION
## Что в PR

Подготовка host nginx на staging-сервере под 5 поддоменов с автоматическим SSL.

### Архитектура

\`\`\`
[Internet:80/443]
       │
  [HOST NGINX] (Let's Encrypt SSL)
       │
       ├─ staging.spaceofjoy.ru          → 127.0.0.1:8080  Frontend
       ├─ api.staging.spaceofjoy.ru      → 127.0.0.1:8081  Backend
       ├─ vhod.staging.spaceofjoy.ru     → 127.0.0.1:8082  Baza
       ├─ pma.staging.spaceofjoy.ru      → 127.0.0.1:8083  phpMyAdmin   + basic auth
       └─ mail.staging.spaceofjoy.ru     → 127.0.0.1:8084  Mailpit      + basic auth
\`\`\`

### Что добавлено

- **5 nginx конфигов** (\`infra/staging/nginx/sites-available/*.conf\`)
  - HTTP сервер блоки с proxy_pass на localhost:808X
  - Location \`/.well-known/acme-challenge/\` для certbot
  - client_max_body_size настроен под нужды (Backend 30M для PDF/email,
    phpMyAdmin 100M для импорта дампов)
  - pma и mail защищены через \`auth_basic\` + общий htpasswd

- **\`setup-host-nginx.sh\`** — устанавливает конфиги:
  - Бэкап старой конфигурации в \`/etc/nginx/backups/YYYYMMDD-HHMMSS/\`
  - Копирует server-блоки в \`sites-available\` + symlinks в \`sites-enabled\`
  - Удаляет default (\"Welcome to nginx!\")
  - Создаёт пустой htpasswd-stub (чтобы \`nginx -t\` прошёл до basic-auth)
  - Проверка \`nginx -t\` → \`systemctl reload\`

- **\`setup-basic-auth.sh\`** — htpasswd:
  - Устанавливает apache2-utils если нет
  - Bcrypt-пароль (-B флаг)
  - Идемпотентен — повторный запуск обновляет пароль

- **\`setup-ssl.sh\`** — Let's Encrypt:
  - **Проверяет DNS** для всех 5 доменов через 8.8.8.8 ДО запроса cert
  - **Проверяет ACME challenge** доступность через curl ДО запроса cert
    (защита от rate-limit Let's Encrypt — 5 failed/час/account)
  - Сертификаты выпускаются по одному (проще управление, гибко при добавлении)
  - Включает \`certbot.timer\` для auto-renew

### Порядок установки (из README)

\`\`\`bash
# 1. Проверка DNS (после создания A-записей)
for sub in '' api. vhod. pma. mail.; do
  echo -n \"\${sub}staging.spaceofjoy.ru: \"
  dig +short \${sub}staging.spaceofjoy.ru @8.8.8.8
done

# 2. Копируем директорию на сервер
scp -r infra/staging root@77.222.32.244:/tmp/

# 3. Поднимаем nginx (502 на всех — норма, контейнеров ещё нет)
ssh root@77.222.32.244 'bash /tmp/staging/setup-host-nginx.sh'

# 4. Логин/пароль для pma и mail
ssh root@77.222.32.244 'bash /tmp/staging/setup-basic-auth.sh admin'

# 5. SSL
ssh root@77.222.32.244 'bash /tmp/staging/setup-ssl.sh твой-email@example.com'
\`\`\`

## Что НЕ в этом PR

- \`docker-compose.staging.yml\` — следующий PR
- Обновление \`deploy-staging.yml\` — финальный PR

## Test plan

- [ ] Реви \`nginx/sites-available/*.conf\` — корректные proxy_pass, basic-auth
- [ ] Реви \`setup-ssl.sh\` — проверки ДО запроса cert (защита от rate-limit)
- [ ] DNS-записи созданы (5 шт.)
- [ ] Запустить setup-host-nginx.sh → 5 поддоменов отвечают 502 (норма)
- [ ] Запустить setup-basic-auth.sh → htpasswd создан
- [ ] Запустить setup-ssl.sh → 5 сертификатов выпущены, HTTPS работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)