### PR TITLE
fix(infra): создавать БД baza для Baza-приложения на staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -226,6 +226,21 @@ jobs:
             sleep 2
           done
 
+      # Если БД `baza` ещё не создана (например, MySQL был инициализирован до
+      # появления init-скрипта Docker/mysql/init/01-create-baza.sql) — создаём её
+      # на лету. Идемпотентно через IF NOT EXISTS.
+      - name: Ensure Baza database exists
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          ROOT_PWD="$(grep ^MYSQL_ROOT_PASSWORD .env.staging | cut -d= -f2)"
+          docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T mysql-staging \
+            mysql -uroot -p"$ROOT_PWD" -e "
+              CREATE DATABASE IF NOT EXISTS baza CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+              GRANT ALL PRIVILEGES ON baza.* TO 'systo'@'%';
+              FLUSH PRIVILEGES;
+            "
+          echo "✓ БД baza существует, права у systo выданы"
+
       # ─── Миграции и сидеры ─────────────────────────────────────────────────
       - name: Run migrations (Backend + Baza)
         working-directory: ${{ env.PROJECT_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 /Baza/bootstrap/cache/
 /FrontEnd/src/main.js
 *.sql
+# Init-скрипты MySQL — нужны в репо для docker-entrypoint-initdb.d
+!Docker/mysql/init/*.sql
 .qwen/*
 !.qwen/agents/
 !.qwen/PROJECT_MEMORY.md

--- a/Docker/mysql/init/01-create-baza.sql
+++ b/Docker/mysql/init/01-create-baza.sql
@@ -1,0 +1,17 @@
+-- Создание дополнительной БД `baza` для приложения Baza (аутентификация).
+-- MySQL-контейнер автоматически создаёт только одну БД через MYSQL_DATABASE,
+-- остальные БД должны быть созданы вручную или через init-скрипты.
+--
+-- Этот скрипт выполняется только при ПЕРВОМ запуске контейнера
+-- (когда /var/lib/mysql пуст). Для уже инициализированных volume'ов
+-- БД нужно создавать вручную через mysql exec.
+
+CREATE DATABASE IF NOT EXISTS baza
+    CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+-- Выдать те же права на baza, что и для основной БД systo.
+-- MYSQL_USER создаётся entrypoint'ом, ему уже выданы права на MYSQL_DATABASE (=systo).
+-- Дополнительно выдаём на baza.
+GRANT ALL PRIVILEGES ON baza.* TO 'systo'@'%';
+FLUSH PRIVILEGES;

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -124,6 +124,9 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-staging_secret}
     volumes:
       - mysql-staging-data:/var/lib/mysql
+      # Init-скрипты выполняются только при первой инициализации (пустой volume).
+      # Создаёт БД `baza` и выдаёт права пользователю systo.
+      - ./Docker/mysql/init:/docker-entrypoint-initdb.d:ro
     networks:
       - staging
     healthcheck:


### PR DESCRIPTION
## Что было

Build #15 — Backend миграции **прошли все** (включая ту что требует dbal!). Упал на Baza:

\`\`\`
SQLSTATE[HY000] [1044] Access denied for user 'systo'@'%' to database 'baza'
\`\`\`

## Корень

MySQL-контейнер создаёт автоматически только **одну** БД через \`MYSQL_DATABASE=systo\`. У юзера \`systo\` есть права только на эту БД.

Приложение Baza подключается к своей БД \`baza\` (см. \`Baza/.env.staging.example\`) — её не существует, прав нет.

## Фикс — три точки

### 1. Init-скрипт для свежих установок

\`Docker/mysql/init/01-create-baza.sql\`:
\`\`\`sql
CREATE DATABASE IF NOT EXISTS baza CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
GRANT ALL PRIVILEGES ON baza.* TO 'systo'@'%';
FLUSH PRIVILEGES;
\`\`\`

### 2. Монтирование в compose

\`\`\`yaml
mysql-staging:
  volumes:
    - mysql-staging-data:/var/lib/mysql
    - ./Docker/mysql/init:/docker-entrypoint-initdb.d:ro
\`\`\`

Скрипты в \`/docker-entrypoint-initdb.d/\` выполняются только при **первом** запуске (пустой volume).

### 3. Шаг "Ensure Baza database exists" в workflow

Для **уже инициализированных** серверов (где init-скрипт не запустится — volume не пустой) — выполняем CREATE/GRANT через docker exec перед миграциями. Идемпотентно через \`IF NOT EXISTS\`.

### Бонус: \`.gitignore\` exception

Общий паттерн \`*.sql\` блокировал init-скрипт (он для дампов БД). Добавил \`!Docker/mysql/init/*.sql\`.

## После мержа

Build пойдёт через "Ensure Baza database exists" → создаст БД → миграции Baza пройдут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)