### PR TITLE
fix(infra): composer install запускать всегда (исправляет stale vendor после #56)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -172,26 +172,19 @@ jobs:
       # ->change() который требует doctrine/dbal, а dbal сейчас приходит только как
       # transitive dependency из require-dev. Правильный фикс — `composer require
       # doctrine/dbal:^3.5` в основные deps, но требует обновления composer.lock
-      # (которому сейчас мешает сеть). TD-задача — перенести dbal в require.
+      # (которому сейчас мешает сеть). TD-25 — перенести dbal в require.
+      #
+      # composer install запускается ВСЕГДА (не идемпотентно) — он быстрый когда
+      # vendor совпадает с lock, и нам важно подтянуть свежие deps при изменениях.
       - name: Composer install (Backend)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
-          if [[ ! -f Backend/vendor/autoload.php ]]; then
-            echo "vendor/ отсутствует — устанавливаю зависимости…"
-            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "composer install --optimize-autoloader --no-interaction --prefer-dist"
-          else
-            echo "✓ Backend/vendor уже есть — пропускаю"
-          fi
+          docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "composer install --optimize-autoloader --no-interaction --prefer-dist"
 
       - name: Composer install (Baza)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
-          if [[ ! -f Baza/vendor/autoload.php ]]; then
-            echo "vendor/ (Baza) отсутствует — устанавливаю зависимости…"
-            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh phpbaza-staging -c "composer install --optimize-autoloader --no-interaction --prefer-dist"
-          else
-            echo "✓ Baza/vendor уже есть — пропускаю"
-          fi
+          docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh phpbaza-staging -c "composer install --optimize-autoloader --no-interaction --prefer-dist"
 
       - name: Generate APP_KEY for Backend (if missing)
         working-directory: ${{ env.PROJECT_DIR }}


### PR DESCRIPTION
## Что было

Build #14 после мержа PR #56 (\`--no-dev\` убрали) **снова** упал на той же миграции:

\`\`\`
In ChangeColumn.php line 30:
  Changing columns for table "questionnaire" requires Doctrine DBAL.
\`\`\`

## Корень

Build #13 (до PR #56) положил \`Backend/vendor/\` на сервер с \`--no-dev\` — без dbal.

В PR #52 шаг \`Composer install\` был сделан идемпотентным:

\`\`\`bash
if [[ ! -f Backend/vendor/autoload.php ]]; then
  composer install ...
else
  echo "✓ vendor уже есть — пропускаю"
fi
\`\`\`

После PR #56 vendor/autoload.php уже существовал → skip → composer install не запустился → dbal так и не появился.

## Фикс

\`composer install\` запускается **всегда** (без skip). Composer быстрый когда vendor совпадает с lock (~5 сек на проверку), не блокер для CD.

Это правильнее и с точки зрения CD-практики: deps всегда подтягиваются под актуальный \`composer.lock\`. Skip-логика была преждевременной оптимизацией с побочкой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)