### PR TITLE
fix(order): validate options[] elements are arrays (qodo PR #68)

### DIFF
--- a/Backend/src/Order/OrderTicket/Application/Pricing/Dto/RawGuestInput.php
+++ b/Backend/src/Order/OrderTicket/Application/Pricing/Dto/RawGuestInput.php
@@ -98,10 +98,22 @@ final class RawGuestInput
             ));
         }
 
-        $options = array_map(
-            static fn (array $raw): RawGuestOptionInput => RawGuestOptionInput::fromState($raw),
-            array_values($rawOptions),
-        );
+        // Каждый элемент `options[]` обязан быть массивом (вложенный payload опции).
+        // Без этой проверки `array_map(fn (array $raw) => ...)` бросит непредсказуемый
+        // `TypeError` (HTTP 500) при `options: ["x"]` / `options: [null]` — а граница
+        // слоя должна возвращать домен-понятный `InvalidArgumentException`.
+        $options = [];
+        foreach (array_values($rawOptions) as $index => $raw) {
+            if (! is_array($raw)) {
+                throw new InvalidArgumentException(sprintf(
+                    'RawGuestInput::fromState() options[%d] must be array, got %s: %s',
+                    $index,
+                    get_debug_type($raw),
+                    var_export($raw, true),
+                ));
+            }
+            $options[] = RawGuestOptionInput::fromState($raw);
+        }
 
         $promoCode = $data['promo_code'] ?? null;
         if (is_string($promoCode)) {

--- a/Backend/tests/Unit/Order/OrderTicket/Application/Pricing/Dto/RawGuestInputTest.php
+++ b/Backend/tests/Unit/Order/OrderTicket/Application/Pricing/Dto/RawGuestInputTest.php
@@ -207,6 +207,35 @@ class RawGuestInputTest extends TestCase
         ]);
     }
 
+    /**
+     * @dataProvider invalidOptionElementProvider
+     */
+    public function test_from_state_rejects_non_array_option_element(mixed $badElement): void
+    {
+        // Раньше `array_map(fn (array $raw) => ...)` с `strict_types=1` бросал TypeError → HTTP 500.
+        // Граница слоя должна давать домен-понятный InvalidArgumentException (qodo PR #68).
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('options[0]');
+
+        RawGuestInput::fromState([
+            'value' => 'Иван Иванов',
+            'email' => 'ivan@example.com',
+            'ticket_type_id' => self::TICKET_TYPE_ID,
+            'options' => [$badElement],
+        ]);
+    }
+
+    public static function invalidOptionElementProvider(): array
+    {
+        return [
+            'string' => ['x'],
+            'null' => [null],
+            'int' => [42],
+            'float' => [3.14],
+            'bool' => [true],
+        ];
+    }
+
     public function test_from_state_expands_multiple_options(): void
     {
         $input = RawGuestInput::fromState([


### PR DESCRIPTION
## Summary

Hotfix-замечание qodo на PR #68 — уже мержнутом. Чиним отдельным PR.

**Проблема:** `RawGuestInput::fromState()` валидировал что `options` — массив, но не валидировал каждый элемент. С `strict_types=1` payload `options: ["x"]` (или `[null]`, `[42]`) бросал `TypeError` → HTTP 500 вместо домен-понятного `InvalidArgumentException`. Нарушает гарантию «strict validation at boundary» (см. PHPDoc DTO).

**Что изменено:**

| Файл | Что |
|------|-----|
| `Backend/src/Order/OrderTicket/Application/Pricing/Dto/RawGuestInput.php` | Перед `array_map` — `foreach` с `is_array($raw)`, при невалидном бросаем `InvalidArgumentException` с индексом и типом |
| `Backend/tests/Unit/Order/OrderTicket/Application/Pricing/Dto/RawGuestInputTest.php` | Новый `@dataProvider` тест `test_from_state_rejects_non_array_option_element` — 5 кейсов (string, null, int, float, bool) |

**Локально:** 38/38 DTO-тестов ✅ (было 33, +5 новых для bad element types).

## Test plan

- [x] DTO unit-тесты локально (38/38)
- [ ] Integration на CI staging
- [ ] Manual: POST /api/v1/order/create с `options: ["x"]` должен вернуть 422 (после controllers-rewrite, не в этом PR)

## Источник

qodo-code-review на PR #68 ([ссылка](https://github.com/ShaevMV/systo/pull/68#discussion_r) на комментарий).

🤖 Generated with [Claude Code](https://claude.com/claude-code)