### PR TITLE
fix(baza): убрать дублирующуюся регистрацию IdeHelperServiceProvider (зеркало #53)

### DIFF
--- a/Baza/config/app.php
+++ b/Baza/config/app.php
@@ -189,7 +189,6 @@ return [
         /*
          * Application Service Providers...
          */
-        Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,


### PR DESCRIPTION
## Что было

Build #11 deploy-staging упал на \`Composer install (Baza)\` ровно с такой же ошибкой что закрыта в Backend через #53:

\`\`\`
In ProviderRepository.php line 206:
  Class "Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" not found
Script @php artisan package:discover --ansi returned with error code 1
\`\`\`

Я забыл что Baza — отдельное Laravel-приложение со своим \`config/app.php\`.

## В Baza ровно такая же тройка

| Файл | Состояние |
|------|-----------|
| \`Baza/composer.json:21\` | \`barryvdh/laravel-ide-helper\` в **require-dev** ✓ |
| \`Baza/app/Providers/AppServiceProvider.php:18\` | Условная регистрация через \`isLocal()\` ✓ |
| \`Baza/config/app.php:192\` | Безусловный дубль — **баг** |

## Фикс

Аналогично #53 — убираю строку из \`Baza/config/app.php\`. AppServiceProvider регит провайдер только для local.

## Проверка

Локально \`docker exec php-baza ./vendor/bin/phpunit\`: **8 тестов / 10 ассертов / 0 проблем** — без регрессов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)