### PR TITLE
chore(infra): docker-compose.staging.yml + nginx + env templates

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,22 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  .env.staging
+#
+#  Переменные для docker-compose.staging.yml (top-level).
+#  Не путать с Backend/.env и Baza/.env — это разные файлы.
+#
+#  При первом деплое:
+#    cp .env.staging.example .env.staging
+#    # отредактировать пароли
+#
+#  Файл .env.staging НЕ коммитится в git (см. .gitignore).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# === MySQL ===================================================================
+MYSQL_DATABASE=systo
+MYSQL_USER=systo
+MYSQL_PASSWORD=staging_secret_CHANGE_ME
+MYSQL_ROOT_PASSWORD=staging_root_secret_CHANGE_ME
+
+# === Baza (на тот же MySQL, но другая БД) ===================================
+# Базу создаст migration / seeder, главное чтобы пользователь имел право CREATE
+BAZA_DB_DATABASE=baza

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/*
 .env
 .env.production
+.env.staging
 .env.testing
 .env.local
 /Backend/phpunit.xml.dist

--- a/Backend/.env.staging.example
+++ b/Backend/.env.staging.example
@@ -1,0 +1,51 @@
+APP_NAME=SolarSysto
+APP_ENV=staging
+APP_KEY=
+APP_DEBUG=true
+APP_URL=https://api.staging.spaceofjoy.ru
+APP_FRONT_URL=https://staging.spaceofjoy.ru
+APP_BAZA_URL=https://vhod.staging.spaceofjoy.ru
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+# === DB (общий MySQL контейнер на staging) ===================================
+DB_CONNECTION=mysql
+DB_HOST=mysql-staging
+DB_PORT=3306
+DB_DATABASE=systo
+DB_USERNAME=systo
+DB_PASSWORD=staging_secret_CHANGE_ME
+
+BROADCAST_DRIVER=log
+CACHE_DRIVER=redis
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=database
+SESSION_DRIVER=redis
+SESSION_LIFETIME=120
+
+# === Redis ===================================================================
+REDIS_HOST=redis-staging
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+# === Mail (через Mailpit — перехватчик в web UI) =============================
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit-staging
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_NAME="SolarSysto Staging"
+MAIL_FROM_ADDRESS=staging@spaceofjoy.ru
+
+# === JWT (свежий токен для staging) ==========================================
+JWT_SECRET=
+
+# === Auto payment (для теста AutoPayment header) =============================
+AUTO_PAYMENT_TOKEN=staging_auto_payment_token
+
+# === Sentry (опционально) ====================================================
+SENTRY_LARAVEL_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0

--- a/Baza/.env.staging.example
+++ b/Baza/.env.staging.example
@@ -1,0 +1,35 @@
+APP_NAME="Baza Staging"
+APP_ENV=staging
+APP_KEY=
+APP_DEBUG=true
+APP_URL=https://vhod.staging.spaceofjoy.ru
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+# === DB (тот же MySQL контейнер, отдельная БД) ==============================
+DB_CONNECTION=mysql
+DB_HOST=mysql-staging
+DB_PORT=3306
+DB_DATABASE=baza
+DB_USERNAME=systo
+DB_PASSWORD=staging_secret_CHANGE_ME
+
+BROADCAST_DRIVER=log
+CACHE_DRIVER=file
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=file
+SESSION_LIFETIME=120
+
+REDIS_HOST=redis-staging
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit-staging
+MAIL_PORT=1025
+MAIL_ENCRYPTION=null
+MAIL_FROM_NAME="Baza Staging"
+MAIL_FROM_ADDRESS=baza-staging@spaceofjoy.ru

--- a/Docker/nginx/default.staging.conf
+++ b/Docker/nginx/default.staging.conf
@@ -1,0 +1,83 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  Docker nginx — конфигурация для STAGING.
+#
+#  Один nginx-контейнер обслуживает 3 поддомена через server_name routing.
+#  Host nginx (на сервере, с SSL) проксирует все 3 поддомена сюда на :80,
+#  передавая правильный Host header. Этот nginx сам не делает SSL — он внутри
+#  docker (HTTP only).
+#
+#  Связь со staging:
+#   - api.staging.spaceofjoy.ru   → Backend (Laravel)
+#   - vhod.staging.spaceofjoy.ru  → Baza (Laravel)
+#   - staging.spaceofjoy.ru       → Frontend (Vue SPA из dist/)
+#
+#  В отличие от dev/prod default.conf — здесь нет SSL listen, нет redirect
+#  на HTTPS (этим занимается host nginx с Let's Encrypt сертификатами).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══ API (Backend SolarSysto) ════════════════════════════════════════════════
+server {
+    listen      80;
+    server_name api.staging.spaceofjoy.ru;
+
+    root  /var/www/org/public;
+    index index.php;
+
+    location / {
+        try_files $uri /index.php$is_args$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass            php-staging:9000;
+        fastcgi_index           index.php?$args;
+        include                 fastcgi_params;
+        fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size     16k;
+        fastcgi_buffers         4 16k;
+        fastcgi_read_timeout    120s;
+    }
+
+    # Host nginx уже добавляет X-Forwarded-Proto — приложение видит https
+    client_max_body_size 30M;
+}
+
+# ═══ VHOD (Baza — аутентификация) ════════════════════════════════════════════
+server {
+    listen      80;
+    server_name vhod.staging.spaceofjoy.ru;
+
+    root  /var/www/vhod/public;
+    index index.php index.html;
+
+    location / {
+        try_files $uri /index.php$is_args$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass            phpbaza-staging:9000;
+        fastcgi_index           index.php?$args;
+        include                 fastcgi_params;
+        fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size     16k;
+        fastcgi_buffers         4 16k;
+        fastcgi_read_timeout    60s;
+    }
+
+    client_max_body_size 10M;
+}
+
+# ═══ FRONTEND (Vue SPA — статика из dist/) ═══════════════════════════════════
+server {
+    listen      80 default_server;
+    server_name staging.spaceofjoy.ru;
+    charset     utf-8;
+
+    location / {
+        root      /var/www/app/dist;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,202 @@
+# ─────────────────────────────────────────────────────────────────────────────
+#  docker-compose.staging.yml
+#
+#  STAGING-окружение на 77.222.32.244.
+#  Host nginx (на сервере) делает SSL + reverse proxy на эти контейнеры.
+#  Все контейнеры биндятся ТОЛЬКО на 127.0.0.1 — публично торчит только host nginx.
+#
+#  Поддомены:
+#   - api.staging.spaceofjoy.ru   → backend (nginx-staging → php-staging)
+#   - vhod.staging.spaceofjoy.ru  → baza    (nginx-staging → phpbaza-staging)
+#   - staging.spaceofjoy.ru       → frontend (nginx-staging serves FrontEnd/dist)
+#   - pma.staging.spaceofjoy.ru   → phpmyadmin (port 8083)
+#   - mail.staging.spaceofjoy.ru  → mailpit web UI (port 8084)
+#
+#  Запуск (вручную или из workflow):
+#    cd /var/www/systo
+#    docker compose -f docker-compose.staging.yml --env-file .env.staging build
+#    docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+#
+#  TD-1 (race condition воркера): mysql-staging имеет healthcheck,
+#  worker и app зависят с condition: service_healthy.
+# ─────────────────────────────────────────────────────────────────────────────
+version: '3.8'
+
+services:
+
+  # ═══ NGINX (3 поддомена, без SSL — host nginx делает SSL) ══════════════════
+  nginx-staging:
+    build:
+      context: ./Docker/nginx
+    container_name: nginx-staging
+    # Сбрасываем prod entrypoint (с envsubst) — у нас готовый default.staging.conf
+    entrypoint: []
+    command: ["nginx", "-g", "daemon off;"]
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - ./Docker/nginx/default.staging.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./Docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./Backend:/var/www/org
+      - ./FrontEnd:/var/www/app
+      - ./Shared:/var/www/Shared
+      - ./Baza:/var/www/vhod
+    networks:
+      - staging
+    depends_on:
+      - php-staging
+      - phpbaza-staging
+    restart: unless-stopped
+
+  # ═══ BACKEND (php-fpm SolarSysto) ══════════════════════════════════════════
+  php-staging:
+    build:
+      context: ./Docker/php
+      args:
+        - WITH_XDEBUG=false
+    container_name: php-staging
+    env_file:
+      - ./Backend/.env
+    volumes:
+      - ./Backend:/var/www/org
+      - ./Shared:/var/www/Shared
+    working_dir: /var/www/org
+    environment:
+      - WITH_XDEBUG=false
+      - WORKING_DIR=/var/www/org
+    networks:
+      - staging
+    depends_on:
+      mysql-staging:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ═══ BAZA (php-fpm аутентификации) ═════════════════════════════════════════
+  phpbaza-staging:
+    build:
+      context: ./Docker/php
+      args:
+        - WITH_XDEBUG=false
+    container_name: phpbaza-staging
+    env_file:
+      - ./Baza/.env
+    volumes:
+      - ./Baza:/var/www/vhod
+      - ./Shared:/var/www/Shared
+    working_dir: /var/www/vhod
+    environment:
+      - WITH_XDEBUG=false
+      - WORKING_DIR=/var/www/vhod
+    networks:
+      - staging
+    depends_on:
+      mysql-staging:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ═══ FRONTEND (Vue build, dist раздаётся через nginx) ══════════════════════
+  # Build делается через `docker compose run --rm node-staging sh -c "npm ci && npm run build"`
+  # — выполняется в workflow перед `up -d`.
+  node-staging:
+    build:
+      context: ./Docker/node
+    container_name: node-staging
+    working_dir: /var/www/app
+    volumes:
+      - ./FrontEnd:/var/www/app
+    command: tail -f /dev/null
+    networks:
+      - staging
+    environment:
+      - NODE_ENV=production
+      - VUE_APP_API_URL=https://api.staging.spaceofjoy.ru/
+      - VUE_APP_BAZA_URL=https://vhod.staging.spaceofjoy.ru/
+    restart: unless-stopped
+
+  # ═══ MYSQL 8 (internal, persistent volume) ═════════════════════════════════
+  mysql-staging:
+    image: mysql:8
+    container_name: mysql-staging
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-systo}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-staging_root_secret}
+      MYSQL_USER: ${MYSQL_USER:-systo}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-staging_secret}
+    volumes:
+      - mysql-staging-data:/var/lib/mysql
+    networks:
+      - staging
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD:-staging_root_secret}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ═══ REDIS (internal, кэш + очереди) ═══════════════════════════════════════
+  redis-staging:
+    image: redis:7-alpine
+    container_name: redis-staging
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-staging-data:/data
+    networks:
+      - staging
+    restart: unless-stopped
+
+  # ═══ WORKER (Laravel queue worker для Backend) ═════════════════════════════
+  worker-staging:
+    build:
+      context: ./Docker/worker
+    container_name: worker-staging
+    image: 'laravelworker'
+    volumes:
+      - ./Backend:/var/www/org
+      - ./Shared:/var/www/Shared
+      - ./Docker/php/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
+      - ./Docker/worker/conf/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
+    command: ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+    networks:
+      - staging
+    depends_on:
+      mysql-staging:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ═══ PHPMYADMIN (веб-интерфейс к MySQL) ════════════════════════════════════
+  phpmyadmin-staging:
+    image: phpmyadmin/phpmyadmin:5
+    container_name: phpmyadmin-staging
+    environment:
+      PMA_HOST: mysql-staging
+      PMA_PORT: 3306
+      UPLOAD_LIMIT: 100M
+    ports:
+      - "127.0.0.1:8083:80"
+    networks:
+      - staging
+    depends_on:
+      mysql-staging:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ═══ MAILPIT (SMTP-перехватчик + web UI) ═══════════════════════════════════
+  # SMTP — внутренний (1025), для приложений: MAIL_HOST=mailpit-staging.
+  # Web UI — наружу (8084) для просмотра писем.
+  mailpit-staging:
+    image: axllent/mailpit:latest
+    container_name: mailpit-staging
+    ports:
+      - "127.0.0.1:8084:8025"
+    networks:
+      - staging
+    restart: unless-stopped
+
+volumes:
+  mysql-staging-data:
+  redis-staging-data:
+
+networks:
+  staging:
+    driver: bridge

--- a/infra/staging/README.md
+++ b/infra/staging/README.md
@@ -175,7 +175,64 @@ ssh root@77.222.32.244 'bash /tmp/staging/setup-ssl.sh твой-email@example.co
 
 Сертификаты обновляются автоматически за 30 дней до истечения.
 
-### 10. Проверка
+### 10. Docker-compose staging
+
+После того как host nginx + SSL настроены (шаги 1-9), приложение разворачивается через `docker-compose.staging.yml`.
+
+#### 10.1. Подготовка .env файлов (один раз на сервере)
+
+```bash
+ssh -i ~/.ssh/gha_deploy deploy@77.222.32.244 << 'EOF'
+cd /var/www/systo
+cp .env.staging.example          .env.staging
+cp Backend/.env.staging.example  Backend/.env
+cp Baza/.env.staging.example     Baza/.env
+
+# Заменить CHANGE_ME на сильные пароли
+sed -i "s/staging_secret_CHANGE_ME/$(openssl rand -hex 16)/g" .env.staging Backend/.env Baza/.env
+sed -i "s/staging_root_secret_CHANGE_ME/$(openssl rand -hex 16)/g" .env.staging
+
+# Сгенерировать APP_KEY через контейнер (после build'a)
+docker compose -f docker-compose.staging.yml --env-file .env.staging build
+docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm php-staging php artisan key:generate --force --no-interaction
+docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm phpbaza-staging php artisan key:generate --force --no-interaction
+EOF
+```
+
+#### 10.2. Build frontend (один раз и при изменениях)
+
+```bash
+ssh -i ~/.ssh/gha_deploy deploy@77.222.32.244 'cd /var/www/systo && docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm node-staging sh -c "npm ci && npm run build"'
+```
+
+#### 10.3. Запуск всех контейнеров
+
+```bash
+ssh -i ~/.ssh/gha_deploy deploy@77.222.32.244 'cd /var/www/systo && docker compose -f docker-compose.staging.yml --env-file .env.staging up -d'
+```
+
+#### 10.4. Миграции + сидеры
+
+```bash
+ssh -i ~/.ssh/gha_deploy deploy@77.222.32.244 << 'EOF'
+cd /var/www/systo
+docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T php-staging php artisan migrate --force --no-interaction
+docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T php-staging php artisan db:seed --force --no-interaction
+docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T phpbaza-staging php artisan migrate --force --no-interaction
+EOF
+```
+
+#### 10.5. Проверка
+
+| URL | Ожидаемо |
+|-----|----------|
+| `https://staging.spaceofjoy.ru/` | Vue SPA фронтенд |
+| `https://api.staging.spaceofjoy.ru/` | Laravel API ответ |
+| `https://vhod.staging.spaceofjoy.ru/` | Baza интерфейс |
+| `https://pma.staging.spaceofjoy.ru/` | phpMyAdmin (basic auth + MySQL auth) |
+| `https://mail.staging.spaceofjoy.ru/` | Mailpit web UI (basic auth) |
+
+### 11. Проверка SSH
 
 С локальной машины:
 

--- a/infra/staging/nginx/sites-available/api.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/api.staging.spaceofjoy.ru.conf
@@ -14,7 +14,10 @@ server {
     }
 
     location / {
-        proxy_pass         http://127.0.0.1:8081;
+        # Все 3 app-поддомена (api / vhod / staging) идут на один docker nginx
+        # внутри docker — он маршрутизирует по Host header (server_name).
+        # См. Docker/nginx/default.staging.conf.
+        proxy_pass         http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;

--- a/infra/staging/nginx/sites-available/vhod.staging.spaceofjoy.ru.conf
+++ b/infra/staging/nginx/sites-available/vhod.staging.spaceofjoy.ru.conf
@@ -14,7 +14,10 @@ server {
     }
 
     location / {
-        proxy_pass         http://127.0.0.1:8082;
+        # Все 3 app-поддомена (api / vhod / staging) идут на один docker nginx
+        # внутри docker — он маршрутизирует по Host header (server_name).
+        # См. Docker/nginx/default.staging.conf.
+        proxy_pass         http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
## Что в PR

Полная docker-конфигурация staging-окружения. 8 контейнеров, всё на 127.0.0.1.

### Архитектура

\`\`\`
[Host nginx 443] (SSL: Let's Encrypt)
       │
       ├─ api.staging.spaceofjoy.ru   ─┐
       ├─ vhod.staging.spaceofjoy.ru  ─┼→ 127.0.0.1:8080 (один nginx-staging)
       ├─ staging.spaceofjoy.ru       ─┘   маршрутизирует по server_name
       │
       ├─ pma.staging.spaceofjoy.ru   → 127.0.0.1:8083 (phpmyadmin)
       └─ mail.staging.spaceofjoy.ru  → 127.0.0.1:8084 (mailpit UI)

[Docker network: staging]
  - nginx-staging        (server_name routing для 3 поддоменов)
  - php-staging          (Backend PHP-FPM)
  - phpbaza-staging      (Baza PHP-FPM)
  - node-staging         (Vue build через run --rm)
  - mysql-staging        (volume, healthcheck)
  - redis-staging        (volume)
  - worker-staging       (Laravel queue worker через supervisord, depends_on mysql healthy)
  - phpmyadmin-staging   (127.0.0.1:8083)
  - mailpit-staging      (127.0.0.1:8084 UI + internal 1025 SMTP)
\`\`\`

### Изменения в host nginx (поправка PR #46)

В PR #46 каждый app-поддомен шёл на разный порт (8080/8081/8082). Но в prod-структуре все 3 app обслуживает один nginx через server_name. Адаптировал staging аналогично:
- api.staging.* → 127.0.0.1:8080 (было 8081)
- vhod.staging.* → 127.0.0.1:8080 (было 8082)
- staging.* → 127.0.0.1:8080 (то же)

Это значит после merge — нужно **повторно запустить** \`setup-host-nginx.sh\` на сервере чтобы подтянул обновлённые конфиги.

### .env шаблоны

- **\`.env.staging.example\`** (корневой) — MYSQL_* для docker-compose
- **\`Backend/.env.staging.example\`** — staging-конфиг Laravel:
  - APP_ENV=staging, APP_DEBUG=true (для отладки)
  - MAIL_HOST=mailpit-staging:1025 (письма перехватываются)
  - APP_BAZA_URL=https://vhod.staging.spaceofjoy.ru
- **\`Baza/.env.staging.example\`** — БД baza, тот же MySQL

\`.env.staging\` добавлен в \`.gitignore\` (в git только .example шаблоны).

### Docker/nginx/default.staging.conf

Конфиг для контейнерного nginx:
- 3 server-блока на :80 (host nginx делает SSL)
- API/Baza → fastcgi_pass на php-fpm контейнеры
- Frontend → static из /var/www/app/dist

## Что НЕ в этом PR

- Обновление \`.github/workflows/deploy-staging.yml\` — отдельный PR
- Полный деплой требует ручных шагов (build, key:generate, npm build)
- README §10 содержит пошаговую инструкцию ручного запуска

## Test plan

- [ ] Реви \`docker-compose.staging.yml\` (особенно healthcheck mysql)
- [ ] Реви \`default.staging.conf\` (server_name + fastcgi_pass)
- [ ] Реви \`Backend/.env.staging.example\` — корректные URL и хосты
- [ ] После merge: запустить заново \`setup-host-nginx.sh\` для обновления портов
- [ ] Запустить шаги 10.1-10.4 README на staging-сервере
- [ ] Проверить https://staging.spaceofjoy.ru/ → Vue SPA вместо 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)