### PR TITLE
fix(infra): npm ci --include=dev для сборки фронта

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -208,10 +208,12 @@ jobs:
             echo "✓ APP_KEY (Baza) уже есть"
           fi
 
+      # NODE_ENV=production в compose заставляет `npm ci` пропустить devDependencies,
+      # а vue-cli-service лежит как раз в devDependencies → нужен --include=dev для сборки.
       - name: Build frontend (npm ci + npm run build)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
-          docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps node-staging sh -c "npm ci && npm run build"
+          docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps node-staging sh -c "npm ci --include=dev && npm run build"
 
       - name: Up containers
         working-directory: ${{ env.PROJECT_DIR }}


### PR DESCRIPTION
## Что было

Build #12 deploy-staging упал на \`Build frontend (npm ci + npm run build)\`:

\`\`\`
sh: 1: vue-cli-service: not found
\`\`\`

При этом \`npm ci\` отрапортовал только **42 added packages** — для фронта с 957 пакетами в lock'е это нонсенс.

## Корень

\`docker-compose.staging.yml\` задаёт \`NODE_ENV=production\` для node-staging контейнера. \`npm ci\` при таком окружении **автоматически пропускает** devDependencies.

А \`@vue/cli-service\` (где живёт CLI \`vue-cli-service\`) — в devDependencies \`FrontEnd/package.json\`.

## Фикс

\`npm ci --include=dev\` для шага сборки — принудительно ставим все зависимости. После \`npm run build\` они нужны.

\`NODE_ENV=production\` оставляем — он используется vue-cli/webpack для production-режима сборки бандла (минификация, tree-shaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)