### PR TITLE
fix(infra): подмена entrypoint для key:generate (CI висел 15+ мин)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -165,12 +165,15 @@ jobs:
         run: |
           docker compose -f docker-compose.staging.yml --env-file .env.staging build
 
+      # ⚠ ENTRYPOINT в Docker/php/Dockerfile хардкодит запуск php-fpm и игнорирует
+      # переданную команду — поэтому для `run` подменяем entrypoint на `sh`.
+      # На уже запущенный контейнер можно ходить через `exec` без подмены.
       - name: Generate APP_KEY for Backend (if missing)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
           if ! grep -qE "^APP_KEY=base64:" Backend/.env; then
             echo "APP_KEY пуст — генерирую…"
-            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps php-staging php artisan key:generate --force --no-interaction
+            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "php artisan key:generate --force --no-interaction"
           else
             echo "✓ APP_KEY уже есть"
           fi
@@ -180,7 +183,7 @@ jobs:
         run: |
           if ! grep -qE "^APP_KEY=base64:" Baza/.env; then
             echo "APP_KEY (Baza) пуст — генерирую…"
-            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps phpbaza-staging php artisan key:generate --force --no-interaction
+            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh phpbaza-staging -c "php artisan key:generate --force --no-interaction"
           else
             echo "✓ APP_KEY (Baza) уже есть"
           fi


### PR DESCRIPTION
## Что было

Build #8 deploy-staging завис на 15 минут на шаге `Generate APP_KEY for Backend (if missing)`. Логи показали что php-fpm запустился (`fpm is running, pid 8`), а команда `php artisan key:generate` не выполнилась.

## Корень

\`Docker/php/docker-entrypoint.sh\` хардкодит \`/usr/local/sbin/php-fpm -F\` и игнорирует переданную команду:

\`\`\`sh
#!/usr/bin/env sh
echo "xdebug"
if [ "\${WITH_XDEBUG}" = "true" ]; then ...; fi
/usr/local/sbin/php-fpm -F   # ← всегда php-fpm, игнорит \$@
\`\`\`

Поэтому \`docker compose run ... php artisan key:generate\` запускает php-fpm и висит вечно.

## Фикс

В шагах \`run\` для key:generate подменяю entrypoint на \`sh\`:

\`\`\`yaml
docker compose run --rm --no-deps --entrypoint sh php-staging -c "php artisan key:generate --force --no-interaction"
\`\`\`

Шаги \`exec\` (миграции, сидеры) не затронуты — \`exec\` идёт в уже запущенный контейнер и игнорирует ENTRYPOINT.

## Почему не правлю docker-entrypoint.sh

Он используется и в prod (Docker/php/Dockerfile общий для всех окружений). Менять \`exec \"\$@\"\` pattern сейчас — большой риск регрессии. Локализую фикс в CD-пайплайне.

## Будущее улучшение

Можно вынести в TD: переписать \`docker-entrypoint.sh\` на pattern \`exec "\$@"\` (если \$# > 0) → запускать команду, иначе → php-fpm. Это правильная reusable форма entrypoint'а. Но это отдельная задача с тестами.

## Что дальше после мержа

\`\`\`bash
git push origin origin/master:refs/heads/staging  # auto-trigger workflow
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)