### PR TITLE
fix(infra): composer install перед key:generate в deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -168,6 +168,26 @@ jobs:
       # ⚠ ENTRYPOINT в Docker/php/Dockerfile хардкодит запуск php-fpm и игнорирует
       # переданную команду — поэтому для `run` подменяем entrypoint на `sh`.
       # На уже запущенный контейнер можно ходить через `exec` без подмены.
+      - name: Composer install (Backend)
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          if [[ ! -f Backend/vendor/autoload.php ]]; then
+            echo "vendor/ отсутствует — устанавливаю зависимости…"
+            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist"
+          else
+            echo "✓ Backend/vendor уже есть — пропускаю"
+          fi
+
+      - name: Composer install (Baza)
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          if [[ ! -f Baza/vendor/autoload.php ]]; then
+            echo "vendor/ (Baza) отсутствует — устанавливаю зависимости…"
+            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh phpbaza-staging -c "composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist"
+          else
+            echo "✓ Baza/vendor уже есть — пропускаю"
+          fi
+
       - name: Generate APP_KEY for Backend (if missing)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |


### PR DESCRIPTION
## Что было

Build #9 deploy-staging упал на \`Generate APP_KEY for Backend\`:

\`\`\`
Failed to open stream: /var/www/org/vendor/autoload.php No such file or directory
\`\`\`

## Корень

В первой версии workflow забыл шаг \`composer install\`. Без \`vendor/\` artisan не загружается → key:generate падает.

## Фикс

Добавил два шага **перед** \`Generate APP_KEY\`:
- \`Composer install (Backend)\` — \`composer install --no-dev --optimize-autoloader\`
- \`Composer install (Baza)\` — то же

Идемпотентность: если \`vendor/autoload.php\` уже есть — пропускаю. На второй+ деплой композер вообще не запускается (если composer.lock не изменился — что чекается через наличие autoload.php; не идеально, но достаточно для безопасности).

Используем \`--entrypoint sh\` (как для key:generate) — entrypoint php-Dockerfile'а хардкодит php-fpm.

## TD на будущее

В composer install через \`--no-dev\` мы не получаем dev-зависимостей. Для запуска тестов на staging нужно будет либо отдельный шаг \`composer install --dev\`, либо отдельный образ. Пока тесты гоняем в CI на GHA-hosted runner, так что не критично.

🤖 Generated with [Claude Code](https://claude.com/claude-code)