### PR TITLE
fix(infra): финальные правки staging — env, права, nginx pattern

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -232,6 +232,25 @@ jobs:
       - name: Fix storage permissions
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
+          # php-контейнеры depends_on mysql healthcheck, поэтому стартуют после mysql.
+          # Между up -d и моментом когда контейнер реально в running есть небольшой
+          # гэп — ждём что docker compose exec реально подключается.
+          for svc in php-staging phpbaza-staging; do
+            echo "Жду готовности контейнера $svc…"
+            for i in $(seq 1 30); do
+              if docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T "$svc" true 2>/dev/null; then
+                echo "  ✓ $svc отвечает (через ${i}s)"
+                break
+              fi
+              if [ "$i" = "30" ]; then
+                echo "::error::$svc не запустился за 30 секунд"
+                docker compose -f docker-compose.staging.yml --env-file .env.staging ps "$svc"
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging     chown -R www-data:www-data storage bootstrap/cache
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root phpbaza-staging chown -R www-data:www-data storage bootstrap/cache
           echo "✓ storage и bootstrap/cache принадлежат www-data"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -226,6 +226,16 @@ jobs:
             sleep 2
           done
 
+      # php-fpm в контейнере работает от www-data, но composer install/key:generate
+      # запускались через --entrypoint sh под root → файлы в storage/ и bootstrap/cache/
+      # принадлежат root. Без chown Laravel падает с "Permission denied" на laravel.log.
+      - name: Fix storage permissions
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging     chown -R www-data:www-data storage bootstrap/cache
+          docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root phpbaza-staging chown -R www-data:www-data storage bootstrap/cache
+          echo "✓ storage и bootstrap/cache принадлежат www-data"
+
       # Если БД `baza` ещё не создана (например, MySQL был инициализирован до
       # появления init-скрипта Docker/mysql/init/01-create-baza.sql) — создаём её
       # на лету. Идемпотентно через IF NOT EXISTS.

--- a/Backend/.env.staging.example
+++ b/Backend/.env.staging.example
@@ -19,16 +19,27 @@ DB_USERNAME=systo
 DB_PASSWORD=staging_secret_CHANGE_ME
 
 BROADCAST_DRIVER=log
-CACHE_DRIVER=redis
+# CACHE_DRIVER=redis/SESSION_DRIVER=redis требуют ext-redis или predis/predis.
+# На staging-контейнере ни того, ни другого пока нет — используем file driver.
+CACHE_DRIVER=file
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
-SESSION_DRIVER=redis
+SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
 # === Redis ===================================================================
+# Redis-контейнер поднят, но PHP-клиент не установлен. См. CACHE/SESSION выше.
+REDIS_CLIENT=predis
 REDIS_HOST=redis-staging
 REDIS_PASSWORD=null
 REDIS_PORT=6379
+
+# === Billing (СБП через AlfaBank, на staging — пустые) =======================
+# BillingService::__construct() читает эти переменные и присваивает их в
+# string-свойства — null недопустим, иначе TypeError ловит весь bootstrap.
+BILLING_KEY_CLIENT=
+BILLING_KEY_PASSWORD=
+BILLING_HOST=
 
 # === Mail (через Mailpit — перехватчик в web UI) =============================
 MAIL_MAILER=smtp

--- a/Backend/.env.staging.example
+++ b/Backend/.env.staging.example
@@ -28,8 +28,14 @@ SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
 # === Redis ===================================================================
-# Redis-контейнер поднят, но PHP-клиент не установлен. См. CACHE/SESSION выше.
-REDIS_CLIENT=predis
+# Redis-контейнер поднят, но PHP-клиент в Backend/vendor/ не установлен:
+#   - ext-redis в Docker/php/Dockerfile не ставится
+#   - predis/predis отсутствует в Backend/composer.json (есть только как suggest)
+# Поэтому CACHE_DRIVER и SESSION_DRIVER переключены на file (см. выше).
+# Когда будет нужен Redis — выбрать одно из:
+#   1) Добавить predis/predis в require + composer update + set REDIS_CLIENT=predis
+#   2) Установить ext-redis в Docker/php/Dockerfile (тогда REDIS_CLIENT не нужен,
+#      т.к. phpredis — дефолт в config/database.php)
 REDIS_HOST=redis-staging
 REDIS_PASSWORD=null
 REDIS_PORT=6379

