### PR TITLE
feat(order): миграция order_tickets.guests в формат v2.6.0 (#4/7)

### DIFF
--- a/.claude/docs/process/migrations/v2.6.0.md
+++ b/.claude/docs/process/migrations/v2.6.0.md
@@ -1,0 +1,144 @@
+# Migration guide v2.6.0 — формат `order_tickets.guests`
+
+**Дата создания:** 2026-06-03
+**Owner:** scrum-master + tech-lead
+**Релевантно для:** релиз v2.6.0 (старт продаж осеннего фестиваля 2026-06-12)
+
+## Что меняется
+
+В v2.6.0 каждый гость в заказе получает собственный `ticket_type_id`, `promo_code`, набор `options[]` и денежный снимок `price_snapshot`. Раньше эти поля были на уровне заказа (одинаковые для всех гостей).
+
+**Карта переноса** (legacy → v2.6.0):
+
+| Источник в legacy | Цель в новом формате `guests[i]` | Логика |
+|-------------------|-----------------------------------|--------|
+| `order_tickets.ticket_type_id` | `guests[i].ticket_type_id` | дублируется на каждого гостя; для list-orders `= null` |
+| `order_tickets.promo_code` | `guests[i].promo_code` | дублируется на каждого гостя |
+| `order_tickets.price` / count | `guests[i].price_snapshot.base_price` | сумма делится поровну (round) |
+| `order_tickets.discount` / count | `guests[i].price_snapshot.discount` | скидка делится поровну (round) |
+| `(price - discount)` / count | `guests[i].price_snapshot.total` | итог на гостя (round) |
+| `ticket_type.is_live_ticket` | `guests[i].is_live_ticket` | флаг с типа билета |
+| — | `guests[i].options` | всегда `[]` для legacy |
+
+**Что НЕ удаляем** (для отката): колонки `order_tickets.ticket_type_id`, `promo_code`, `price`, `discount` остаются на месте до aggregate-rewrite (sub-PR #5). После v2.6.0 в проде они становятся избыточными, но снос — в v2.7.0+ когда убедимся что новый формат стабилен.
+
+## Округление цен
+
+`round((price - discount) / count)` — простое half-away-from-zero. На каждого гостя расхождение `≤ 0.5 ₽`, итоговое расхождение **по заказу `≤ (count - 1) ₽`**.
+
+`OrderMigrationReport::maxAllowedRoundingError` суммирует допуск по всем мигрированным заказам. Если фактическое расхождение `roundingDelta()` превышает допуск — миграция считается **повреждённой**, прогон возвращает `FAILURE`, транзакция откатывается.
+
+Пример (отдельный заказ): `price=8400, discount=600, count=2`:
+- `totalPerGuest = round((8400 - 600) / 2) = 3900`
+- `discountPerGuest = round(600 / 2) = 300`
+- `basePerGuest = 3900 + 300 = 4200`
+- Σ total после = `3900 × 2 = 7800` — совпадает с `price - discount = 7800` ✅
+
+## Прогон миграции
+
+### Артефакты
+
+- **Команда:** `php artisan order:migrate-to-guests-format`
+- **Опции:**
+  - `--apply` — реально применить (без флага — dry-run)
+  - `--no-backup` — пропустить inline-бэкап (только для повторных прогонов)
+  - `--chunk=100` — размер пачки
+
+### Чек-лист релиза
+
+#### Перед stagging deploy
+1. `git checkout feat/v2.6.0-data-migration`
+2. `gh pr create ...` → ревью → merge в master
+
+#### На staging (репетиция)
+1. Накатить копию прод-БД на staging (см. `STAGING_LINKS.md`).
+2. SSH на staging-сервер:
+   ```bash
+   docker exec php-staging php artisan order:migrate-to-guests-format
+   ```
+   ↑ dry-run, проверить отчёт.
+3. Запустить с `--apply`:
+   ```bash
+   docker exec php-staging php artisan order:migrate-to-guests-format --apply
+   ```
+4. Проверить через phpMyAdmin: один-два заказа имеют в `guests` поля `price_snapshot`, `ticket_type_id` на гостях.
+5. Зафиксировать имя backup-таблицы из вывода — пригодится для отката.
+
+#### На проде (день релиза)
+1. **5 копий БД через mysqldump** перед запуском (стандартный pre-release протокол, не часть artisan-команды).
+   ```bash
+   mysqldump systo > /backups/systo_pre_v2.6.0_$(date +%Y%m%d_%H%M%S).sql
+   # × 5 на разные локации
+   ```
+2. Dry-run на проде:
+   ```bash
+   docker exec php-solarSysto php artisan order:migrate-to-guests-format
+   ```
+3. Apply (создаст ещё inline-бэкап в самой БД):
+   ```bash
+   docker exec php-solarSysto php artisan order:migrate-to-guests-format --apply
+   ```
+4. Проверить отчёт: `errors=0`, расхождение в допуске.
+
+## Откат
+
+Если миграция повредила данные (расхождение сумм выше допуска / errors > 0 / smoke-тест провалился):
+
+### Откат до aggregate-rewrite (sub-PR #5 ещё не выпущен)
+
+Inline-бэкап остался в той же БД. Достаточно:
+
+```sql
+TRUNCATE TABLE order_tickets;
+INSERT INTO order_tickets SELECT * FROM `order_tickets_backup_v2_6_0_<TIMESTAMP>`;
+```
+
+(имя таблицы — из вывода `--apply`).
+
+### Откат после aggregate-rewrite
+
+Aggregate v2.6.0 будет читать **только новый формат** (`price_snapshot` обязателен). Откат миграции в одиночку **не достаточен** — нужно откатить и код:
+
+1. `git revert <commit_of_aggregate_rewrite>` (или deploy предыдущей версии)
+2. Затем `TRUNCATE + INSERT FROM backup` (см. выше)
+
+## Идемпотентность
+
+Если у первого гостя заказа есть поле `price_snapshot` — заказ считается мигрированным и пропускается. Можно безопасно перезапускать команду — повторных изменений не будет.
+
+Метрика `alreadyMigrated` в отчёте показывает сколько заказов было пропущено.
+
+## Maintenance window (обязательно)
+
+**Во время `--apply` сервис ДОЛЖЕН быть в read-only режиме** — новые заказы через API не должны приниматься:
+
+- `chunk()` обходит таблицу по `id ASC` — заказ, созданный после старта чанка, может быть пропущен (read position уже прошёл).
+- Новый заказ создаётся через legacy-формат (sub-PR aggregate-rewrite ещё не выпущен), значит он будет в смешанном состоянии с уже мигрированными.
+- Inline-бэкап делается ДО миграции — новые заказы туда не попадают, откат их потеряет.
+
+**Способ ввести maintenance:**
+- Nginx maintenance page (`return 503` для `/api/v1/order/create*` endpoints), либо
+- временно остановить контейнер `php-solarSysto` на время прогона.
+
+Чек: миграция 50k заказов занимает ~10-30 сек. С запасом — 5-10 минут window.
+
+## Известные ограничения и edge-cases
+
+- **`count(guests) = 0`** — пропускаются без ошибки (метрика `emptyGuestsSkipped`). Это аномалия данных, но не блокер миграции.
+- **Битый JSON `guests`** — попадает в `errors` отчёта, команда возвращает FAILURE (транзакция откатывается).
+- **`discount > price`** — отвергается явно (RuntimeException → error в отчёте). Это всегда баг данных, не норма.
+- **`ticket_type_id` orphan** (нет в `ticket_type`) — отвергается явно (error). Раньше silent fallback на `is_live_ticket=false` скрывал такие проблемы.
+- **Списки** (`curator_id IS NOT NULL`, `ticket_type_id IS NULL`) — мигрируются с `ticket_type_id=null` у каждого гостя, `price=discount=0` → `total=0`. Это норма.
+- **Split-brain** (первый гость мигрирован, остальные — нет): теоретически возможен только если кто-то вручную сломал JSON. Идемпотентность проверяет только первого гостя — заказ будет пропущен. Защита от split-brain: атомарный UPDATE всего guests JSON одной операцией.
+
+## Технический долг (из adversarial verify, не блокирует релиз)
+
+- **Встроенная команда `order:rollback-guests-format`** — пока откат через ручной SQL (см. выше). В v2.6.x добавить безопасную команду.
+- **`--force-remigrate`** — если оператор вручную изменил `price_snapshot` одного заказа и хочет переподписать — сейчас нельзя без удаления поля. Добавить опцию.
+- **Проверка наличия 5 mysqldump-копий** перед `--apply` — сейчас полностью на человеке. Можно автоматизировать в CI/CD pipeline.
+
+## Связанные документы
+
+- Спека формата: `.claude/specs/order-format-architecture.md`
+- Sub-PR трекинг: `.claude/docs/BOARD.md`
+- Релиз-процесс: `.claude/docs/process/RELEASES.md` §8 (чек-лист релиза)

--- a/Backend/app/Console/Commands/MigrateOrdersToGuestsFormatCommand.php
+++ b/Backend/app/Console/Commands/MigrateOrdersToGuestsFormatCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\ConnectionInterface;
+use Symfony\Component\Console\Command\Command as CommandAlias;
+use Throwable;
+use Tickets\Order\OrderTicket\Migration\OrderGuestsBackupService;
+use Tickets\Order\OrderTicket\Migration\OrderGuestsMigrator;
+
+/**
+ * Миграция формата `order_tickets.guests` JSON из v2.5.x в v2.6.0.
+ *
+ * Под капотом: {@see OrderGuestsMigrator} (логика трансформации) + {@see OrderGuestsBackupService}
+ * (CREATE TABLE AS SELECT перед началом).
+ *
+ * Безопасность:
+ * - **По умолчанию dry-run** (никаких изменений в БД). Реально пишет только с `--apply`.
+ * - Перед `--apply` обязательный inline-бэкап `order_tickets_backup_v2_6_0_<timestamp>`.
+ *   Отключается флагом `--no-backup` (только для повторных прогонов после первого бэкапа).
+ * - Идемпотентна: повторный запуск пропускает уже мигрированные заказы.
+ *
+ * Использование:
+ *   php artisan order:migrate-to-guests-format                  # dry-run, печатает что будет
+ *   php artisan order:migrate-to-guests-format --apply          # реально пишет (с бэкапом)
+ *   php artisan order:migrate-to-guests-format --apply --no-backup  # повторный прогон без бэкапа
+ *   php artisan order:migrate-to-guests-format --chunk=500     # размер пачки для chunk()
+ *
+ * См. `.claude/docs/process/migrations/v2.6.0.md`.
+ */
+class MigrateOrdersToGuestsFormatCommand extends Command
+{
+    protected $signature = 'order:migrate-to-guests-format
+        {--apply : Реально применить изменения в БД. Без флага — dry-run.}
+        {--no-backup : Не создавать inline-бэкап таблицы (только с --apply, для повторных прогонов).}
+        {--force : Пропустить интерактивные подтверждения (для CI/CD без TTY).}
+        {--chunk=100 : Размер пачки для построчного обхода (default 100).}';
+
+    protected $description = 'Мигрировать order_tickets.guests JSON в формат v2.6.0 (per-guest ticket_type / promo / price_snapshot)';
+
+    public function handle(
+        ConnectionInterface $connection,
+        OrderGuestsMigrator $migrator,
+        OrderGuestsBackupService $backup,
+    ): int {
+        $apply = (bool) $this->option('apply');
+        $noBackup = (bool) $this->option('no-backup');
+        $force = (bool) $this->option('force');
+        $chunkSize = max(1, (int) $this->option('chunk'));
+
+        $mode = $apply ? '🔥 APPLY (реальная миграция)' : '🧪 DRY-RUN (изменений в БД не будет)';
+        $this->info(sprintf('Режим: %s', $mode));
+        $this->info(sprintf('Размер пачки (chunk): %d', $chunkSize));
+
+        // ─── 1. Inline-бэкап (только в режиме --apply, без --no-backup) ───
+        $backupTable = null;
+        if ($apply && ! $noBackup) {
+            try {
+                $timestamp = date('Y_m_d_His');
+                $this->info('');
+                $this->info(sprintf('Создаю бэкап-таблицу с timestamp %s ...', $timestamp));
+                $backupTable = $backup->createBackup($timestamp);
+
+                $sourceCount = $backup->countRowsInOrderTickets();
+                $backupCount = $backup->countRowsInBackup($backupTable);
+
+                if ($sourceCount !== $backupCount) {
+                    $this->error(sprintf(
+                        'Бэкап неконсистентен: source=%d, backup=%d. Прерываю.',
+                        $sourceCount, $backupCount,
+                    ));
+
+                    return CommandAlias::FAILURE;
+                }
+                $this->info(sprintf(
+                    '✅ Бэкап готов: %s (%d строк). Для отката: TRUNCATE order_tickets; INSERT INTO order_tickets SELECT * FROM `%s`;',
+                    $backupTable, $backupCount, $backupTable,
+                ));
+            } catch (Throwable $e) {
+                $this->error(sprintf('Не удалось создать бэкап: %s', $e->getMessage()));
+
+                return CommandAlias::FAILURE;
+            }
+        } elseif ($apply && $noBackup) {
+            // В CI/CD `$this->confirm()` зависает без TTY — обходим через --force.
+            // Без --force и в неинтерактивной среде падаем явно (а не молча).
+            if ($force) {
+                $this->warn('--no-backup + --force: inline-бэкап пропущен по флагу.');
+            } else {
+                if (! $this->input->isInteractive()) {
+                    $this->error('--no-backup в неинтерактивной среде требует --force (иначе нельзя подтвердить).');
+
+                    return CommandAlias::FAILURE;
+                }
+                if (! $this->confirm('Точно пропустить inline-бэкап? Откатить миграцию будет невозможно.', false)) {
+                    $this->warn('Прервано пользователем.');
+
+                    return CommandAlias::SUCCESS;
+                }
+            }
+        }
+
+        // ─── 2. Прогон миграции ───
+        $this->info('');
+        $this->info('Запускаю миграцию ...');
+
+        try {
+            // Транзакция только в режиме --apply: dry-run не пишет в БД, транзакция не нужна.
+            $report = $apply
+                ? $connection->transaction(static fn () => $migrator->migrate(dryRun: false, chunkSize: $chunkSize))
+                : $migrator->migrate(dryRun: true, chunkSize: $chunkSize);
+        } catch (Throwable $e) {
+            $this->error(sprintf('Миграция упала: %s', $e->getMessage()));
+            $this->error('Транзакция откачена — данные не изменились.');
+            if ($backupTable !== null) {
+                $this->warn(sprintf('Бэкап-таблица %s осталась — можно удалить вручную после анализа.', $backupTable));
+            }
+
+            return CommandAlias::FAILURE;
+        }
+
+        // ─── 3. Итоги ───
+        $this->info('');
+        $this->table(['Метрика', 'Значение'], $report->toTableRows());
+
+        if (! empty($report->errorMessages)) {
+            $this->newLine();
+            $this->warn(sprintf('Ошибок (первые %d):', count($report->errorMessages)));
+            foreach ($report->errorMessages as $msg) {
+                $this->line('  • ' . $msg);
+            }
+        }
+
+        if (! $report->isRoundingWithinTolerance()) {
+            $this->newLine();
+            $this->error('❌ Расхождение сумм ВЫШЕ допустимого порога округления. ДАННЫЕ ПОВРЕЖДЕНЫ.');
+
+            return CommandAlias::FAILURE;
+        }
+
+        // Любые ошибки в отчёте = FAILURE, даже если суммы сошлись.
+        // Один пропущенный заказ — это уже инцидент, нужно ручное вмешательство.
+        if ($report->errors > 0) {
+            $this->newLine();
+            $this->error(sprintf(
+                '❌ Ошибок при миграции: %d. См. список выше. Команда возвращает FAILURE.',
+                $report->errors,
+            ));
+
+            return CommandAlias::FAILURE;
+        }
+
+        if ($apply) {
+            $this->newLine();
+            $this->info('✅ Миграция применена.');
+        } else {
+            $this->newLine();
+            $this->comment('Это был dry-run. Запустите с --apply чтобы реально применить.');
+        }
+
+        return CommandAlias::SUCCESS;
+    }
+}

--- a/Backend/src/Order/OrderTicket/Migration/OrderGuestsBackupService.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderGuestsBackupService.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Order\OrderTicket\Migration;
+
+use Illuminate\Database\ConnectionInterface;
+
+/**
+ * Бэкап таблицы `order_tickets` перед миграцией формата гостей в v2.6.0.
+ *
+ * Стратегия: `CREATE TABLE order_tickets_backup_v2_6_0_<YYYY_mm_dd_His> AS SELECT * FROM order_tickets`.
+ * Это создаёт независимую копию данных в той же БД — для отката достаточно
+ * `INSERT INTO order_tickets SELECT * FROM <backup_table>` (после `TRUNCATE`).
+ *
+ * **Дополнительные копии БД** (5 штук, как требует `.claude/specs/order-format-architecture.md` §3.3)
+ * делаются на уровне CI/CD пайплайна через `mysqldump` перед запуском artisan-команды
+ * (см. `.claude/docs/process/migrations/v2.6.0.md`). Сервис обеспечивает только одну
+ * inline-копию — последний рубеж защиты на случай если pipeline-бэкапы не сработают.
+ *
+ * Имя таблицы намеренно содержит timestamp до секунды — повторный запуск создаёт новую
+ * таблицу, старые не удаляются (ручная чистка через несколько дней после успешного релиза).
+ */
+class OrderGuestsBackupService
+{
+    public function __construct(
+        private ConnectionInterface $db,
+    ) {
+    }
+
+    /**
+     * Создать бэкап-таблицу. Возвращает имя созданной таблицы для логирования.
+     *
+     * @param  string  $timestamp  опционально — для тестов чтобы зафиксировать имя
+     * @throws \RuntimeException если таблица с таким именем уже существует
+     */
+    public function createBackup(string $timestamp): string
+    {
+        $backupTable = $this->buildBackupTableName($timestamp);
+
+        // Проверка: если по случайности уже есть таблица с таким именем — не перезаписываем,
+        // лучше сразу падать. Это маловероятно (timestamp до секунды), но дёшевая защита.
+        $exists = $this->db->select(
+            'SHOW TABLES LIKE ?',
+            [$backupTable],
+        );
+        if (! empty($exists)) {
+            throw new \RuntimeException(sprintf(
+                'Backup-таблица %s уже существует — удалите её перед повторным запуском',
+                $backupTable,
+            ));
+        }
+
+        // `CREATE TABLE ... AS SELECT` — копирует ДАННЫЕ и колонки, но НЕ ключи/индексы.
+        // Для бэкапа этого достаточно (откат через INSERT работает на любых данных).
+        $this->db->statement(sprintf(
+            'CREATE TABLE `%s` AS SELECT * FROM `order_tickets`',
+            $backupTable,
+        ));
+
+        return $backupTable;
+    }
+
+    /**
+     * Сосчитать строки в бэкап-таблице — для проверки что бэкап непустой.
+     */
+    public function countRowsInBackup(string $backupTable): int
+    {
+        $result = $this->db->select(sprintf(
+            'SELECT COUNT(*) AS cnt FROM `%s`',
+            $backupTable,
+        ));
+
+        return (int) ($result[0]->cnt ?? 0);
+    }
+
+    /**
+     * Сосчитать строки в исходной таблице — для сверки.
+     */
+    public function countRowsInOrderTickets(): int
+    {
+        return (int) $this->db->table('order_tickets')->count();
+    }
+
+    public function buildBackupTableName(string $timestamp): string
+    {
+        // Защита от инъекций — оставляем только [a-zA-Z0-9_].
+        $safe = preg_replace('/[^a-zA-Z0-9_]/', '_', $timestamp);
+
+        return sprintf('order_tickets_backup_v2_6_0_%s', $safe);
+    }
+}

--- a/Backend/src/Order/OrderTicket/Migration/OrderGuestsMigrator.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderGuestsMigrator.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Order\OrderTicket\Migration;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Мигратор `order_tickets.guests` JSON из legacy формата (v2.5.x) в новый формат (v2.6.0).
+ *
+ * **Зачем:** в v2.6.0 каждый гость получает свой `ticket_type_id` / `promo_code` / `options[]`
+ * и собственный `price_snapshot` (MoneySnapshot). Раньше эти поля были на уровне заказа.
+ * См. `.claude/specs/order-format-architecture.md` §3.3.
+ *
+ * **Карта переноса** (legacy → new):
+ *   GuestsDto {id, value, email, number, festival_id}
+ *   + OrderTicket.ticket_type_id  ──┐
+ *   + OrderTicket.promo_code      ──┼──→  OrderGuestLine {..., ticket_type_id, promo_code, options=[],
+ *   + OrderTicket.price           ──┘     price_snapshot{base, options_sum=0, discount, total},
+ *   + OrderTicket.discount                is_live_ticket}
+ *   + ticket_type.is_live_ticket  ──→  OrderGuestLine.is_live_ticket
+ *
+ * **Распределение цены поровну между гостями:**
+ *   totalPerGuest    = round((order.price - order.discount) / count(guests))
+ *   discountPerGuest = round(order.discount / count(guests))
+ *   basePerGuest     = totalPerGuest + discountPerGuest   ← это priceItem (цена ДО скидки)
+ *
+ * Округление вносит расхождение ≤ (count - 1) рублей на заказ — допустимо
+ * (см. {@see OrderMigrationReport::maxAllowedRoundingError}).
+ *
+ * **Идемпотентность:** если у гостя уже есть `price_snapshot` — он считается мигрированным
+ * и пропускается (можно перезапускать команду многократно).
+ *
+ * **Что НЕ делает миграция:**
+ * - Не трогает `order_tickets.ticket_type_id` / `promo_code` / `price` / `discount` —
+ *   эти колонки остаются (для отката и для read-моделей до aggregate-rewrite).
+ * - Не валидирует структуру нового JSON через Domain VO `OrderGuestLine::fromState` —
+ *   потому что Domain в master ещё не готов и валидация может сломаться на peculiar данных.
+ *   Это произойдёт после aggregate-rewrite (sub-PR #5).
+ *
+ * Источник: Чистая архитектура — миграция как одноразовая команда вне Domain;
+ * Совершенный код, гл. «Защитное программирование» — try/catch на каждый заказ, отчёт об ошибках.
+ */
+class OrderGuestsMigrator
+{
+    public function __construct(
+        private ConnectionInterface $db,
+    ) {
+    }
+
+    /**
+     * Прогон миграции.
+     *
+     * @param  bool  $dryRun   true → ничего не пишем в БД, только считаем отчёт
+     * @param  int   $chunkSize  обработка пачками (память)
+     */
+    public function migrate(bool $dryRun = true, int $chunkSize = 100): OrderMigrationReport
+    {
+        $report = new OrderMigrationReport();
+
+        // Preload: ticket_type → is_live_ticket (одним запросом, чтобы избежать N+1).
+        $liveByTicketType = $this->loadLiveFlagByTicketType();
+
+        // Обрабатываем чанками — на 50k заказов разом память не закончится.
+        $this->db->table('order_tickets')
+            ->select(['id', 'guests', 'ticket_type_id', 'promo_code', 'price', 'discount'])
+            ->orderBy('id')
+            ->chunk($chunkSize, function ($rows) use ($report, $liveByTicketType, $dryRun) {
+                foreach ($rows as $row) {
+                    $this->migrateOneOrder($row, $report, $liveByTicketType, $dryRun);
+                }
+            });
+
+        return $report;
+    }
+
+    /**
+     * Преобразовать guests конкретного заказа. **Чистая функция** — не пишет в БД,
+     * возвращает новый массив + diff-метрики. Используется и для миграции, и для тестов.
+     *
+     * @param  array<int, array<string, mixed>>  $guests   текущий массив гостей (legacy или уже новый)
+     * @param  array<string, bool>  $liveByTicketType   map [ticket_type_id → is_live_ticket]
+     * @return array{
+     *     guests: array<int, array<string, mixed>>,
+     *     migrated: bool,
+     *     totalBefore: float,
+     *     totalAfter: float,
+     *     emptyGuests: bool,
+     * }
+     * @throws \RuntimeException при некорректных данных (отрицательный total, неизвестный ticket_type)
+     */
+    public function transformOrderGuests(
+        array $guests,
+        ?string $ticketTypeId,
+        ?string $promoCode,
+        float $price,
+        float $discount,
+        array $liveByTicketType,
+    ): array {
+        if (empty($guests)) {
+            return [
+                'guests' => $guests,
+                'migrated' => false,
+                'totalBefore' => 0.0,
+                'totalAfter' => 0.0,
+                'emptyGuests' => true,
+            ];
+        }
+
+        // Идемпотентность: если у ПЕРВОГО гостя есть price_snapshot — заказ уже мигрирован.
+        // Не разбираем массив целиком, потому что миграция всех гостей атомарна
+        // (UPDATE order_tickets.guests = ... обновляет весь JSON одной операцией).
+        if (isset($guests[0]['price_snapshot'])) {
+            return [
+                'guests' => $guests,
+                'migrated' => false,
+                'totalBefore' => 0.0,
+                'totalAfter' => 0.0,
+                'emptyGuests' => false,
+            ];
+        }
+
+        // Валидация: discount > price — означает кривые данные.
+        // Money не может быть отрицательным (конструктор VO кидает exception),
+        // поэтому отказываем заранее с понятным сообщением.
+        if ($discount > $price) {
+            throw new \RuntimeException(sprintf(
+                'discount > price (%.2f > %.2f) — отрицательный totalPerGuest недопустим',
+                $discount, $price,
+            ));
+        }
+
+        // Валидация: если ticket_type указан, но его нет в preload-карте, это сломанные данные
+        // (orphan FK / удалённый тип). Молчаливый fallback на is_live_ticket=false скрыл бы
+        // аномалию — лучше явно репортить и дать оператору решить.
+        if ($ticketTypeId !== null && ! array_key_exists($ticketTypeId, $liveByTicketType)) {
+            throw new \RuntimeException(sprintf(
+                'ticket_type %s не найден (orphan FK или удалённый тип)',
+                $ticketTypeId,
+            ));
+        }
+
+        $count = count($guests);
+        $totalBefore = $price - $discount;
+
+        // Banker's rounding (half-to-even) — совпадает с Money::fromFloat() в Shared.
+        // Без унификации после aggregate-rewrite миграция и runtime-расчёт расходились бы
+        // на граничных значениях (0.5, 1.5, 2.5 ...).
+        $totalPerGuest = (int) round($totalBefore / $count, 0, PHP_ROUND_HALF_EVEN);
+        $discountPerGuest = (int) round($discount / $count, 0, PHP_ROUND_HALF_EVEN);
+        $basePerGuest = $totalPerGuest + $discountPerGuest;  // priceItem ДО скидки
+
+        $isLiveTicket = $ticketTypeId !== null
+            && ($liveByTicketType[$ticketTypeId] ?? false);
+
+        $totalAfter = 0.0;
+        $newGuests = [];
+        foreach ($guests as $guest) {
+            $snapshot = [
+                'base_price' => $basePerGuest,
+                'options_sum' => 0,
+                'discount' => $discountPerGuest,
+                'total' => $totalPerGuest,
+            ];
+
+            $newGuests[] = array_merge($guest, [
+                'ticket_type_id' => $ticketTypeId,
+                'options' => [],
+                'promo_code' => $promoCode,
+                'price_snapshot' => $snapshot,
+                'is_live_ticket' => $isLiveTicket,
+            ]);
+
+            $totalAfter += $totalPerGuest;
+        }
+
+        return [
+            'guests' => $newGuests,
+            'migrated' => true,
+            'totalBefore' => (float) $totalBefore,
+            'totalAfter' => $totalAfter,
+            'emptyGuests' => false,
+        ];
+    }
+
+    /**
+     * Один заказ → отчёт.
+     *
+     * @param  object  $row  результат builder->get() (stdClass)
+     * @param  array<string, bool>  $liveByTicketType
+     */
+    private function migrateOneOrder(
+        object $row,
+        OrderMigrationReport $report,
+        array $liveByTicketType,
+        bool $dryRun,
+    ): void {
+        $report->totalScanned++;
+
+        try {
+            $rawGuests = json_decode((string) $row->guests, true, flags: JSON_THROW_ON_ERROR);
+            if (! is_array($rawGuests)) {
+                throw new \RuntimeException('guests JSON не array');
+            }
+
+            $result = $this->transformOrderGuests(
+                guests: $rawGuests,
+                ticketTypeId: $row->ticket_type_id,
+                promoCode: $row->promo_code,
+                price: (float) ($row->price ?? 0.0),
+                discount: (float) ($row->discount ?? 0.0),
+                liveByTicketType: $liveByTicketType,
+            );
+
+            if ($result['emptyGuests']) {
+                $report->emptyGuestsSkipped++;
+
+                return;
+            }
+
+            if (! $result['migrated']) {
+                $report->alreadyMigrated++;
+
+                return;
+            }
+
+            $report->totalBefore += $result['totalBefore'];
+            $report->totalAfter += $result['totalAfter'];
+            $report->maxAllowedRoundingError += max(0, count($rawGuests) - 1);
+
+            if (! $dryRun) {
+                $this->db->table('order_tickets')
+                    ->where('id', $row->id)
+                    ->update([
+                        'guests' => json_encode(
+                            $result['guests'],
+                            JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+                        ),
+                    ]);
+            }
+
+            $report->migrated++;
+        } catch (Throwable $e) {
+            $report->errors++;
+            if (count($report->errorMessages) < 50) {
+                $report->errorMessages[] = sprintf(
+                    'order=%s: %s',
+                    $row->id,
+                    $e->getMessage(),
+                );
+            }
+        }
+    }
+
+    /**
+     * Загрузить флаг `is_live_ticket` для всех типов билетов одним запросом.
+     *
+     * @return array<string, bool>  ключ — `ticket_type.id`, значение — `is_live_ticket`
+     */
+    private function loadLiveFlagByTicketType(): array
+    {
+        $rows = $this->db->table('ticket_type')
+            ->select(['id', 'is_live_ticket'])
+            ->get();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(string) $row->id] = (bool) $row->is_live_ticket;
+        }
+
+        return $map;
+    }
+}

--- a/Backend/src/Order/OrderTicket/Migration/OrderMigrationReport.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderMigrationReport.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\Order\OrderTicket\Migration;
+
+/**
+ * Отчёт о прогоне {@see OrderGuestsMigrator::migrate()}.
+ *
+ * Используется командой `order:migrate-to-guests-format` для печати таблицы итогов
+ * и в тестах — для assertions без чтения вывода.
+ *
+ * Все суммы — в рублях с копейками (float), потому что legacy `order_tickets.price`
+ * хранится как `float`. После v2.6.0 в `guests[].price_snapshot.*` всё в целых рублях
+ * (int), но миграция работает с **обоими форматами**, поэтому контрольные суммы float.
+ */
+final class OrderMigrationReport
+{
+    public function __construct(
+        /** Всего заказов отсмотрено */
+        public int $totalScanned = 0,
+        /** Заказов где guests уже в новом формате (price_snapshot есть) — пропущены идемпотентно */
+        public int $alreadyMigrated = 0,
+        /** Заказов с пустым `guests` (count = 0) — пропущены без ошибок */
+        public int $emptyGuestsSkipped = 0,
+        /** Заказов фактически мигрированных в этом прогоне */
+        public int $migrated = 0,
+        /** Заказов с ошибкой (битый JSON, неконсистентные поля, неизвестный ticket_type) */
+        public int $errors = 0,
+        /** Контрольная сумма `price - discount` ДО миграции (по всем мигрируемым заказам) */
+        public float $totalBefore = 0.0,
+        /** Контрольная сумма `Σ price_snapshot.total` ПО ВСЕМ ГОСТЯМ ПОСЛЕ миграции */
+        public float $totalAfter = 0.0,
+        /** Допустимое расхождение из-за округления: ≤ (count-1) рубль на заказ */
+        public float $maxAllowedRoundingError = 0.0,
+        /** Подробные ошибки (массив строк, не больше 50 для нумерации) */
+        public array $errorMessages = [],
+    ) {
+    }
+
+    /**
+     * Расхождение сумм. Если больше допустимого — миграция повредила данные.
+     */
+    public function roundingDelta(): float
+    {
+        return abs($this->totalAfter - $this->totalBefore);
+    }
+
+    public function isRoundingWithinTolerance(): bool
+    {
+        return $this->roundingDelta() <= $this->maxAllowedRoundingError;
+    }
+
+    /**
+     * Краткое описание прогона — для вывода в команде.
+     *
+     * @return array<int, array{string, int|string|float}>  пары [метрика, значение] для $this->table()
+     */
+    public function toTableRows(): array
+    {
+        return [
+            ['Всего отсмотрено', $this->totalScanned],
+            ['Уже мигрированы (idempotent skip)', $this->alreadyMigrated],
+            ['Пустые guests (skip)', $this->emptyGuestsSkipped],
+            ['Фактически мигрировано', $this->migrated],
+            ['Ошибок', $this->errors],
+            ['Сумма ДО (price - discount)', number_format($this->totalBefore, 2, '.', ' ')],
+            ['Сумма ПОСЛЕ (Σ price_snapshot.total)', number_format($this->totalAfter, 2, '.', ' ')],
+            ['Расхождение (округление)', number_format($this->roundingDelta(), 2, '.', ' ')],
+            ['Допустимое расхождение', number_format($this->maxAllowedRoundingError, 2, '.', ' ')],
+            ['Расхождение в допуске?', $this->isRoundingWithinTolerance() ? '✅ да' : '❌ НЕТ — данные повреждены'],
+        ];
+    }
+}

--- a/Backend/tests/Unit/Order/OrderTicket/Migration/OrderGuestsMigratorTest.php
+++ b/Backend/tests/Unit/Order/OrderTicket/Migration/OrderGuestsMigratorTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Order\OrderTicket\Migration;
+
+use Illuminate\Database\ConnectionInterface;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Tickets\Order\OrderTicket\Migration\OrderGuestsMigrator;
+
+/**
+ * Unit-тесты на чистую функцию {@see OrderGuestsMigrator::transformOrderGuests()}.
+ *
+ * Тестируем без БД — мокаем connection (он не используется внутри transformOrderGuests).
+ * Логика migrate() с обходом chunk() покрывается integration-тестами на staging.
+ */
+class OrderGuestsMigratorTest extends TestCase
+{
+    private const TICKET_TYPE_ORG = 'a1111111-1111-1111-1111-111111111111';
+    private const TICKET_TYPE_LIVE = 'a2222222-2222-2222-2222-222222222222';
+    private const PROMO_CODE = 'SYSTO20';
+
+    private OrderGuestsMigrator $migrator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connection = Mockery::mock(ConnectionInterface::class);
+        $this->migrator = new OrderGuestsMigrator($connection);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function transforms_single_guest_with_no_discount(): void
+    {
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        self::assertTrue($result['migrated']);
+        self::assertFalse($result['emptyGuests']);
+        self::assertSame(4200.0, $result['totalBefore']);
+        self::assertSame(4200.0, $result['totalAfter']);
+
+        $guest = $result['guests'][0];
+        self::assertSame(self::TICKET_TYPE_ORG, $guest['ticket_type_id']);
+        self::assertSame([], $guest['options']);
+        self::assertNull($guest['promo_code']);
+        self::assertFalse($guest['is_live_ticket']);
+
+        self::assertSame(4200, $guest['price_snapshot']['base_price']);
+        self::assertSame(0, $guest['price_snapshot']['options_sum']);
+        self::assertSame(0, $guest['price_snapshot']['discount']);
+        self::assertSame(4200, $guest['price_snapshot']['total']);
+    }
+
+    /** @test */
+    public function distributes_price_equally_across_two_guests(): void
+    {
+        // price 8400, discount 600 → totalPerGuest=(8400-600)/2=3900, discountPerGuest=300, base=4200
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван'), $this->legacyGuest('Мария')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: self::PROMO_CODE,
+            price: 8400.0,
+            discount: 600.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        self::assertTrue($result['migrated']);
+        self::assertSame(7800.0, $result['totalBefore']);  // 8400 - 600
+        self::assertSame(7800.0, $result['totalAfter']);   // 3900 × 2
+
+        foreach ($result['guests'] as $guest) {
+            self::assertSame(4200, $guest['price_snapshot']['base_price']);
+            self::assertSame(300, $guest['price_snapshot']['discount']);
+            self::assertSame(3900, $guest['price_snapshot']['total']);
+            self::assertSame(self::PROMO_CODE, $guest['promo_code']);
+        }
+    }
+
+    /** @test */
+    public function rounding_split_across_three_guests_within_tolerance(): void
+    {
+        // price 10000, discount 0, count 3 → totalPerGuest = round(10000/3) = 3333
+        // Σ total после = 3333 × 3 = 9999, расхождение -1 ₽ (≤ count-1 = 2)
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('A'), $this->legacyGuest('B'), $this->legacyGuest('C')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 10000.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        self::assertSame(10000.0, $result['totalBefore']);
+        self::assertSame(9999.0, $result['totalAfter']);
+        self::assertEqualsWithDelta(1.0, abs($result['totalBefore'] - $result['totalAfter']), 0.01);
+
+        foreach ($result['guests'] as $guest) {
+            self::assertSame(3333, $guest['price_snapshot']['total']);
+        }
+    }
+
+    /** @test */
+    public function preserves_existing_guest_fields_and_adds_new_ones(): void
+    {
+        $legacyGuest = [
+            'id' => '550e8400-e29b-41d4-a716-446655440000',
+            'value' => 'Иван Петров',
+            'email' => 'ivan@example.com',
+            'number' => 42,
+            'festival_id' => '660e8400-e29b-41d4-a716-446655440001',
+        ];
+
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$legacyGuest],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        $guest = $result['guests'][0];
+
+        // Старые поля сохранены
+        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $guest['id']);
+        self::assertSame('Иван Петров', $guest['value']);
+        self::assertSame('ivan@example.com', $guest['email']);
+        self::assertSame(42, $guest['number']);
+        self::assertSame('660e8400-e29b-41d4-a716-446655440001', $guest['festival_id']);
+
+        // Новые поля добавлены
+        self::assertArrayHasKey('ticket_type_id', $guest);
+        self::assertArrayHasKey('options', $guest);
+        self::assertArrayHasKey('promo_code', $guest);
+        self::assertArrayHasKey('price_snapshot', $guest);
+        self::assertArrayHasKey('is_live_ticket', $guest);
+    }
+
+    /** @test */
+    public function is_idempotent_skips_already_migrated_orders(): void
+    {
+        // Идемпотентность: повторный прогон не должен ничего менять.
+        $alreadyMigratedGuest = array_merge($this->legacyGuest('Иван'), [
+            'ticket_type_id' => self::TICKET_TYPE_ORG,
+            'options' => [],
+            'promo_code' => null,
+            'price_snapshot' => [
+                'base_price' => 4200,
+                'options_sum' => 0,
+                'discount' => 0,
+                'total' => 4200,
+            ],
+            'is_live_ticket' => false,
+        ]);
+
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$alreadyMigratedGuest],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        self::assertFalse($result['migrated']);
+        self::assertFalse($result['emptyGuests']);
+        // Гости остались без изменений (тот же массив)
+        self::assertEquals($alreadyMigratedGuest, $result['guests'][0]);
+    }
+
+    /** @test */
+    public function handles_empty_guests_array(): void
+    {
+        // Edge: заказ с пустым массивом гостей (не должно происходить, но защищаемся).
+        $result = $this->migrator->transformOrderGuests(
+            guests: [],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 0.0,
+            discount: 0.0,
+            liveByTicketType: [],
+        );
+
+        self::assertFalse($result['migrated']);
+        self::assertTrue($result['emptyGuests']);
+        self::assertSame([], $result['guests']);
+    }
+
+    /** @test */
+    public function propagates_is_live_ticket_flag_from_ticket_type(): void
+    {
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],
+            ticketTypeId: self::TICKET_TYPE_LIVE,
+            promoCode: null,
+            price: 3800.0,
+            discount: 0.0,
+            liveByTicketType: [
+                self::TICKET_TYPE_ORG => false,
+                self::TICKET_TYPE_LIVE => true,
+            ],
+        );
+
+        self::assertTrue($result['guests'][0]['is_live_ticket']);
+    }
+
+    /** @test */
+    public function throws_when_ticket_type_unknown(): void
+    {
+        // Раньше silent fallback на is_live_ticket=false скрывал orphan FK / удалённые типы.
+        // Теперь явно репортим — заказ попадёт в errors отчёта и команда вернёт FAILURE.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('ticket_type ffffffff-ffff-ffff-ffff-ffffffffffff не найден');
+
+        $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],
+            ticketTypeId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [],  // пустой map
+        );
+    }
+
+    /** @test */
+    public function throws_when_discount_exceeds_price(): void
+    {
+        // discount > price → отрицательный total. Money не может быть отрицательным,
+        // поэтому отвергаем заранее с понятным сообщением (вместо ошибки в Domain VO).
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('discount > price');
+
+        $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 100.0,
+            discount: 500.0,  // больше чем price
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+    }
+
+    /** @test */
+    public function uses_bankers_rounding_for_half_values(): void
+    {
+        // Banker's (half-even) для совпадения с Money::fromFloat(). На граничном 0.5:
+        // обычный round(0.5) = 1 (half-away-from-zero),
+        // banker's round(0.5, 0, HALF_EVEN) = 0 (округляем к чётному).
+        // Проверяем на price=1, count=2 → totalPerGuest = round(0.5) → ожидаем 0 (banker's).
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('A'), $this->legacyGuest('B')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 1.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        // 1/2 = 0.5 → banker's → 0 (round to even). 0+0 = 0.
+        foreach ($result['guests'] as $guest) {
+            self::assertSame(0, $guest['price_snapshot']['total']);
+        }
+        self::assertSame(0.0, $result['totalAfter']);
+    }
+
+    /** @test */
+    public function migrates_list_order_with_null_ticket_type_id(): void
+    {
+        // Заказы-списки (curator_id != null) имеют ticket_type_id = null — это норма.
+        // OrderGuestLine принимает nullable ticket_type_id.
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],
+            ticketTypeId: null,
+            promoCode: null,
+            price: 0.0,
+            discount: 0.0,
+            liveByTicketType: [],
+        );
+
+        self::assertTrue($result['migrated']);
+        self::assertNull($result['guests'][0]['ticket_type_id']);
+        self::assertFalse($result['guests'][0]['is_live_ticket']);
+        self::assertSame(0, $result['guests'][0]['price_snapshot']['total']);
+    }
+
+    /** @test */
+    public function options_sum_is_always_zero_for_legacy_orders(): void
+    {
+        // Опций в v2.5 не было — все мигрированные guests должны иметь options=[] и options_sum=0.
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван'), $this->legacyGuest('Мария')],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 8400.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+        );
+
+        foreach ($result['guests'] as $guest) {
+            self::assertSame([], $guest['options']);
+            self::assertSame(0, $guest['price_snapshot']['options_sum']);
+        }
+    }
+
+    /** @test */
+    public function discount_distributes_evenly_when_price_is_zero(): void
+    {
+        // Edge: price=0, discount=0 — список без цены. snapshot должен быть {0,0,0,0}.
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('A'), $this->legacyGuest('B')],
+            ticketTypeId: null,
+            promoCode: null,
+            price: 0.0,
+            discount: 0.0,
+            liveByTicketType: [],
+        );
+
+        foreach ($result['guests'] as $guest) {
+            self::assertSame(0, $guest['price_snapshot']['base_price']);
+            self::assertSame(0, $guest['price_snapshot']['options_sum']);
+            self::assertSame(0, $guest['price_snapshot']['discount']);
+            self::assertSame(0, $guest['price_snapshot']['total']);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function legacyGuest(string $name): array
+    {
+        return [
+            'id' => sprintf('550e8400-e29b-41d4-a716-%012d', mt_rand(1, 999999)),
+            'value' => $name,
+            'email' => sprintf('%s@example.com', strtolower($name)),
+            'number' => null,
+            'festival_id' => '660e8400-e29b-41d4-a716-446655440001',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Sub-PR #4 в `feat/v2.6.0-fall-festival`. **Артизан-команда + сервис трансформации `order_tickets.guests`** из legacy формата (поля заказа) в новый формат v2.6.0 (per-guest).

**Решение по плану:** [tech-lead агент](https://github.com/ShaevMV/systo/pull/68#issuecomment-) предложил **вариант D** — data-migration независимо от aggregate-rewrite, чтобы тестировать миграцию на staging параллельно с переписыванием Domain.

**Прогресс v2.6.0:**
- ✅ #62 Money VO
- ✅ #66 Domain VO
- ✅ #68 + #69 OrderPriceCalculator
- 👉 **этот PR** — data-migration (sub-PR #4)
- ⏳ aggregate-rewrite (sub-PR #5)
- ⏳ controllers-rewrite + buy-form

## Что добавлено

### Артизан-команда

```bash
php artisan order:migrate-to-guests-format                           # dry-run (default)
php artisan order:migrate-to-guests-format --apply                   # apply с inline-бэкапом
php artisan order:migrate-to-guests-format --apply --no-backup --force  # CI/CD без TTY
php artisan order:migrate-to-guests-format --chunk=500               # размер пачки
```

### Файлы

| Файл | Что |
|------|-----|
| `Backend/app/Console/Commands/MigrateOrdersToGuestsFormatCommand.php` | Тонкая команда — DI, опции, отчёт |
| `Backend/src/Order/OrderTicket/Migration/OrderGuestsMigrator.php` | Ядро: `transformOrderGuests()` чистая функция (testable) |
| `Backend/src/Order/OrderTicket/Migration/OrderGuestsBackupService.php` | `CREATE TABLE order_tickets_backup_v2_6_0_<TS> AS SELECT ...` |
| `Backend/src/Order/OrderTicket/Migration/OrderMigrationReport.php` | DTO результата + допуск округления |
| `Backend/tests/Unit/Order/OrderTicket/Migration/OrderGuestsMigratorTest.php` | 13 unit-кейсов |
| `.claude/docs/process/migrations/v2.6.0.md` | Runbook: staging→prod, rollback, edge-cases |

### Формула распределения цены

```
totalPerGuest    = round((price - discount) / count, HALF_EVEN)
discountPerGuest = round(discount / count, HALF_EVEN)
basePerGuest     = totalPerGuest + discountPerGuest    # priceItem ДО скидки
options          = []                                  # legacy не имел опций
is_live_ticket   = ticket_type.is_live_ticket          # preload одним запросом
```

**Допуск округления:** `Σ (count-1) ₽` по всем заказам. Превышение → FAILURE + транзакция откатывается.

### Banker's rounding (HALF_EVEN)

Унифицировано с `Money::fromFloat()`. На граничных значениях (0.5, 1.5, 2.5) поведение совпадает с runtime-расчётом — не будет разъезжаться после aggregate-rewrite.

## Защиты (по итогам adversarial verify)

| Severity | Что | Решение |
|----------|-----|---------|
| **CRITICAL** | `confirm()` блокирует CI/CD (no TTY) | `--force` флаг |
| **HIGH** | `round()` (away-from-zero) ≠ `Money::fromFloat()` (banker's) | `PHP_ROUND_HALF_EVEN` |
| **HIGH** | `discount > price` → silent отрицательный | `RuntimeException` |
| **HIGH** | `errors > 0` возвращало SUCCESS | проверка перед SUCCESS |
| **MEDIUM** | Unknown ticket_type → silent fallback false | `RuntimeException` |
| **MEDIUM** | Maintenance window не задокументирован | секция в guide |

## Откат

См. `.claude/docs/process/migrations/v2.6.0.md` § «Откат».

Кратко: `TRUNCATE order_tickets; INSERT INTO order_tickets SELECT * FROM order_tickets_backup_v2_6_0_<TS>;`
**Важно:** требует maintenance window (потеря новых заказов между миграцией и откатом).

## Что НЕ делает

- Не удаляет старые колонки (`order_tickets.ticket_type_id`, `promo_code`, `price`, `discount`) — оставлены для отката. Удалит aggregate-rewrite (sub-PR #5).
- Не валидирует через `OrderGuestLine::fromState` — Domain в master ещё legacy.

## Тесты

- 13 unit-кейсов через `Mockery` (БД не нужна)
- Покрытие: распределение 1/2/3 гостя, banker's rounding на 0.5, идемпотентность, empty guests, list-order, propagation is_live_ticket, discount>price exception, unknown ticket_type exception
- **Локально: 139/139 ✅** (Money + Snapshot + GuestLine + Migrator)

## Test plan

- [x] Unit-тесты локально
- [ ] CI staging (auto-deploy на push в staging)
- [ ] **Прогон dry-run на staging:** `docker exec php-staging php artisan order:migrate-to-guests-format`
- [ ] **Прогон --apply на staging:** проверить inline-бэкап + содержимое `guests[].price_snapshot`

## Ссылки для проверки на стенде

- БД: https://pma.staging.spaceofjoy.ru/ → `order_tickets` → колонка `guests` (после `--apply` появится `price_snapshot`)
- Бэкап-таблица: `order_tickets_backup_v2_6_0_<TS>` появится в той же БД
- Логи: `docker exec php-staging tail -f storage/logs/laravel.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)