### PR TITLE
docs(spec): handoff для v2.6.0 aggregate-rewrite

### DIFF
--- a/.claude/specs/v2.6.0-aggregate-rewrite-handoff.md
+++ b/.claude/specs/v2.6.0-aggregate-rewrite-handoff.md
@@ -1,0 +1,254 @@
+# Handoff: v2.6.0 aggregate-rewrite
+
+**Дата создания:** 2026-06-03
+**Контекст:** sub-PR #5 в `feat/v2.6.0-fall-festival`, до дедлайна 2026-06-12 (старт продаж).
+
+## Старт новой сессии
+
+**Скажи Claude:**
+> Продолжаем v2.6.0 aggregate-rewrite. Прочитай `.claude/specs/v2.6.0-aggregate-rewrite-handoff.md` и `.claude/specs/order-format-architecture.md` §4-5. Создай ветку `feat/v2.6.0-aggregate-rewrite` от master и начни Этап 1 (Domain + DTO).
+
+Этого достаточно — handoff содержит всё, что нужно.
+
+---
+
+## Что уже сделано (master)
+
+| PR | Что | Где |
+|----|-----|-----|
+| #62 | `Shared\Domain\ValueObject\Money` | `Shared/Domain/ValueObject/Money.php` |
+| #66 | `OrderGuestLine`, `OrderGuestOption`, `MoneySnapshot` | `Backend/src/Order/OrderTicket/Domain/ValueObject/` |
+| #68 + #69 | `OrderPriceCalculator` + `RawGuestInput` + `CalculateOrderPriceQuery` | `Backend/src/Order/OrderTicket/Application/Pricing/` |
+| #70 | Artisan `order:migrate-to-guests-format` + миграция данных | `Backend/src/Order/OrderTicket/Migration/` |
+
+**Готовые "кирпичики" для aggregate-rewrite:**
+- `OrderGuestLine` — VO одной строки заказа (`id`, `value`, `email`, `number`, `festival_id`, `ticket_type_id`, `options[]`, `promo_code`, `price_snapshot: MoneySnapshot`, `is_live_ticket`). Имеет `fromState()`, `toArray()`, `total(): Money`.
+- `MoneySnapshot` — VO детализации цены (`basePrice`, `optionsSum`, `discount`) + `total(): Money`.
+- `OrderPriceCalculator::calculateLines(festivalId, RawGuestInput[]): OrderGuestLine[]` — получает per-guest payload, возвращает готовые VO с заполненными `price_snapshot`.
+
+---
+
+## Решение по подходу (tech-lead)
+
+**Один атомарный PR** в одной ветке `feat/v2.6.0-aggregate-rewrite`. **Не** делить на 3 PR — master будет в нерабочем состоянии (Domain в новом формате, Controllers в старом → 500). Tech-lead против двух форматов в Domain (нарушает Dependency Rule).
+
+**Разбить работу на 3 сессии Claude**, но всё в одной ветке + один PR в конце:
+
+| Сессия | Что |
+|--------|-----|
+| **Сессия 1** | Domain агрегат `OrderTicket` + DTO `OrderTicketDto` |
+| **Сессия 2** | Repository + Domain Events |
+| **Сессия 3** | Controllers + Tests + adversarial verify + open PR |
+
+Оценка tech-lead: ~6.5 рабочих дней.
+
+---
+
+## Карта переписки
+
+### Слой 1: Domain агрегат `Backend/src/Order/OrderTicket/Domain/OrderTicket.php`
+
+**Текущее (640 строк, 15 фабрик):**
+```php
+class OrderTicket extends AggregateRoot {
+    use HasHistory;
+    protected Uuid     $festival_id;
+    protected Uuid     $user_id;
+    protected ?Uuid    $types_of_payment_id;
+    protected PriceDto $price;            // ← УДАЛИТЬ
+    protected Status   $status;
+    protected array    $ticket;           // ← ЗАМЕНИТЬ на $guests: OrderGuestLine[]
+    protected Uuid     $id;
+    protected ?string  $promo_code;        // ← УДАЛИТЬ (per-guest теперь)
+    protected ?Uuid    $location_id;
+    protected ?Uuid    $curator_id;
+}
+```
+
+**Новое:**
+```php
+class OrderTicket extends AggregateRoot {
+    use HasHistory;
+    protected Uuid     $festival_id;
+    protected Uuid     $user_id;
+    protected ?Uuid    $types_of_payment_id;
+    protected array    $guests;           // ← OrderGuestLine[]
+    protected Status   $status;
+    protected Uuid     $id;
+    protected ?Uuid    $location_id;
+    protected ?Uuid    $curator_id;
+
+    public function totalPrice(): Money { /* sum guests[].total() */ }
+    public function isLive(): bool { /* guests[0]->isLive() — все одинаковы по инварианту */ }
+}
+```
+
+**15 фабрик** (имена сохраняются):
+1. `create(OrderTicketDto, kilter)` → status из DTO + `ProcessUserNotificationNewOrderTicket`
+2. `toPaidInLiveTicket(OrderTicketDto, kilter)` → `PAID_FOR_LIVE` + create + paid_live + questionnaires
+3. `toProcessGuestNotificationQuestionnaire(OrderTicketDto)` → only questionnaires
+4. `toPaid(OrderTicketDto, ?comment, ?ExternalPromoCodeDto)` → `PAID` + create + paid + questionnaires + telegram
+5. `toPaidFriendly(OrderTicketDto, ?comment, ?ExternalPromoCodeDto)` → `PAID` + paid_friendly variant
+6. `toCancel(OrderTicketDto)` → `CANCEL` + cancel + cancel_email
+7. `toCancelLive(OrderTicketDto)` → `CANCEL_FOR_LIVE` + cancel + cancel_live
+8. `toLiveIssued(OrderTicketDto, $liveNumber[])` → `LIVE_TICKET_ISSUED` + create + questionnaires + push_live
+9. `toRemoveTicket(OrderTicketDto, ticketId)` → no status + cancel(ticketId)
+10. `toChangeTicket(OrderTicketDto, $valueMap, $emailMap)` → no status + cancel + create + changed_email + questionnaires
+11. `toDifficultiesArose(OrderTicketDto, comment)` → `DIFFICULTIES_AROSE` + cancel + difficulties_email
+12. `createList(OrderTicketDto, kilter, ?locationName)` → `NEW_LIST` + history only
+13. `toApproveList(OrderTicketDto)` → `APPROVE_LIST` + create + list_approved + questionnaires
+14. `toCancelList(OrderTicketDto)` → `CANCEL_LIST` + cancel + list_cancel
+15. `toListDifficultiesArose(OrderTicketDto, comment)` → `DIFFICULTIES_AROSE_LIST` + cancel + list_difficulties
+
+**Главная замена в каждой фабрике:** `$dto->getTicket()` (GuestsDto[]) → `$dto->getGuests()` (OrderGuestLine[]). `$dto->getTicketTypeId()` → `$guest->ticketTypeId`. `$dto->getPromoCode()` → `$guest->promoCode`.
+
+### Слой 2: DTO `Backend/src/Order/OrderTicket/Dto/OrderTicket/OrderTicketDto.php`
+
+**Текущее (283 строки):** 20 полей в конструкторе включая `ticket_type_id`, `promo_code`, `ticket: GuestsDto[]`, `priceDto: PriceDto`.
+
+**Новое:**
+- `ticket_type_id` — УДАЛИТЬ
+- `promo_code` — УДАЛИТЬ
+- `priceDto` — УДАЛИТЬ (добавить `totalPrice(): Money` — агрегация)
+- `ticket: GuestsDto[]` → `guests: OrderGuestLine[]`
+- `fromState($data, $userId, $isLiveTicket, ?$pusherId)` — больше не принимает `PriceDto` (цена внутри guests). Парсит `$data['guests']` через `OrderGuestLine::fromState()` для каждого элемента.
+- `fromStateForList($data, $userId, $curatorId, $locationId)` — аналогично, но `OrderGuestLine` с `ticket_type_id=null` и `price_snapshot=MoneySnapshot::zero()`.
+- `toArray()` — `$jsonGuests = json_encode([OrderGuestLine[].toArray()])`. Колонки `ticket_type_id`, `promo_code` уходят, `price`/`discount` тоже (читаются из `guests[].price_snapshot`).
+
+### Слой 3: Repository `Backend/src/Order/OrderTicket/Repositories/InMemoryMySqlOrderTicketRepository.php`
+
+| Метод | Что меняется |
+|-------|--------------|
+| `create()` | Убрать вставку `ticket_type_id`/`promo_code`/`price`/`discount` (или оставить null для backward-compat — спросить). Поле `guests` JSON в новом формате. |
+| `findOrder()` | `OrderTicketDto::fromState($data, $userId)` — без `PriceDto` (внутри). Если `curator_id` есть → `fromStateForList`. |
+| `getItem()` | Парсить `guests` JSON в `OrderGuestLine[]` для Response. |
+| `getList()` / `getUserList()` / `getFriendlyList()` / `getListsList()` | Парсить `guests` JSON в Response классах. |
+| `changeStatus(orderId, status, OrderGuestLine[])` | Сериализовать массив через `array_map(fn($g) => $g->toArray(), $guests)`. |
+| `updateGuests(orderId, OrderGuestLine[])` | Аналогично. |
+| `changePrice(orderId, float)` | **Под вопросом**: цена теперь в guests, отдельной колонки нет. Возможно метод устарел — спросить пользователя или удалить через `ChangeOrderPriceCommand`. |
+
+### Слой 4: Controllers `Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php`
+
+**~810 строк, 3 ключевых метода для переписки:**
+
+1. **`create()` (строка ~117)** — обычный заказ:
+   - Принимает payload с `guests: RawGuestInput[]` (per-guest `ticket_type_id`, `options`, `promo_code`).
+   - Использует `CalculateOrderPriceQueryHandler` для получения `OrderGuestLine[]`.
+   - Создаёт `OrderTicketDto::fromState()` с новыми guests.
+   - Валидация через FormRequest `CreateOrderTicketsRequest` (нужно переписать под per-guest).
+
+2. **`createFriendly()` (строка ~209)** — friendly заказ, аналогично.
+
+3. **`createList()` (строка ~311)** — заказ-список, аналогично но без опций/промо.
+
+**Метод `create()` с заголовком `AutoPayment`** — оставить логику авто-PAID, проверить что работает.
+
+### Слой 5: Domain Events (14 классов)
+
+Все события которые получают `getTicket()` (массив GuestsDto):
+- `ProcessCreateTicket($orderId, GuestsDto[] $guests)` → `ProcessCreateTicket($orderId, OrderGuestLine[] $guests)`
+- `ProcessGuestNotificationQuestionnaire($email, $orderId, $ticketId)` — без изменения сигнатуры
+- `ProcessUserNotificationOrderPaid($email, GuestsDto[] $tickets, ...)` → `OrderGuestLine[]`
+- `ProcessUserNotificationOrderPaidFriendly`, `ProcessUserNotificationListApproved` — аналогично
+- `ProcessCancelLiveTicket($orderId, GuestsDto[] $guests)` → `OrderGuestLine[]`
+- `ProcessUserNotificationOrderTicketChanged` — содержит `changes` map, проверить структуру
+
+**Каждое событие — Eloquent Job в `Backend/src/Order/OrderTicket/Events/` или `app/Jobs/`.** Найди через `grep -rn "implements ShouldQueue" Backend/`.
+
+### Слой 6: Тесты (5 файлов)
+
+- `tests/Unit/Order/OrderTicket/Application/ChangeOrderPriceTest.php` — может устареть (нет priceDto)
+- `tests/Unit/Order/OrderTicket/Application/Create/CreateOrderTest.php` — переписать фикстуру
+- `tests/Unit/Order/OrderTicket/Domain/OrderTicketToPaidFriendlyTest.php` — переписать
+- `tests/Unit/Order/OrderTicket/Domain/OrderTicketToChangeTicketTest.php` — переписать
+- `tests/Unit/Ticket/Application/ApplicationTicketTest.php` — GuestsDto fixture → OrderGuestLine
+
+---
+
+## Известные риски (из adversarial verify планировавшегося в PR)
+
+1. **Backward-compat при чтении legacy данных** — после деплоя нового кода миграция (PR #70) должна быть запущена. Если данные в БД ещё legacy (без `price_snapshot`) — `OrderGuestLine::fromState` упадёт с `InvalidArgumentException`. Это **правильно** (fail-fast), но runbook деплоя должен начинать с миграции.
+
+2. **Domain Events Jobs могут быть в очереди со старыми payload-ами** — если в moment деплоя есть невыполненные jobs с `GuestsDto[]`, после деплоя они не смогут десериализоваться. Решение: дренировать `php artisan queue:work --stop-when-empty` до деплоя.
+
+3. **`getTicketTypeId()` на DTO исчезнет** — все вызовы по проекту (включая фильтры в `OrderListFilterQueryHandler`) нужно обновить.
+
+4. **`OrderTickets::createFriendly()` использует `request.price` напрямую (баг!)** — переписка должна **убрать** этот баг (цена считается на бэке через Calculator).
+
+---
+
+## Чек-лист сессии 1 (Domain + DTO)
+
+```
+[ ] git checkout master && git pull origin master
+[ ] git checkout -b feat/v2.6.0-aggregate-rewrite (если ветки нет)
+[ ] Прочитать Domain/OrderTicket.php целиком (640 строк) — НЕ через Explore, целиком
+[ ] Прочитать Dto/OrderTicket/OrderTicketDto.php целиком (283 строки)
+[ ] Прочитать ValueObject/OrderGuestLine.php (готовый VO)
+[ ] Переписать OrderTicketDto (новый конструктор, fromState без PriceDto, toArray)
+[ ] Переписать OrderTicket (поля $guests, методы totalPrice/isLive, 15 фабрик)
+[ ] Локальный php -l (syntax check)
+[ ] Commit "feat(order): aggregate + DTO под формат v2.6.0 (этап 1/3)"
+[ ] git push -u origin feat/v2.6.0-aggregate-rewrite (не staging — будет ломаться)
+[ ] Сказать пользователю: «Этап 1 готов, в новой сессии Этап 2 (Repository + Events)»
+```
+
+## Чек-лист сессии 2 (Repository + Events)
+
+```
+[ ] git checkout feat/v2.6.0-aggregate-rewrite && git pull
+[ ] Repository: все методы переписать под guests[]
+[ ] Domain Events: 14 классов обновить
+[ ] Response классы (OrderTicketItemResponse, OrderTicketItemForListResponse и пр.) обновить
+[ ] Commit "feat(order): Repository + Events под формат v2.6.0 (этап 2/3)"
+[ ] git push
+```
+
+## Чек-лист сессии 3 (Controllers + Tests + PR)
+
+```
+[ ] FormRequest CreateOrderTicketsRequest — переписать под per-guest
+[ ] OrderTickets controller: create / createFriendly / createList переписать
+[ ] 5 тестов переписать
+[ ] docker exec php-solarSysto ./vendor/bin/phpunit (ожидаем зелёный)
+[ ] Adversarial verify через Workflow (correctness + architecture + security)
+[ ] Исправить находки
+[ ] git push origin feat/v2.6.0-aggregate-rewrite:refs/heads/staging --force
+[ ] git push origin feat/v2.6.0-aggregate-rewrite
+[ ] gh pr create --base master --title "feat(order): aggregate-rewrite (v2.6.0)"
+```
+
+---
+
+## Полезные команды
+
+```bash
+# Прочитать всё что готово
+ls Backend/src/Order/OrderTicket/Domain/ValueObject/
+ls Backend/src/Order/OrderTicket/Application/Pricing/
+ls Backend/src/Order/OrderTicket/Migration/
+
+# Узнать структуру таблицы (важно для Repository)
+docker exec mysql-solarSysto mysql -uroot -p systo -e "DESCRIBE order_tickets"
+
+# Прогнать тесты
+docker exec php-solarSysto ./vendor/bin/phpunit --no-coverage
+
+# Текущий формат JSON в БД после миграции
+docker exec mysql-solarSysto mysql -uroot -p systo -e "SELECT guests FROM order_tickets LIMIT 1\G"
+```
+
+---
+
+## Спецификации (читать перед сессией)
+
+- `.claude/specs/order-format-architecture.md` — **главная спека v2.6.0** (§4 Domain, §5 Application, §6 Repository)
+- `.claude/docs/process/migrations/v2.6.0.md` — runbook миграции данных (для понимания формата)
+- `.claude/docs/BUSINESS_RULES.md` §1 — матрица переходов статусов (не меняется)
+
+## Ссылки на стенд
+
+- API healthcheck: https://api.staging.spaceofjoy.ru/
+- БД: https://pma.staging.spaceofjoy.ru/
+- Mailpit: https://mail.staging.spaceofjoy.ru/ (для проверки email после `--apply`)
+- См. `.claude/docs/STAGING_LINKS.md` за паролями


### PR DESCRIPTION
## Summary

Handoff-документ `.claude/specs/v2.6.0-aggregate-rewrite-handoff.md` для продолжения работы над **aggregate-rewrite** в новой сессии Claude без блюра контекста.

## Что внутри

- **Старт новой сессии** — точный prompt для Claude
- **Что уже сделано** в master (PR #62/#66/#68/#69/#70 + готовые VO)
- **Решение по подходу** от tech-lead — один атомарный PR, 3 сессии в одной ветке
- **Карта переписки** по 6 слоям:
  - Domain агрегат (640 строк, 15 фабрик с описанием)
  - DTO (283 строки)
  - Repository (350 строк)
  - Controllers (~810 строк, 3 ключевых метода)
  - Domain Events (14 классов)
  - Tests (5 файлов)
- **Чек-листы по 3 сессиям** Claude
- **Известные риски** (deploy order, queued jobs, getTicketTypeId исчезает, баг в createFriendly)
- **Полезные команды** + ссылки на спеки/стенд

## Как использовать

В новой сессии напиши Claude:

> Продолжаем v2.6.0 aggregate-rewrite. Прочитай `.claude/specs/v2.6.0-aggregate-rewrite-handoff.md` и `.claude/specs/order-format-architecture.md` §4-5. Создай ветку `feat/v2.6.0-aggregate-rewrite` от master и начни Этап 1 (Domain + DTO).

Этого достаточно — handoff содержит всё что нужно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)