--- a/Docker/nginx/default.staging.conf
+++ b/Docker/nginx/default.staging.conf
@@ -16,6 +16,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ═══ API (Backend SolarSysto) ════════════════════════════════════════════════
+# Используем рекомендованный Laravel-паттерн:
+#   - location /         — try_files с fallback на /index.php
+#   - location = /index.php — отдельный match только для index.php (после fallback)
+#   - location ~ \.php$  — deny all (не позволяем выполнять любые .php в public/)
+# Это безопаснее (предотвращает выполнение случайных .php) и обходит проблему
+# с SCRIPT_FILENAME через try_files в location ~ \.php$.
 server {
     listen      80;
     server_name api.staging.spaceofjoy.ru;
@@ -24,19 +30,23 @@ server {
     index index.php;
 
     location / {
-        try_files $uri /index.php$is_args$query_string;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location ~ \.php$ {
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    location = /index.php {
         fastcgi_pass            php-staging:9000;
-        fastcgi_index           index.php?$args;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include                 fastcgi_params;
-        fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param           DOCUMENT_ROOT   $realpath_root;
         fastcgi_intercept_errors off;
         fastcgi_buffer_size     16k;
         fastcgi_buffers         4 16k;
         fastcgi_read_timeout    120s;
+    }
+
+    location ~ \.php$ {
+        return 404;
     }
 
     # Host nginx уже добавляет X-Forwarded-Proto — приложение видит https
@@ -49,22 +59,26 @@ server {
     server_name vhod.staging.spaceofjoy.ru;
 
     root  /var/www/vhod/public;
-    index index.php index.html;
+    index index.php;
 
     location / {
-        try_files $uri /index.php$is_args$query_string;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location ~ \.php$ {
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    location = /index.php {
         fastcgi_pass            phpbaza-staging:9000;
-        fastcgi_index           index.php?$args;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include                 fastcgi_params;
-        fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param           SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param           DOCUMENT_ROOT   $realpath_root;
         fastcgi_intercept_errors off;
         fastcgi_buffer_size     16k;
         fastcgi_buffers         4 16k;
         fastcgi_read_timeout    60s;
+    }
+
+    location ~ \.php$ {
+        return 404;
     }
 
     client_max_body_size 10M;


### PR DESCRIPTION
## Что было

После build #16 (✅ деплой прошёл, все контейнеры up) — на сервере вручную исправлены 3 проблемы. Сейчас переношу всё в репо чтобы будущие деплои были чистыми и не падали.

## Что меняется

### 1. `Backend/.env.staging.example`

| Переменная | Зачем |
|------------|-------|
| `CACHE_DRIVER=file` (было redis) | Класс `Redis` не найден (нет ext-redis в контейнере) |
| `SESSION_DRIVER=file` (было redis) | То же |
| `REDIS_CLIENT=predis` (новая) | Про запас, на случай если когда-то поставится predis/predis |
| `BILLING_KEY_CLIENT=` (новая) | `BillingService::__construct` присваивает `null` в `string \$login` → TypeError в bootstrap'е → 500 на всех роутах |
| `BILLING_KEY_PASSWORD=` (новая) | Аналогично |
| `BILLING_HOST=` (новая) | Аналогично |

### 2. `.github/workflows/deploy-staging.yml`

Новый шаг **"Fix storage permissions"** после "Up containers":

\`\`\`yaml
docker compose exec -T -u root php-staging chown -R www-data:www-data storage bootstrap/cache
\`\`\`

Корень: \`composer install\` и \`key:generate\` через \`--entrypoint sh\` создают файлы от root. Но php-fpm работает от www-data → не может писать в laravel.log → Laravel ловит исключение в логгере и возвращает 500.

### 3. `Docker/nginx/default.staging.conf` — Laravel-pattern

Старый pattern (как в prod) на staging выдавал `File not found` от PHP даже для прямого `/index.php`:

\`\`\`
HTTP/1.1 404 Not Found
X-Powered-By: PHP/8.2.31
File not found.
\`\`\`

Новый pattern:
\`\`\`nginx
location / {
    try_files \$uri \$uri/ /index.php?\$query_string;
}
location = /index.php {
    fastcgi_pass php-staging:9000;
    fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
    ...
}
location ~ \\.php\$ {
    return 404;  # запрет на любые другие .php в public/
}
\`\`\`

Безопаснее (не позволяет выполнять случайные .php) и обходит проблему с SCRIPT_FILENAME через \`$realpath_root\`.

## Связанное

См. memory `project_staging_setup_2026_05_31.md` — там вся история вечерней отладки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)