### PR TITLE
fix(infra): генерация JWT_SECRET в deploy-staging

### DIFF
--- a/.claude/docs/PROJECT_MEMORY.md
+++ b/.claude/docs/PROJECT_MEMORY.md
@@ -59,6 +59,11 @@
 - **CQRS**: Команды для изменения, Query для чтения. Shared Bus.
 - **Типизация**: Frontend state должен совпадать с Backend DTO (snake_case).
 - **Безопасность**: Секреты в `.env`, реальные ключи в git **запрещены**.
+- **Staging deploy** (`.github/workflows/deploy-staging.yml`):
+  - Все секреты (`MYSQL_*`, `APP_KEY`, `JWT_SECRET`) генерируются **автоматически** при first deploy через `openssl rand` / `php artisan key:generate` / `php artisan jwt:secret`.
+  - Все шаги идемпотентны — повторный деплой не перезаписывает существующие секреты.
+  - После генерации `JWT_SECRET` на уже работающих контейнерах workflow делает `up -d --force-recreate php-staging worker-staging` (env_file читается только при создании контейнера).
+  - Подробности и команды ротации — `.claude/docs/process/RELEASES.md §9`.
 
 ## 💻 Технические предпочтения
 

--- a/.claude/docs/process/RELEASES.md
+++ b/.claude/docs/process/RELEASES.md
@@ -312,6 +312,41 @@ master           ─── основная линия разработки
 
 ---
 
+## 9. Staging deploy pipeline
+
+`.github/workflows/deploy-staging.yml` — auto-deploy на сервер `77.222.32.244` при push в ветку `staging`. Подробности — в `infra/staging/README.md`.
+
+### Автоматически генерируемые секреты (first deploy)
+
+При первом запуске workflow на чистом сервере следующие секреты создаются автоматически и пишутся в `.env`:
+
+| Секрет | Где | Как генерируется |
+|--------|-----|-------------------|
+| `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD` | `.env.staging` | `openssl rand -hex 16` в шаге Bootstrap |
+| `APP_KEY` (Backend, Baza) | `Backend/.env`, `Baza/.env` | `php artisan key:generate --force` |
+| `JWT_SECRET` (Backend) | `Backend/.env` | `php artisan jwt:secret --force` |
+
+Все шаги идемпотентны: если значение уже задано в `.env` (не пустое и формат корректный) — шаг пропускается. **Никогда не перезаписываем существующие секреты.**
+
+### Ротация
+
+Чтобы пересоздать секрет — удалить строку из `.env` на сервере и перезапустить workflow:
+
+```bash
+ssh deploy@77.222.32.244 'sed -i "s/^JWT_SECRET=.*//g" /var/www/systo/Backend/.env'
+gh workflow run deploy-staging.yml -f ref=staging
+```
+
+Workflow увидит пустой `JWT_SECRET`, сгенерирует новый, и сделает `up -d --force-recreate php-staging worker-staging` чтобы контейнеры подхватили новое значение (`env_file` читается только при создании контейнера, restart не помогает).
+
+### Проверка применённого секрета
+
+```bash
+ssh deploy@77.222.32.244 'docker exec php-staging php -r "echo config(\"jwt.secret\");"'
+```
+
+---
+
 ## История изменений документа
 
 | Дата | Изменение |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -206,6 +206,20 @@ jobs:
             echo "✓ APP_KEY (Baza) уже есть"
           fi
 
+      # JWT_SECRET для php-open-source-saver/jwt-auth. Если пустой —
+      # JWT-токены ловят InvalidKeyProvided("Key cannot be empty") на любом
+      # запросе через api-guard middleware. Команда генерирует случайный
+      # 64-символьный hex и пишет в .env (флаг --force обходит подтверждение).
+      - name: Generate JWT_SECRET for Backend (if missing)
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          if ! grep -qE "^JWT_SECRET=.+" Backend/.env; then
+            echo "JWT_SECRET пуст — генерирую…"
+            docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "php artisan jwt:secret --force --no-interaction"
+          else
+            echo "✓ JWT_SECRET уже есть"
+          fi
+
       # NODE_ENV=production в compose заставляет `npm ci` пропустить devDependencies,
       # а vue-cli-service лежит как раз в devDependencies → нужен --include=dev для сборки.
       - name: Build frontend (npm ci + npm run build)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -210,12 +210,25 @@ jobs:
       # JWT-токены ловят InvalidKeyProvided("Key cannot be empty") на любом
       # запросе через api-guard middleware. Команда генерирует случайный
       # 64-символьный hex и пишет в .env (флаг --force обходит подтверждение).
+      #
+      # ВАЖНО: env_file читается docker compose при СОЗДАНИИ контейнера, не при
+      # restart. Если генерировали ПОСЛЕ up — нужен force-recreate, иначе
+      # php-staging и worker-staging продолжат работать с пустым JWT_SECRET.
+      # На первом деплое это безопасно: up -d идёт после этого шага. На
+      # последующих — если JWT_SECRET уже есть, шаг скипается, recreate не
+      # нужен. Recreate делаем ТОЛЬКО когда реально сгенерировали.
       - name: Generate JWT_SECRET for Backend (if missing)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
           if ! grep -qE "^JWT_SECRET=.+" Backend/.env; then
             echo "JWT_SECRET пуст — генерирую…"
             docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps --entrypoint sh php-staging -c "php artisan jwt:secret --force --no-interaction"
+            # Recreate'им только если контейнеры уже запущены (повторный деплой).
+            # На первом деплое они ещё не подняты — будут созданы со свежим .env.
+            if docker compose -f docker-compose.staging.yml --env-file .env.staging ps php-staging | grep -q "Up"; then
+              echo "Контейнеры уже запущены — пересоздаю php-staging и worker-staging чтобы подхватить новый JWT_SECRET…"
+              docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --force-recreate --no-deps php-staging worker-staging
+            fi
           else
             echo "✓ JWT_SECRET уже есть"
           fi


### PR DESCRIPTION
## Что было

Build #17 деплой прошёл, **vhod login работает 200** ✅, но api → 500:

\`\`\`
Lcobucci\JWT\Signer\InvalidKeyProvided: Key cannot be empty
  at /var/www/org/vendor/lcobucci/jwt/src/Signer/InvalidKeyProvided.php:34
\`\`\`

\`JWT_SECRET\` в \`Backend/.env.staging.example\` пустой — приложение не может подписать токен.

## Фикс

Новый шаг **"Generate JWT_SECRET for Backend (if missing)"** после "Generate APP_KEY for Baza":

\`\`\`yaml
if ! grep -qE "^JWT_SECRET=.+" Backend/.env; then
  echo "JWT_SECRET пуст — генерирую…"
  docker compose ... run --rm --entrypoint sh php-staging -c \\
    "php artisan jwt:secret --force --no-interaction"
fi
\`\`\`

Идемпотентно — если JWT_SECRET уже задан, шаг пропускается. По аналогии с APP_KEY.

## Состояние после build #17

- ✅ \`staging.spaceofjoy.ru\` → 200 (Vue SPA)
- ✅ \`vhod.staging.spaceofjoy.ru/login\` → 200 (Baza работает!)
- ✅ \`pma.\` / \`mail.\` → 401 (basic auth)
- ⚠ \`api.staging.spaceofjoy.ru\` → 500 (этот PR должен починить)

🤖 Generated with [Claude Code](https://claude.com/claude-code)