### PR TITLE
fix(infra): YAML syntax в deploy-staging.yml

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Show deployed commit
         working-directory: ${{ env.PROJECT_DIR }}
-        run: git log -1 --pretty=format:"%h %s%n%nAuthor: %an <%ae>%nDate:   %ad" --date=short
+        run: |
+          git log -1 --pretty=format:'%h %s%n%nAuthor: %an <%ae>%nDate:   %ad' --date=short
 
       # ─── Bootstrap .env при первом деплое ──────────────────────────────────
       - name: Bootstrap .env.staging (first deploy)


### PR DESCRIPTION
## Что фиксит

Run #4 на master упал at 0s с сообщением "This run likely failed because of a workflow file issue."

YAML parser давился на двоеточии в \`git log --pretty=format:"... Date: %ad"\` — он воспринимал \`Date:\` как ключ map'а.

## Решение

Обернуть команду в pipe-block \`|\` — YAML тогда трактует значение как multi-line literal без интерпретации \`:\`, и shell получает строку как есть.

## Test

\`\`\`bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml')); print('OK')"
# ✓ YAML OK
\`\`\`

После мержа можно запустить workflow вручную через UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)