### PR TITLE
fix(backend): убрать дублирующуюся регистрацию IdeHelperServiceProvider

### DIFF
--- a/Backend/config/app.php
+++ b/Backend/config/app.php
@@ -194,7 +194,6 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
-        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
         Barryvdh\DomPDF\ServiceProvider::class,
 
 


### PR DESCRIPTION
## Что было

Build #10 deploy-staging упал на \`Composer install (Backend)\`:

\`\`\`
In ProviderRepository.php line 208:
  Class "Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" not found
Script @php artisan package:discover --ansi handling the post-autoload-dump
event returned with error code 1
\`\`\`

## Корень

Пакет \`barryvdh/laravel-ide-helper\` правильно лежит в \`composer.json:require-dev\` — он нужен только для dev.

Но в \`Backend/config/app.php:197\` он зарегистрирован **безусловно**:

\`\`\`php
App\Providers\RouteServiceProvider::class,
Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,   // ← баг
Barryvdh\DomPDF\ServiceProvider::class,
\`\`\`

При этом в \`AppServiceProvider::register()\` он же регается **условно** (правильно):

\`\`\`php
if (\$this->app->isLocal()) {
    \$this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
}
\`\`\`

На staging с \`composer install --no-dev\` пакет не ставится → \`package:discover\` ищет class → падает.

## Фикс

Убираю безусловную регистрацию из \`config/app.php\`. \`AppServiceProvider\` продолжает регистрировать провайдер только в local-окружении.

## Что меняется

| Окружение | До | После |
|-----------|-----|-------|
| **local** (полный composer install) | Регается через config/app.php **и** через AppServiceProvider | Регается только через AppServiceProvider (без изменений в поведении) |
| **prod / staging** (--no-dev) | Падает на package:discover | Не регается, ничего не падает |

## Проверка

Локально \`./vendor/bin/phpunit\`: **55 тестов / 128 ассертов / 4 skipped** — без регрессов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)