### PR TITLE
feat(order): новая форма покупки (per-guest) + понятный вывод заказа + инфра-фиксы (v2.6.0)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -281,6 +281,8 @@ jobs:
             done
           done
 
+          # Каталог PDF билетов + симлинк public/storage (иначе билеты 404, даже если сгенерены).
+          docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging sh -c "mkdir -p storage/app/public/tickets && php artisan storage:link || true"
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging     chown -R www-data:www-data storage bootstrap/cache
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root phpbaza-staging chown -R www-data:www-data storage bootstrap/cache
           echo "✓ storage и bootstrap/cache принадлежат www-data"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -238,6 +238,9 @@ jobs:
       - name: Build frontend (npm ci + npm run build)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |
+          # Чистим прошлый dist под root: после `chown deploy` на хосте файлы прошлой сборки
+          # внутри контейнера принадлежат чужому UID → vue-cli падает с EACCES при unlink.
+          docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps -u root node-staging sh -c "rm -rf dist"
           docker compose -f docker-compose.staging.yml --env-file .env.staging run --rm --no-deps node-staging sh -c "npm ci --include=dev && npm run build"
 
       - name: Up containers

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -285,7 +285,10 @@ jobs:
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging sh -c "mkdir -p storage/app/public/tickets && php artisan storage:link || true"
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging     chown -R www-data:www-data storage bootstrap/cache
           docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root phpbaza-staging chown -R www-data:www-data storage bootstrap/cache
-          echo "✓ storage и bootstrap/cache принадлежат www-data"
+          # Воркер бежит под `user` (он в группе www-data) — делаем storage group-writable
+          # + setgid на каталогах, чтобы новые файлы (PDF/логи/views) наследовали группу www-data.
+          docker compose -f docker-compose.staging.yml --env-file .env.staging exec -T -u root php-staging sh -c "chmod -R g+rwX storage bootstrap/cache && find storage bootstrap/cache -type d -exec chmod g+s {} +"
+          echo "✓ storage и bootstrap/cache: владелец www-data, группа с правом записи (для воркера)"
 
       # Если БД `baza` ещё не создана (например, MySQL был инициализирован до
       # появления init-скрипта Docker/mysql/init/01-create-baza.sql) — создаём её

--- a/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
+++ b/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
@@ -174,6 +174,53 @@ class OrderTickets extends Controller
 
 
     /**
+     * Live-расчёт цены заказа без сохранения (per-guest) — для формы покупки.
+     *
+     * Принимает тот же per-guest payload, что и create (`festival_id` + `guests[]` с
+     * `ticket_type_id`/`options`/`promo_code`), считает цену на бэке через `OrderPriceCalculator`
+     * и возвращает разбивку по строкам + итог. Ничего не сохраняет, события/историю не пишет.
+     */
+    public function calculatePrice(Request $request): JsonResponse
+    {
+        try {
+            $festivalId = new Uuid((string) $request->input('festival_id'));
+
+            $rawGuests = array_map(
+                static fn (array $guest): RawGuestInput => RawGuestInput::fromState($guest),
+                $request->input('guests', []),
+            );
+
+            $lines = $this->orderPriceCalculator->calculateLines($festivalId, $rawGuests);
+
+            $total = 0;
+            $resultLines = [];
+            foreach ($lines as $line) {
+                $snapshot = $line->price;
+                $lineTotal = $line->total()->amount();
+                $resultLines[] = [
+                    'basePrice' => $snapshot->basePrice->amount(),
+                    'optionsSum' => $snapshot->optionsSum->amount(),
+                    'discount' => $snapshot->discount->amount(),
+                    'total' => $lineTotal,
+                ];
+                $total += $lineTotal;
+            }
+
+            return response()->json([
+                'success' => true,
+                'lines' => $resultLines,
+                'totalPrice' => $total,
+            ]);
+        } catch (Throwable $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 422);
+        }
+    }
+
+
+    /**
      * Создать заказ
      *
      * @throws Throwable

--- a/Backend/routes/order.php
+++ b/Backend/routes/order.php
@@ -12,6 +12,9 @@ Route::prefix('v1/order')->group(static function (): void {
     Route::post('/create',
         [OrderTickets::class, 'create']);
 
+    // live-расчёт цены заказа без сохранения (для формы покупки, per-guest)
+    Route::post('/calculatePrice', [OrderTickets::class, 'calculatePrice']);
+
     Route::post('/createFriendly',[OrderTickets::class, 'createFriendly'])
         ->middleware('auth:api')
         ->middleware('role:pusher,pusher_curator');

--- a/Backend/src/Order/OrderTicket/Migration/OrderGuestsBackupService.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderGuestsBackupService.php
@@ -40,8 +40,11 @@ class OrderGuestsBackupService
 
         // Проверка: если по случайности уже есть таблица с таким именем — не перезаписываем,
         // лучше сразу падать. Это маловероятно (timestamp до секунды), но дёшевая защита.
+        // Через information_schema (а не `SHOW TABLES LIKE ?`): MySQL/PDO не поддерживает
+        // плейсхолдеры в `SHOW TABLES` → биндинг падает с syntax error near '?'.
         $exists = $this->db->select(
-            'SHOW TABLES LIKE ?',
+            'SELECT table_name FROM information_schema.tables
+             WHERE table_schema = DATABASE() AND table_name = ?',
             [$backupTable],
         );
         if (! empty($exists)) {

--- a/Docker/worker/Dockerfile
+++ b/Docker/worker/Dockerfile
@@ -41,6 +41,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 #
 RUN useradd -m user
+# Воркер бежит под `user`, но пишет в storage (владелец www-data). Членство в группе
+# www-data + group-writable storage (deploy: chmod g+w) даёт право писать логи/PDF/views.
+RUN usermod -aG www-data user
 RUN chown -R user:user /var/www/html
 RUN chgrp -R user /var/www/html
 

--- a/Docker/worker/conf/supervisord.conf
+++ b/Docker/worker/conf/supervisord.conf
@@ -9,7 +9,10 @@ process_name=%(program_name)s_%(process_num)02d
 command=php /var/www/org/artisan queue:work --tries=3 --timeout=3000
 autostart=true
 autorestart=true
-user=user
+; Воркер пишет в storage (логи, framework/views, PDF билетов), а storage принадлежит
+; www-data (deploy: chown -R www-data storage). Под юзером `user` queue:work падал с
+; Permission denied → билеты/PDF/письма не создавались. www-data совпадает с web-контейнером.
+user=www-data
 numprocs=1
 timeout=60*60
 redirect_stderr=true

--- a/Docker/worker/conf/supervisord.conf
+++ b/Docker/worker/conf/supervisord.conf
@@ -9,10 +9,10 @@ process_name=%(program_name)s_%(process_num)02d
 command=php /var/www/org/artisan queue:work --tries=3 --timeout=3000
 autostart=true
 autorestart=true
-; Воркер пишет в storage (логи, framework/views, PDF билетов), а storage принадлежит
-; www-data (deploy: chown -R www-data storage). Под юзером `user` queue:work падал с
-; Permission denied → билеты/PDF/письма не создавались. www-data совпадает с web-контейнером.
-user=www-data
+; Воркер работает под `user` (под www-data queue:work не консьюмит задачи).
+; Право писать в storage (логи/framework/views/PDF, владелец www-data) даётся через
+; членство `user` в группе www-data (см. Dockerfile usermod) + group-writable storage.
+user=user
 numprocs=1
 timeout=60*60
 redirect_stderr=true

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -31,7 +31,8 @@
   "eslintConfig": {
     "root": true,
     "env": {
-      "node": true
+      "node": true,
+      "vue/setup-compiler-macros": true
     },
     "extends": [
       "plugin:vue/vue3-essential",

--- a/FrontEnd/src/components/BuyTicket/BuyTicket.vue
+++ b/FrontEnd/src/components/BuyTicket/BuyTicket.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="container-fluid">
+    <!-- Кнопка-триггер модалки успеха (скрыта) -->
     <button
         type="button"
         class="btn btn-primary"
@@ -11,6 +12,7 @@
       Launch demo modal
     </button>
 
+    <!-- Модалка успеха -->
     <div
         class="modal fade"
         id="exampleModal"
@@ -23,422 +25,200 @@
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="exampleModalLabel">Успех</h5>
-            <button
-                type="button"
-                class="close"
-                data-dismiss="modal"
-                aria-label="Close"
-            >
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
               <span aria-hidden="true">х</span>
             </button>
           </div>
           <div class="modal-body" v-html="message"></div>
           <div class="modal-footer">
-            <button
-                type="button"
-                class="btn btn-secondary"
-                data-dismiss="modal"
-            >
-              Закрыть
-            </button>
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Закрыть</button>
           </div>
         </div>
       </div>
     </div>
+
     <div class="text-center title-block">
       <h1>Форма подтверждения добровольного оргвзноса</h1>
-      <small class="form-text text-muted"
-      >на создание туристического слёта Solar Systo Togathering 2026</small
-      >
+      <small class="form-text text-muted">
+        на создание туристического слёта Solar Systo Togathering 2026
+      </small>
     </div>
+
     <div class="row" id="main-form">
       <div class="col-md-10 mx-auto">
         <div class="card mt-2 mx-auto">
           <div class="card-body">
-            <div id="contact-form" role="form">
-              <div class="controls">
-                <div class="pp1 row">
-                  <span>ШАГ 1.</span> Введи свои контактные данные, после чего
-                  система автоматически создаст тебе аккаунт:
-                </div>
-                <div class="row y-row">
-                  <div class="col-md-4">
-                    <div class="form-group">
-                      <label for="form_email" class="hidder">Email *</label>
-                      <input
-                          id="form_email"
-                          type="email"
-                          name="email"
-                          class="form-control"
-                          placeholder="Email: *"
-                          required="required"
-                          v-model="email"
-                          data-error="Valid email is required."
-                      />
-                      <small class="form-text text-muted">
-                        {{ getError('email') }}</small
-                      >
-                    </div>
-                  </div>
+            <div role="form">
 
-                  <div class="col-md-4">
-                    <div class="form-group">
-                      <label for="form_phone" class="hidder">Телефон *</label>
-                      <input
-                          id="form_phone"
-                          type="email"
-                          name="phone"
-                          class="form-control"
-                          placeholder="Телефон:*"
-                          required="required"
-                          v-model="phone"
-                          data-error="Valid phone is required."
-                      />
-                      <small class="form-text text-muted">
-                        {{ getError('phone') }}</small
-                      >
-                    </div>
-                  </div>
-                  <div class="col-md-4">
-                    <div class="form-group">
-                      <label for="form_phone" class="hidder">Город *</label>
-                      <input
-                          id="form_phone"
-                          type="text"
-                          name="city"
-                          class="form-control"
-                          placeholder="Город:*"
-                          required="required"
-                          v-model="city"
-                          data-error="Valid phone is required."
-                      />
-                      <small class="form-text text-muted">
-                        {{ getError('city') }}</small
-                      >
-                    </div>
-                  </div>
-
-                </div>
-                <div class="pp2 row" v-show="!isParking">Введи свои Имя и Фамилию или Имя и Фамилию ребёнка, если вносишь оргвзнос за ребёнка</div>
-                <div class="quest-item row" id="first-item-row" v-show="!isParking">
-                  <label for="name" style="display: none">Твои Имя и Фамилия или Имя и Фамилия ребёнка: *</label>
-
-                  <div class="input-group" id="promo-input" v-show="!isNotNeedQuestionnaire">
-                    <input
-                        type="text"
-                        id="name"
-                        class="form-control"
-                        placeholder="Твои Имя и Фамилия или Имя и Фамилия ребёнка"
-                        aria-label="Твои Имя и Фамилия или Имя и Фамилия ребёнка"
-                        v-model="masterName"
-                        aria-describedby="basic-addon1"
-                    />
-                  </div>
-                </div>
-                <div class="row mt-3 mb-3" id="enter-guests" v-show="!isParking">
-                  <div class="pp2">Введи данные дополнительных своих друзей, за которых ты хочешь внести оргвзнос:</div>
-                  <div class="not-first-guest input-group mb-3">
-
-                    <input
-                        type="text"
-                        id="newGuest"
-                        class="form-control"
-                        placeholder="Имя и фамилия твоего друга"
-                        aria-label="Имя и фамилия твоего друга"
-                        v-model="newGuest"
-                        aria-describedby="basic-addon1"
-                        @blur="addGuest"
-                    />
+              <!-- ШАГ 1: Данные покупателя -->
+              <div class="pp1 row">
+                <span>ШАГ 1.</span> Введи свои контактные данные, после чего система автоматически создаст тебе аккаунт:
+              </div>
+              <div class="row y-row">
+                <div class="col-md-4">
+                  <div class="form-group">
+                    <label class="hidder">Email *</label>
                     <input
                         type="email"
-                        id="newEmailGuest"
                         class="form-control"
-                        placeholder="Email твоего друга"
-                        aria-label="E-mail этого друга"
-                        v-model="newGuestEmail"
-                        aria-describedby="basic-addon1"
-                        @blur="addGuest"
+                        placeholder="Email: *"
+                        v-model="email"
                     />
-                    <div class="input-group-prepend">
-                      <span
-                          class="input-group-text btn"
-                          @click="addGuest()"
-                          id="basic-addon1"
-                      >Добавить</span
-                      >
-                    </div>
+                    <small class="form-text text-muted">{{ getError('email') }}</small>
                   </div>
                 </div>
-                <div class="row mt-3 mb-3" id="enter-cars" v-show="isParking">
-                  <div class="pp2">Введи данные автомобилей, для которых нужна парковка:</div>
-                  <div class="not-first-guest input-group mb-3">
+                <div class="col-md-4">
+                  <div class="form-group">
+                    <label class="hidder">Телефон *</label>
                     <input
                         type="text"
-                        id="newCarNumber"
                         class="form-control"
-                        placeholder="Гос. номер (например, А123АА777)"
-                        aria-label="Гос. номер автомобиля"
-                        v-model="newCarNumber"
-                        @blur="addParking"
+                        placeholder="Телефон: *"
+                        v-model="phone"
                     />
+                    <small class="form-text text-muted">{{ getError('phone') }}</small>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <div class="form-group">
+                    <label class="hidder">Город *</label>
                     <input
                         type="text"
-                        id="newCarBrand"
                         class="form-control"
-                        placeholder="Марка автомобиля"
-                        aria-label="Марка автомобиля"
-                        v-model="newCarBrand"
-                        @blur="addParking"
+                        placeholder="Город: *"
+                        v-model="city"
                     />
+                    <small class="form-text text-muted">{{ getError('city') }}</small>
+                  </div>
+                </div>
+              </div>
+              <div class="row y-row">
+                <div class="col-md-12">
+                  <div class="form-group">
+                    <label class="hidder">Имя покупателя (для аккаунта)</label>
                     <input
                         type="text"
-                        id="newDriverName"
                         class="form-control"
-                        placeholder="ФИО водителя"
-                        aria-label="ФИО водителя"
-                        v-model="newDriverName"
-                        @blur="addParking"
+                        placeholder="Имя покупателя"
+                        v-model="name"
                     />
-                    <input
-                        type="email"
-                        id="newDriverEmail"
-                        class="form-control"
-                        placeholder="Email для отправки анкеты"
-                        aria-label="Email для отправки анкеты"
-                        v-model="newGuestEmail"
-                        @blur="addParking"
-                    />
-                    <div class="input-group-prepend">
-                      <span
-                          class="input-group-text btn"
-                          @click="addParking()"
-                          id="basic-addon1"
-                      >Добавить</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="row x-row" v-show="guests.length > 0" id="adding-guests">
-                  <div class="col-12">
-                    <div class="form-group">
-                      <div
-                          class="input-group mb-3"
-                          v-for="(itemGuest, index) in guests"
-                          v-bind:key="index"
-                      >
-                        <input
-                            type="text"
-                            class="form-control"
-                            readonly
-                            v-bind:value="itemGuest.value"
-                            aria-describedby="basic-addon2"
-                        />
-                        <input
-                            type="email"
-                            class="form-control"
-                            readonly
-                            v-bind:value="itemGuest.email"
-                            aria-describedby="basic-addon2"
-                        />
-                        <div class="input-group-prepend">
-                          <span
-                              class="input-group-text btn"
-                              @click="delGuest(index)"
-                              id="basic-addon2"
-                          >
-                            <i class="fa fa-trash"></i>
-                          </span>
-                        </div>
-                      </div>
-                      <small class="form-text text-muted">
-                        {{ getError('guests') }}</small
-                      >
-                    </div>
-                  </div>
-                </div>
-                <div class="row col-12">
-                  <h4 class="font-weight-normal" id="count-label">
-                    Общее количество гостей в твоем заказе:
-                    <span>{{ countGuests }}</span>
-                  </h4>
-                </div>
-
-                <div class="row sub-warn"><b>ВНИМАНИЕ!</b> После оформления заказа на твою почту и почты твоих друзей придёт ссылка на анкету, которую необходимо заполнить, чтобы
-                  активировать ваши QR-коды, а также получить доступ к новому закрытому чату гостей Solar Systo Togathering 2026.
-
-                </div>
-
-                <div class="pp1 row">
-                  <span>ШАГ 2.</span> Выбери тип оргвзноса и введи данные
-                  каждого гостя, за которого будешь вносить средства:
-                </div>
-
-                <div class="mb-3" id="org-type">
-                  <div class="col-3">
-                    <label for="form_need">Тип оргвзноса: *</label>
-                  </div>
-
-                  <div class="mt-1 col-9">
-                    <div class="in-choice">
-                      <div
-                          class="ticket-choice"
-                          v-for="typeTickets in getTicketType"
-                          v-bind:key="typeTickets.id"
-                      >
-                        <div class="form-check">
-                          <label
-                              class="form-check-label"
-                              v-bind:for="typeTickets.id"
-                          >
-                            <input
-                                type="radio"
-                                class="form-check-input"
-                                v-model="selectTypeTicket"
-                                v-bind:value="typeTickets.id"
-                                v-bind:id="typeTickets.id"
-                                @change="sendTicketType()"
-                            />
-                            <span class="intckt">
-                            <p>
-                              {{ typeTickets.name }} /
-                              {{ typeTickets.price }} руб.
-                            </p>
-                            <p v-html="typeTickets.description"></p>
-                              </span>
-                          </label>
-                          <small class="form-text text-muted">
-                            {{ getError('ticket_type_id') }}
-                          </small>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <!--                  Промокод-->
-                <div class="row">
-                  <div class="col-3">
-                    <label for="form_promo_cod">Промокод:</label>
-                  </div>
-                  <div class="col-4">
-                    <div class="input-group" id="promo-input">
-                      <input
-                          type="text"
-                          id="form_promo_cod"
-                          class="form-control"
-                          placeholder="Промокод"
-                          aria-label="Промокод"
-                          v-model="promoCode"
-                          aria-describedby="basic-addon1"
-                          @blur="sendPromoCode"
-                      />
-                      <span
-                          class="input-group-text"
-                          @click="sendPromoCode"
-                          id="basic-addon1"
-                      ></span>
-                    </div>
-                  </div>
-                  <div class="col-5">
-                    <small
-                        class="form-text text-muted id-info"
-                        v-show="messageForPromoCode !== null"
-                    >
-                      {{ messageForPromoCode }}
+                    <small class="form-text text-muted">
+                      Это имя для аккаунта получателя. Если ты тоже участвуешь — добавь себя отдельной карточкой гостя ниже.
                     </small>
                   </div>
                 </div>
+              </div>
 
+              <!-- ШАГ 2: Корзина гостей -->
+              <div class="pp1 row">
+                <span>ШАГ 2.</span> Добавь гостей. Для каждого выбери тип оргвзноса, опции и при необходимости промокод:
+              </div>
 
+              <GuestCard
+                  v-for="(guest, index) in guests"
+                  :key="guest._key"
+                  :index="index"
+                  :model-value="guest"
+                  :ticket-types="getTicketType"
+                  :options="optionsByKey[guest._key] || []"
+                  :loading-options="loadingOptionsByKey[guest._key] === true"
+                  :removable="guests.length > 1"
+                  :price-line="priceLines[index] || null"
+                  :locked-live-mode="lockedLiveMode"
+                  @update:model-value="updateGuest(index, $event)"
+                  @select-ticket-type="onGuestSelectTicketType"
+                  @remove="removeGuest(index)"
+              />
 
-                <div class="row itog-row mb-4" v-show="totalPrice !== null && !Number.isNaN(totalPrice)">
-                  <div class="col-12">
-                    <h4 class="my-lg-2 font-weight-normal">
-                      Итого к внесению:
-                      <small class="text-muted">{{ totalPrice }} руб.</small>
-                    </h4>
-                  </div>
+              <small class="form-text text-danger" v-if="getError('guests')">{{ getError('guests') }}</small>
 
+              <div class="row mb-3">
+                <div class="col-12">
+                  <button
+                      type="button"
+                      class="btn btn-outline-primary"
+                      @click="addGuest"
+                      :disabled="guests.length >= MAX_GUESTS"
+                  >
+                    <i class="fa fa-plus"></i> Добавить гостя
+                  </button>
+                  <span class="ml-3 text-muted">Гостей в заказе: {{ guests.length }} / {{ MAX_GUESTS }}</span>
+                </div>
+              </div>
 
-                  <div class="col-4" v-show="getDiscountByPromoCode > 0">
-                    <h4 class="my-lg-2 font-weight-normal">
-                      Скидка по промокоду:
-                      <small class="text-muted"
-                      >{{
-                          getDiscountByPromoCode * countGuests
-                        }}
-                        рублей</small
+              <div class="row sub-warn">
+                <b>ВНИМАНИЕ!</b> После оформления заказа на почту каждого гостя придёт ссылка на анкету,
+                которую необходимо заполнить, чтобы активировать QR-код и получить доступ к закрытому чату
+                гостей Solar Systo Togathering 2026.
+              </div>
+
+              <!-- Итоговая стоимость -->
+              <div class="row itog-row mb-4" v-show="totalPrice !== null">
+                <div class="col-12">
+                  <h4 class="my-lg-2 font-weight-normal">
+                    Итого к внесению:
+                    <small class="text-muted">{{ totalPrice }} руб.</small>
+                    <span
+                        class="spinner-border spinner-border-sm ml-2"
+                        role="status"
+                        aria-hidden="true"
+                        v-show="priceLoading"
+                    ></span>
+                  </h4>
+                </div>
+                <div class="col-12" v-if="totalDiscount > 0">
+                  <h5 class="my-lg-1 font-weight-normal text-muted">
+                    Общая скидка по промокодам: {{ totalDiscount }} руб.
+                  </h5>
+                </div>
+              </div>
+
+              <!-- ШАГ 3: Оплата -->
+              <div class="pp1 row">
+                <span>ШАГ 3.</span> Выбери способ оплаты, осуществи перевод и заполни данные о платеже!
+              </div>
+              <div class="row">
+                <div class="col-12">
+                  <div class="form-group">
+                    <label class="hidder">Способ оплаты: *</label>
+                    <div class="in-choice">
+                      <div
+                          class="payment-choice"
+                          v-for="typesOfPayment in getTypesOfPayment"
+                          :key="typesOfPayment.id"
                       >
-                    </h4>
-                  </div>
-                </div>
-
-                <div class="pp1 row">
-                  <span>ШАГ 3.</span> Выбери куда ты будешь переводить средства,
-                  осуществи перевод и заполни данные о платеже!
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    <div class="form-group">
-                      <label for="form_need" class="hidder"
-                      >Способ оплаты: *</label>
-                      <div class="in-choice">
-                        <div
-                            class="payment-choice"
-                            v-for="typesOfPayment in getTypesOfPayment"
-                            v-bind:key="typesOfPayment.id"
-                        >
-                          <div class="form-check">
-                            <label
-                                class="form-check-label"
-                                v-bind:for="typesOfPayment.id"
-                            >
-                              <input
-                                  type="radio"
-                                  class="form-check-input"
-                                  v-model="selectTypesOfPayment"
-                                  v-bind:value="typesOfPayment.id"
-                                  v-bind:id="typesOfPayment.id"
-                              />
-                              <span >
-                                <span v-html="typesOfPayment.name"></span>
-                                <i
-                                    class="copy-payment"
-                                    title="Нажми, чтобы скопировать реквизиты"
-                                    @click="
-                                    CopyTypesOfPayment(typesOfPayment.card)
-                                  "
-                                ></i>
-                              </span>
-                            </label>
-
-                            <small class="form-text text-muted">
-                              {{ getError('types_of_payment_id') }}</small
-                            >
-                          </div>
+                        <div class="form-check">
+                          <label class="form-check-label" :for="'pay-' + typesOfPayment.id">
+                            <input
+                                type="radio"
+                                class="form-check-input"
+                                v-model="selectTypesOfPayment"
+                                :value="typesOfPayment.id"
+                                :id="'pay-' + typesOfPayment.id"
+                            />
+                            <span>
+                              <span v-html="typesOfPayment.name"></span>
+                              <i
+                                  class="copy-payment"
+                                  title="Нажми, чтобы скопировать реквизиты"
+                                  @click="copyTypesOfPayment(typesOfPayment.card)"
+                              ></i>
+                            </span>
+                          </label>
+                          <small class="form-text text-muted">{{ getError('types_of_payment_id') }}</small>
                         </div>
                       </div>
                     </div>
-                    <div class="copy-btn">
-                      Нажми на <span></span> чтобы скопировать реквизиты
-                    </div>
                   </div>
+                  <div class="copy-btn">Нажми на <span></span> чтобы скопировать реквизиты</div>
                 </div>
-                <div v-show="!selectTypesOfPaymentIsBilling">
-                <div
-                    class="row flex-flex justify-content-center mt-7"
-                    style="
-                    color: var(--c-red);
-                    text-align: center;
-                    font-weight: bold;
-                  "
-                >
-                  ТЕПЕРЬ СОВЕРШИ ПЕРЕВОД СРЕДСТВ САМОСТОЯТЕЛЬНО В ПРИЛОЖЕНИИ
-                  БАНКА
+              </div>
+
+              <div v-show="!selectTypesOfPaymentIsBilling">
+                <div class="row flex-flex justify-content-center mt-7" style="color: var(--c-red); text-align: center; font-weight: bold;">
+                  ТЕПЕРЬ СОВЕРШИ ПЕРЕВОД СРЕДСТВ САМОСТОЯТЕЛЬНО В ПРИЛОЖЕНИИ БАНКА
                 </div>
-                <div
-                    class="row mb-4 flex-flex justify-content-center"
-                    style="text-align: center; font-weight: bold"
-                >
+                <div class="row mb-4 flex-flex justify-content-center" style="text-align: center; font-weight: bold;">
                   и только после этого заполни поля ниже
                 </div>
                 <div class="row mb-4 flex-flex">
@@ -450,157 +230,67 @@
                   </div>
                   <div class="col-6">
                     <small class="form-text text-muted id-info">
-                      При переводах на Сбербанк напиши сюда
-                      <b>последние 4 цифры номера карты</b>, с которой был
-                      сделан перевод
+                      При переводах на Сбербанк напиши сюда <b>последние 4 цифры номера карты</b>, с которой был сделан перевод
                     </small>
                   </div>
-                  <small class="form-text text-muted">
-                    {{ getError('idBuy') }}</small
-                  >
                 </div>
-                <!--                  Дата платежа -->
                 <div class="row mt-4">
                   <div class="col-3">
-                    <label for="form_message">Когда был сделан платеж?</label>
+                    <label>Когда был сделан платеж?</label>
                   </div>
                   <div class="col-9 flex-flex">
                     <input
                         type="text"
                         class="form-control"
                         placeholder="Например: 18 февраля в 13.20"
-                        aria-label="Дата и время перевода"
                         v-model="date"
                     />
                   </div>
-                  <small class="form-text text-muted">
-                    {{ getError('date') }}</small
-                  >
                 </div>
-
                 <div class="row">
                   <div class="col-3">
-                    <label for="idBuy">Комментарий к платежу:</label>
+                    <label>Комментарий к платежу:</label>
                   </div>
-
                   <div class="col-9">
-                    <textarea
-                        class="form-control order-text"
-                        v-model="comment"
-                        id="idBuy"
-                    ></textarea>
-                  </div>
-                </div>
-                </div>
-
-                <div class="row" style="justify-content: center">
-                    <div class="form-check" id="check-check">
-                      <input
-                          class="form-check-input"
-                          type="checkbox"
-                          value=""
-                          v-model="confirm"
-                          id="defaultCheck1"
-                      />
-                      <label class="form-check-label" for="defaultCheck1">
-                        Регистрируя добровольный оргвзнос, ты соглашаешься с
-                        &nbsp;<a href="/conditions" target="_blank"><b>Правилами и условиями участия в туристическом слёте</b></a>
-                        и <a href="/private" target="_blank"><b>Политикой обработки персональных данных.</b></a>
-                      </label>
-                    </div>
-                  <div class="col-12">
-                    <button
-                        type="button"
-                        :disabled="preload || !isNotCorrect"
-                        @click="orderTicket"
-                        class="btn btn-lg btn-block btn-outline-primary reg-btn"
-                    >
-                      <span
-                          class="spinner-border spinner-border-sm"
-                          role="status"
-                          aria-hidden="true"
-                          v-show="preload"
-                      ></span>
-                      Зарегистрировать оргвзнос
-                    </button>
-                  </div>
-                </div>
-                <div
-                    class="row justify-content-center"
-                    v-if="!isNotCorrect"
-                    style="text-align: center"
-                >
-                  Если кнопка не активна проверь все ли поля заполнены!
-                </div>
-                <div class="row mt-4" id="sub-order">
-                  <div class="after-order">
-                    <p>
-                      После подтверждения перевода на твой e-mail придет <strong>электронный билет с QR-кодом</strong><br> для входа на Solar Systo Togathering 2026! А также ссылка на анкету для добавления в новый закрытый чат
-                    </p>
-                    <!--p>
-                      <b>«Живые билеты» в виде памятной карточки можно будет приобрести в </b>
-                      <br />
-                      Санкт-Петербурге и Москве ориентировочно к концу января.
-                      <br />
-                      Все гости, внесшие средства электронно смогут получиться памятные конверты с карточкой и наклейкой на инфоцентре во время Систо.
-                      <br />
-
-                      <a href="https://t.me/cacaotemple" target="_blank"
-                      >Телеграм </a
-                      ><br />
-
-                      <a href="https://cacaotemple.ru" target="_blank">Сайт </a
-                      ><br />
-
-                      <a
-                          href="https://yandex.ru/navi/org/kakao_templ/156023560596?si=hgcx2kzvw06q9hvz04e4a1dp4g"
-                          target="_blank"
-                      >Как проехать</a
-                      ><br />
-                      <br />
-                      "Живой билет" является таким же видом оргвзноса, как и
-                      электронный, просто в этом случае вы получите конверт
-                      внутри которого будет карта участника с номером и
-                      сувенирная продукция. При регистрации оргвзноса электронно
-                      - отдельно покупать "живой билет" не нужно!
-                    </p-->
+                    <textarea class="form-control order-text" v-model="comment"></textarea>
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-        <!-- /.8 -->
-      </div>
-      <!-- /.row-->
-      <div class="modal" tabindex="-1" role="dialog" id="myModal">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title">Успех</h5>
-              <button
-                  type="button"
-                  class="close"
-                  data-dismiss="modal"
-                  aria-label="Close"
-              >
-                <span aria-hidden="true">x</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <p>Modal body text goes here.</p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-primary">
-                Save changes
-              </button>
-              <button
-                  type="button"
-                  class="btn btn-secondary"
-                  data-dismiss="modal"
-              >
-                Close
-              </button>
+
+              <!-- Согласие + сабмит -->
+              <div class="row" style="justify-content: center">
+                <div class="form-check" id="check-check">
+                  <input class="form-check-input" type="checkbox" v-model="confirm" id="defaultCheck1" />
+                  <label class="form-check-label" for="defaultCheck1">
+                    Регистрируя добровольный оргвзнос, ты соглашаешься с&nbsp;<a href="/conditions" target="_blank"><b>Правилами и условиями участия в туристическом слёте</b></a>
+                    и <a href="/private" target="_blank"><b>Политикой обработки персональных данных.</b></a>
+                  </label>
+                </div>
+                <div class="col-12">
+                  <button
+                      type="button"
+                      :disabled="preload || !isFormValid"
+                      @click="orderTicket"
+                      class="btn btn-lg btn-block btn-outline-primary reg-btn"
+                  >
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" v-show="preload"></span>
+                    Зарегистрировать оргвзнос
+                  </button>
+                </div>
+              </div>
+              <div class="row justify-content-center" v-if="!isFormValid" style="text-align: center">
+                {{ validationHint }}
+              </div>
+
+              <div class="row mt-4" id="sub-order">
+                <div class="after-order">
+                  <p>
+                    После подтверждения перевода на твой e-mail придёт <strong>электронный билет с QR-кодом</strong><br>
+                    для входа на Solar Systo Togathering 2026! А также ссылка на анкету для добавления в новый закрытый чат.
+                  </p>
+                </div>
+              </div>
+
             </div>
           </div>
         </div>
@@ -609,334 +299,376 @@
   </div>
 </template>
 
-<script>
-import { mapActions, mapGetters } from 'vuex';
+<script setup>
+import { ref, reactive, computed, watch, onMounted } from 'vue';
+import { useStore } from 'vuex';
+import { useRoute } from 'vue-router';
+import GuestCard from '@/components/BuyTicket/GuestCard.vue';
 
-export default {
-  name: 'BuyTicket',
-  props: {
-    'userId': String
-  },
-  data() {
-    return {
-      isNotNeedQuestionnaire: false,
-      preload: false,
-      day: null,
-      mount: null,
-      hour: null,
-      minute: null,
-      selectTypesOfPayment: null,
-      guests: [],
-      masterName: '',
-      newGuest: '',
-      newGuestEmail: '',
-      newCarNumber: '',
-      newCarBrand: '',
-      newDriverName: '',
-      isFirstGuestAdded: false,
-      email: null,
-      date: null,
-      phone: null,
-      city: null,
-      idBuy: null,
-      confirm: false,
-      message: null,
-      promoCode: null,
-      messageForPromoCode: null,
-      comment: null,
-    };
-  },
-  watch: {
-    getTypesOfPayment: {
-      immediate: true,
-      handler(types) {
-        if (types && types.length > 0) {
-          this.selectTypesOfPayment = types[0].id;
-        }
-      },
-    },
-  },
-  computed: {
-    ...mapGetters('appFestivalTickets', [
-      'getTypesOfPayment',
-      'getTicketType',
-      'isAllowedGuest',
-      'isAllowedGuestMin',
-      'getSelectTicketType',
-      'getSelectTicketTypeId',
-      'getSelectTicketTypeLimit',
-      'getDiscountByPromoCode',
-      'getPromoCodeName',
-    ]),
-    ...mapGetters('appUser', ['isAuth', 'getEmail', 'getUserData']),
-    ...mapGetters('appOrder', ['getError']),
-    /**
-     * Признак типа билета "парковка" — меняет форму ввода гостей на ввод данных автомобиля
-     */
-    isParking: function () {
-      return this.getSelectTicketType?.isParking === true;
-    },
-    selectTypesOfPaymentIsBilling: function () {
-      let typesOfPaymentList = this.getTypesOfPayment;
-      if(this.selectTypesOfPayment !== null ) {
-        let select = typesOfPaymentList?.find(user => user.id == this.selectTypesOfPayment);
-        return select?.is_billing ?? false;
+const props = defineProps({
+  userId: { type: String, default: null },
+});
+
+const store = useStore();
+const route = useRoute();
+
+const FESTIVAL_ID = '9d679bcf-b438-4ddb-ac04-023fa9bff4b8';
+const MAX_GUESTS = 10;
+
+// --- Данные покупателя ---
+const email = ref(null);
+const phone = ref(null);
+const city = ref(null);
+const name = ref(null);
+const comment = ref(null);
+const date = ref(null);
+const idBuy = ref(null);
+const confirm = ref(false);
+const preload = ref(false);
+const message = ref(null);
+const selectTypesOfPayment = ref(null);
+
+// --- Корзина гостей ---
+let guestKeySeq = 0;
+
+function makeGuest() {
+  guestKeySeq += 1;
+  return {
+    _key: 'g' + guestKeySeq,
+    ticket_type_id: null,
+    value: '',
+    email: '',
+    promo_code: '',
+    options: [],
+    // парковочные поля (склеиваются в value при сабмите)
+    carNumber: '',
+    carBrand: '',
+    driverName: '',
+  };
+}
+
+const guests = ref([makeGuest()]);
+
+// Опции и индикатор загрузки опций — по ключу гостя
+const optionsByKey = reactive({});
+const loadingOptionsByKey = reactive({});
+
+// Разбивка цены по строкам (из /calculatePrice), в порядке guests[]
+const priceLines = ref([]);
+const totalPrice = ref(null);
+const priceLoading = ref(false);
+let priceDebounceTimer = null;
+
+// --- Геттеры стора ---
+const getTicketType = computed(() => store.getters['appFestivalTickets/getTicketType']);
+const getTypesOfPayment = computed(() => store.getters['appFestivalTickets/getTypesOfPayment']);
+const getError = computed(() => store.getters['appOrder/getError']);
+const isAuth = computed(() => store.getters['appUser/isAuth']);
+const getEmail = computed(() => store.getters['appUser/getEmail']);
+
+/**
+ * Выбранный способ оплаты — биллинговый (СБП и т.п.).
+ */
+const selectTypesOfPaymentIsBilling = computed(() => {
+  if (selectTypesOfPayment.value === null) {
+    return false;
+  }
+  const found = getTypesOfPayment.value?.find((p) => p.id === selectTypesOfPayment.value);
+  return found?.is_billing ?? false;
+});
+
+/**
+ * Зафиксированный режим заказа (live / non-live) по первому гостю с выбранным типом.
+ * null — пока ни один тип не выбран (смешивать свободно).
+ */
+const lockedLiveMode = computed(() => {
+  for (const guest of guests.value) {
+    if (guest.ticket_type_id) {
+      const tt = getTicketType.value?.find((t) => t.id === guest.ticket_type_id);
+      if (tt) {
+        return { isLiveTicket: Boolean(tt.isLiveTicket) };
       }
-      return false;
-    },
-
-    /**
-     * Проверка на ведение всех данных
-     * @returns {false|*|null}
-     */
-    isNotCorrect: function () {
-      let group = true;
-
-      if (this.getSelectTicketType !== null) {
-        if (!this.isAllowedGuestMin(this.guests.length)) {
-          group = false;
-        }
-      }
-
-      let result = (
-          this.selectTypeTicket !== null &&
-          this.selectTypesOfPayment !== null &&
-          this.phone !== null &&
-          this.confirm === true &&
-          group &&
-          (this.isAuth || this.email)
-      )
-
-      if(!this.isNotNeedQuestionnaire && !this.isParking) {
-        result = result && this.masterName.length > 0;
-      } else {
-        result = result && this.guests.length > 0;
-      }
-
-      if(!this.selectTypesOfPaymentIsBilling) {
-        result = result &&
-            (this.date !== null && this.date.length > 0) &&
-            (this.idBuy !== null && this.idBuy.length > 0);
-      }
-
-      return result;
-    },
-    /**
-     * Выбранный тип билета
-     */
-    selectTypeTicket: {
-      get: function () {
-        return this.getSelectTicketTypeId;
-      },
-      set: function (newValue) {
-        let oldId = this.getSelectTicketTypeId;
-
-        this.setSelectTicketType(newValue);
-        if (this.getSelectTicketType !== null) {
-          if (!this.isAllowedGuest(this.guests.length)) {
-            alert(
-                'Привышен лимин по данному типу доступна только ' +
-                this.getSelectTicketTypeLimit
-            );
-            this.setSelectTicketType(oldId);
-          }
-        }
-      },
-    },
-    /**
-     * Стоимость билета
-     */
-    totalPrice: function () {
-      let price = null;
-      let countTicket = this.guests.length + ((!this.isNotNeedQuestionnaire && this.masterName.length > 0) ? 1 : 0);
-      if (this.getSelectTicketType !== null) {
-        price = this.getSelectTicketType.price;
-        let count =
-            this.getSelectTicketTypeLimit !== null ? 1 : countTicket;
-        return price * count - this.getDiscountByPromoCode * count;
-      }
-
-      return null;
-    },
-    /**
-     * Кол-во гостей
-     * @returns {number}
-     */
-    countGuests: function () {
-      return this.guests.length + ((!this.isNotNeedQuestionnaire && this.masterName.length > 0) > 0 ? 1 : 0);
-    },
-    /**
-     * Проверка на добавление нового гостя
-     * @returns {boolean}
-     */
-    isAllowedNewGuest: function () {
-      if (this.getSelectTicketType !== null) {
-        return (
-            this.getSelectTicketTypeLimit === null ||
-            this.getSelectTicketTypeLimit >= this.countGuests + 2
-        );
-      }
-      return false;
-    },
-  },
-  methods: {
-    ...mapActions('appFestivalTickets', [
-      'loadDataForOrderingTickets',
-      'setSelectTicketType',
-      'checkPromoCode',
-      'clearPromoCode',
-      'loadTypesOfPayment',
-    ]),
-    ...mapActions('appOrder', ['goToCreateOrderTicket', 'clearError']),
-    ...mapActions('appUser', ['loadUserData']),
-    CopyTypesOfPayment: function (name) {
-      let area = document.createElement('textarea');
-      document.body.appendChild(area);
-      area.value = name;
-      area.select();
-      document.execCommand('copy');
-      document.body.removeChild(area);
-    },
-    sendTicketType: function () {
-        let select = this.selectTypeTicket;
-        this.loadTypesOfPayment({
-          ticket_type_id: select
-        })
-    },
-    /**
-     * Отправить промо код
-     */
-    sendPromoCode: function () {
-      let self = this;
-      this.checkPromoCode({
-        promoCode: this.promoCode,
-        typeOrder: this.getSelectTicketTypeId,
-        callback: function (message) {
-          self.messageForPromoCode = message;
-        },
-      });
-    },
-    /**
-     * Добавить нового гостя
-     */
-    addGuest: function () {
-      if (this.newGuest.length > 0 && this.newGuestEmail.length > 0) {
-        this.guests.push({
-          value: this.newGuest,
-          email: this.newGuestEmail,
-        });
-        this.newGuest = '';
-        this.newGuestEmail = '';
-      }
-    },
-    /**
-     * Добавить парковочное место — гос. номер, марка и водитель склеиваются в одну строку value,
-     * чтобы backend получал привычный формат guests[].value/email без изменений.
-     */
-    addParking: function () {
-      if (
-          this.newCarNumber.length > 0 &&
-          this.newCarBrand.length > 0 &&
-          this.newDriverName.length > 0 &&
-          this.newGuestEmail.length > 0
-      ) {
-        this.guests.push({
-          value: this.newCarNumber + ' / ' + this.newCarBrand + ' / ' + this.newDriverName,
-          email: this.newGuestEmail,
-        });
-        this.newCarNumber = '';
-        this.newCarBrand = '';
-        this.newDriverName = '';
-        this.newGuestEmail = '';
-      }
-    },
-    /**
-     * Удалить гостя
-     * @param index
-     */
-    delGuest: function (index) {
-      this.guests.splice(index, 1);
-    },
-    /**
-     * Заказать билет
-     */
-    orderTicket: function () {
-      let self = this;
-      this.preload = true;
-      let guests = this.guests;
-      let data = {
-        email: this.email,
-        ticket_type_id: this.getSelectTicketTypeId,
-        name: this.masterName,
-        guests: guests,
-        promo_code: this.promoCode,
-        date: this.date,
-        id_buy: this.idBuy,
-        city: this.city,
-        phone: this.phone,
-        comment: this.comment,
-        invite: this.$route.params.userId,
-        types_of_payment_id: this.selectTypesOfPayment,
-        festival_id: '9d679bcf-b438-4ddb-ac04-023fa9bff4b8',
-        callback: function (result, message, link) {
-          if (result) {
-            self.clearData();
-          }
-          if (link !== null) {
-          //  window.location.href = link;
-          } else {
-            self.message = message;
-            document.getElementById('modalOpenBtn').click();
-            self.preload = false;
-          }
-        },
-      };
-      console.log(data);
-      this.goToCreateOrderTicket(data);
-    },
-    /**
-     * Очистить данные
-     */
-    clearData: async function () {
-      this.selectTypesOfPayment = null;
-      this.guests = [];
-      this.preload = false;
-      this.newGuest = '';
-      this.newGuestEmail = '';
-      this.newCarNumber = '';
-      this.newCarBrand = '';
-      this.newDriverName = '';
-      this.email = this.getEmail;
-      this.promoCode = null;
-      this.day = null;
-      this.mount = null;
-      this.date = null;
-      this.minute = null;
-      this.messageForPromoCode = null;
-      this.idBuy = null;
-      this.comment = null;
-      this.confirm = false;
-      this.isFirstGuestAdded = false; // сбросить состояние до первого участника
-      this.clearPromoCode();
-    },
-  },
-  async created() {
-    await this.loadDataForOrderingTickets({
-      festival_id: '9d679bcf-b438-4ddb-ac04-023fa9bff4b8',
-    });
-    await this.clearError();
-    if (this.isAuth) {
-      let self = this;
-      await this.loadUserData({
-        callback: function (data) {
-          self.phone = data.phone;
-          self.city = data.city;
-        },
-      });
-      this.email = this.getEmail;
     }
-  },
-};
+  }
+  return null;
+});
+
+const totalDiscount = computed(() =>
+    priceLines.value.reduce((acc, line) => acc + (line?.discount || 0), 0),
+);
+
+// --- Работа с гостями ---
+function addGuest() {
+  if (guests.value.length >= MAX_GUESTS) {
+    return;
+  }
+  guests.value.push(makeGuest());
+}
+
+function removeGuest(index) {
+  const removed = guests.value[index];
+  guests.value.splice(index, 1);
+  if (removed) {
+    delete optionsByKey[removed._key];
+    delete loadingOptionsByKey[removed._key];
+  }
+}
+
+function updateGuest(index, nextGuest) {
+  guests.value.splice(index, 1, nextGuest);
+}
+
+/**
+ * При выборе типа билета в карточке — подгрузить активные опции этого типа.
+ */
+async function onGuestSelectTicketType({ ticketTypeId, index }) {
+  const guest = guests.value[index];
+  if (!guest) {
+    return;
+  }
+  const key = guest._key;
+  optionsByKey[key] = [];
+  loadingOptionsByKey[key] = true;
+  try {
+    const list = await store.dispatch('appOrder/loadOptionsForTicketType', { ticketTypeId });
+    optionsByKey[key] = list;
+  } finally {
+    loadingOptionsByKey[key] = false;
+  }
+}
+
+/**
+ * Признак: гость — парковочный (для склейки value перед отправкой).
+ */
+function isParkingGuest(guest) {
+  const tt = getTicketType.value?.find((t) => t.id === guest.ticket_type_id);
+  return tt?.isParking === true;
+}
+
+/**
+ * Собрать payload guests[] для бэка (склеить парковку, нормализовать промокод/опции).
+ */
+function buildGuestsPayload() {
+  return guests.value.map((guest) => {
+    const isParking = isParkingGuest(guest);
+    const value = isParking
+        ? [guest.carNumber, guest.carBrand, guest.driverName].map((v) => (v || '').trim()).join(' / ')
+        : (guest.value || '').trim();
+
+    const promo = (guest.promo_code || '').trim();
+
+    return {
+      value,
+      email: (guest.email || '').trim(),
+      ticket_type_id: guest.ticket_type_id,
+      options: (guest.options || []).filter((o) => o.qty > 0),
+      promo_code: promo.length > 0 ? promo : null,
+    };
+  });
+}
+
+/**
+ * Проверка готовности одного гостя для live-расчёта/сабмита.
+ */
+function isGuestReady(guest) {
+  if (!guest.ticket_type_id) {
+    return false;
+  }
+  const email = (guest.email || '').trim();
+  if (email.length === 0) {
+    return false;
+  }
+  if (isParkingGuest(guest)) {
+    return (
+        (guest.carNumber || '').trim().length > 0 &&
+        (guest.carBrand || '').trim().length > 0 &&
+        (guest.driverName || '').trim().length > 0
+    );
+  }
+  return (guest.value || '').trim().length > 0;
+}
+
+// --- Live-расчёт цены ---
+function scheduleRecalc() {
+  if (priceDebounceTimer) {
+    clearTimeout(priceDebounceTimer);
+  }
+  priceDebounceTimer = setTimeout(recalcPrice, 400);
+}
+
+async function recalcPrice() {
+  // Считаем только если каждый гость имеет тип билета (на бэке ticket_type_id обязателен)
+  const ready = guests.value.length > 0 && guests.value.every((g) => Boolean(g.ticket_type_id) && (g.email || '').trim().length > 0);
+  if (!ready) {
+    priceLines.value = [];
+    totalPrice.value = null;
+    return;
+  }
+
+  priceLoading.value = true;
+  try {
+    const result = await store.dispatch('appOrder/calculatePrice', {
+      body: {
+        festival_id: FESTIVAL_ID,
+        guests: buildGuestsPayload(),
+      },
+    });
+    if (result.success) {
+      priceLines.value = result.lines || [];
+      totalPrice.value = result.totalPrice ?? null;
+    } else {
+      priceLines.value = [];
+      totalPrice.value = null;
+    }
+  } finally {
+    priceLoading.value = false;
+  }
+}
+
+// Пересчитывать при любом изменении состава корзины
+watch(
+    guests,
+    () => {
+      scheduleRecalc();
+    },
+    { deep: true },
+);
+
+// Автовыбор первого способа оплаты, когда список загрузился
+watch(
+    getTypesOfPayment,
+    (types) => {
+      if (types && types.length > 0 && selectTypesOfPayment.value === null) {
+        selectTypesOfPayment.value = types[0].id;
+      }
+    },
+    { immediate: true },
+);
+
+// --- Валидация формы ---
+const isFormValid = computed(() => {
+  if (!email.value || !phone.value || !city.value) {
+    return false;
+  }
+  if (!confirm.value) {
+    return false;
+  }
+  if (selectTypesOfPayment.value === null) {
+    return false;
+  }
+  if (guests.value.length === 0) {
+    return false;
+  }
+  if (!guests.value.every(isGuestReady)) {
+    return false;
+  }
+  // Не смешивать live + non-live
+  if (!isLiveModeConsistent()) {
+    return false;
+  }
+  // Для не-биллинговых способов — обязателен идентификатор и дата платежа
+  if (!selectTypesOfPaymentIsBilling.value) {
+    if (!date.value || date.value.length === 0) {
+      return false;
+    }
+    if (!idBuy.value || idBuy.value.length === 0) {
+      return false;
+    }
+  }
+  return true;
+});
+
+function isLiveModeConsistent() {
+  const modes = guests.value
+      .map((g) => getTicketType.value?.find((t) => t.id === g.ticket_type_id))
+      .filter(Boolean)
+      .map((t) => Boolean(t.isLiveTicket));
+  if (modes.length === 0) {
+    return true;
+  }
+  return modes.every((m) => m === modes[0]);
+}
+
+const validationHint = computed(() => {
+  if (!isLiveModeConsistent()) {
+    return 'Нельзя смешивать живые и обычные билеты в одном заказе — оформите отдельным заказом.';
+  }
+  return 'Если кнопка не активна — проверь, все ли поля заполнены (у каждого гостя нужен тип билета и email).';
+});
+
+// --- Действия ---
+function copyTypesOfPayment(card) {
+  const area = document.createElement('textarea');
+  document.body.appendChild(area);
+  area.value = card;
+  area.select();
+  document.execCommand('copy');
+  document.body.removeChild(area);
+}
+
+function orderTicket() {
+  preload.value = true;
+
+  const invite = props.userId || route.params.userId || null;
+
+  const body = {
+    email: email.value,
+    phone: phone.value,
+    city: city.value,
+    name: name.value || '',
+    comment: comment.value,
+    invite: invite,
+    festival_id: FESTIVAL_ID,
+    types_of_payment_id: selectTypesOfPayment.value,
+    guests: buildGuestsPayload(),
+  };
+
+  store.dispatch('appOrder/goToCreateOrderTicket', {
+    body,
+    callback: (success, msg) => {
+      preload.value = false;
+      if (success) {
+        clearData();
+        message.value = msg;
+        document.getElementById('modalOpenBtn').click();
+      } else {
+        message.value = msg;
+        document.getElementById('modalOpenBtn').click();
+      }
+    },
+  });
+}
+
+function clearData() {
+  guests.value = [makeGuest()];
+  Object.keys(optionsByKey).forEach((k) => delete optionsByKey[k]);
+  Object.keys(loadingOptionsByKey).forEach((k) => delete loadingOptionsByKey[k]);
+  priceLines.value = [];
+  totalPrice.value = null;
+  comment.value = null;
+  date.value = null;
+  idBuy.value = null;
+  confirm.value = false;
+  email.value = isAuth.value ? getEmail.value : null;
+}
+
+// --- Инициализация ---
+onMounted(async () => {
+  await store.dispatch('appFestivalTickets/loadDataForOrderingTickets', {
+    festival_id: FESTIVAL_ID,
+  });
+  await store.dispatch('appOrder/clearError');
+
+  if (isAuth.value) {
+    await store.dispatch('appUser/loadUserData', {
+      callback: (data) => {
+        phone.value = data.phone;
+        city.value = data.city;
+      },
+    });
+    email.value = getEmail.value;
+  }
+});
 </script>
 
 <style scoped>

--- a/FrontEnd/src/components/BuyTicket/BuyTicket.vue
+++ b/FrontEnd/src/components/BuyTicket/BuyTicket.vue
@@ -259,12 +259,14 @@
 
               <!-- Согласие + сабмит -->
               <div class="row" style="justify-content: center">
-                <div class="form-check" id="check-check">
-                  <input class="form-check-input" type="checkbox" v-model="confirm" id="defaultCheck1" />
-                  <label class="form-check-label" for="defaultCheck1">
-                    Регистрируя добровольный оргвзнос, ты соглашаешься с&nbsp;<a href="/conditions" target="_blank"><b>Правилами и условиями участия в туристическом слёте</b></a>
-                    и <a href="/private" target="_blank"><b>Политикой обработки персональных данных.</b></a>
-                  </label>
+                <div class="col-12 mb-3">
+                  <div class="form-check" id="check-check">
+                    <input class="form-check-input" type="checkbox" v-model="confirm" id="defaultCheck1" />
+                    <label class="form-check-label" for="defaultCheck1">
+                      Регистрируя добровольный оргвзнос, ты соглашаешься с&nbsp;<a href="/conditions" target="_blank"><b>Правилами и условиями участия в туристическом слёте</b></a>
+                      и <a href="/private" target="_blank"><b>Политикой обработки персональных данных.</b></a>
+                    </label>
+                  </div>
                 </div>
                 <div class="col-12">
                   <button
@@ -687,5 +689,16 @@ label {
 .card {
   margin-left: 10px;
   margin-right: 10px;
+}
+
+/* Согласие + кнопка: гарантируем нормальный поток (без наложения кнопки на текст) */
+#check-check {
+  position: static;
+  text-align: left;
+}
+
+.reg-btn {
+  position: static;
+  margin-top: 0.5rem;
 }
 </style>

--- a/FrontEnd/src/components/BuyTicket/GuestCard.vue
+++ b/FrontEnd/src/components/BuyTicket/GuestCard.vue
@@ -1,0 +1,302 @@
+<template>
+  <div class="card mb-3 guest-card">
+    <div class="card-body">
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="font-weight-normal mb-0">Гость №{{ index + 1 }}</h5>
+        <button
+            v-if="removable"
+            type="button"
+            class="btn btn-sm btn-outline-danger"
+            @click="$emit('remove')"
+            title="Удалить гостя"
+        >
+          <i class="fa fa-trash"></i> Удалить
+        </button>
+      </div>
+
+      <!-- Тип билета -->
+      <div class="form-group">
+        <label class="font-weight-bold">Тип оргвзноса: *</label>
+        <div class="in-choice">
+          <div
+              class="ticket-choice"
+              v-for="typeTicket in ticketTypes"
+              :key="typeTicket.id"
+          >
+            <div class="form-check">
+              <label class="form-check-label" :for="'tt-' + index + '-' + typeTicket.id">
+                <input
+                    type="radio"
+                    class="form-check-input"
+                    :id="'tt-' + index + '-' + typeTicket.id"
+                    :value="typeTicket.id"
+                    :checked="modelValue.ticket_type_id === typeTicket.id"
+                    :disabled="isTicketTypeDisabled(typeTicket)"
+                    @change="onSelectTicketType(typeTicket.id)"
+                />
+                <span class="intckt">
+                  <p>{{ typeTicket.name }} / {{ typeTicket.price }} руб.</p>
+                  <p v-if="typeTicket.description" v-html="typeTicket.description"></p>
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+        <small
+            class="form-text text-danger"
+            v-if="liveLockHint"
+        >{{ liveLockHint }}</small>
+      </div>
+
+      <!-- Опции (доп. услуги) -->
+      <div class="form-group" v-if="options.length > 0">
+        <label class="font-weight-bold">Дополнительные опции:</label>
+        <div
+            class="option-row d-flex align-items-center mb-2"
+            v-for="option in options"
+            :key="option.id"
+        >
+          <div class="form-check mr-3">
+            <input
+                class="form-check-input"
+                type="checkbox"
+                :id="'opt-' + index + '-' + option.id"
+                :checked="optionQty(option.id) > 0"
+                @change="toggleOption(option)"
+            />
+            <label class="form-check-label" :for="'opt-' + index + '-' + option.id">
+              {{ option.name }} / {{ option.price }} руб.
+              <small v-if="option.description" class="text-muted d-block" v-html="option.description"></small>
+            </label>
+          </div>
+          <div class="qty-control ml-auto" v-if="optionQty(option.id) > 0">
+            <button type="button" class="btn btn-sm btn-outline-secondary" @click="changeQty(option, -1)">−</button>
+            <span class="mx-2">{{ optionQty(option.id) }}</span>
+            <button type="button" class="btn btn-sm btn-outline-secondary" @click="changeQty(option, 1)">+</button>
+          </div>
+        </div>
+      </div>
+      <div class="form-group" v-else-if="loadingOptions">
+        <small class="text-muted">Загрузка опций…</small>
+      </div>
+
+      <!-- Данные гостя: обычный билет -->
+      <template v-if="!isParking">
+        <div class="form-group">
+          <label class="font-weight-bold">Имя и Фамилия гостя: *</label>
+          <input
+              type="text"
+              class="form-control"
+              placeholder="Имя и Фамилия"
+              :value="modelValue.value"
+              @input="updateField('value', $event.target.value)"
+          />
+        </div>
+        <div class="form-group">
+          <label class="font-weight-bold">Email гостя: *</label>
+          <input
+              type="email"
+              class="form-control"
+              placeholder="Email (на него придёт анкета)"
+              :value="modelValue.email"
+              @input="updateField('email', $event.target.value)"
+          />
+          <small class="form-text text-muted">На этот email придёт ссылка на анкету.</small>
+        </div>
+      </template>
+
+      <!-- Данные гостя: парковка -->
+      <template v-else>
+        <div class="form-group">
+          <label class="font-weight-bold">Гос. номер: *</label>
+          <input
+              type="text"
+              class="form-control"
+              placeholder="Например, А123АА777"
+              :value="modelValue.carNumber"
+              @input="updateParkingField('carNumber', $event.target.value)"
+          />
+        </div>
+        <div class="form-group">
+          <label class="font-weight-bold">Марка автомобиля: *</label>
+          <input
+              type="text"
+              class="form-control"
+              placeholder="Марка автомобиля"
+              :value="modelValue.carBrand"
+              @input="updateParkingField('carBrand', $event.target.value)"
+          />
+        </div>
+        <div class="form-group">
+          <label class="font-weight-bold">ФИО водителя: *</label>
+          <input
+              type="text"
+              class="form-control"
+              placeholder="ФИО водителя"
+              :value="modelValue.driverName"
+              @input="updateParkingField('driverName', $event.target.value)"
+          />
+        </div>
+        <div class="form-group">
+          <label class="font-weight-bold">Email водителя: *</label>
+          <input
+              type="email"
+              class="form-control"
+              placeholder="Email для отправки анкеты"
+              :value="modelValue.email"
+              @input="updateField('email', $event.target.value)"
+          />
+        </div>
+      </template>
+
+      <!-- Промокод гостя -->
+      <div class="form-group">
+        <label class="font-weight-bold">Промокод (необязательно):</label>
+        <input
+            type="text"
+            class="form-control"
+            placeholder="Промокод"
+            :value="modelValue.promo_code"
+            @input="updateField('promo_code', $event.target.value)"
+        />
+      </div>
+
+      <!-- Разбивка цены строки -->
+      <div class="line-price text-muted" v-if="priceLine">
+        <small>
+          Билет: {{ priceLine.basePrice }} руб.
+          <template v-if="priceLine.optionsSum > 0"> + опции: {{ priceLine.optionsSum }} руб.</template>
+          <template v-if="priceLine.discount > 0"> − скидка: {{ priceLine.discount }} руб.</template>
+          = <b>{{ priceLine.total }} руб.</b>
+        </small>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  index: { type: Number, required: true },
+  modelValue: { type: Object, required: true },
+  ticketTypes: { type: Array, default: () => [] },
+  options: { type: Array, default: () => [] },
+  loadingOptions: { type: Boolean, default: false },
+  removable: { type: Boolean, default: true },
+  priceLine: { type: Object, default: null },
+  // Тип билета (live/non-live), на который заблокирован весь заказ. null — свободно.
+  lockedLiveMode: { type: Object, default: null },
+});
+
+const emit = defineEmits(['update:modelValue', 'select-ticket-type', 'remove']);
+
+/**
+ * Выбранный тип билета (полный объект) — нужен для признака парковки.
+ */
+const selectedTicketType = computed(() =>
+    props.ticketTypes.find((t) => t.id === props.modelValue.ticket_type_id) ?? null,
+);
+
+const isParking = computed(() => selectedTicketType.value?.isParking === true);
+
+/**
+ * Блокировка смешивания live + non-live в одном заказе.
+ * Если в заказе уже зафиксирован режим (по первому гостю с типом), типы другого режима недоступны.
+ */
+function isTicketTypeDisabled(typeTicket) {
+  if (props.lockedLiveMode === null) {
+    return false;
+  }
+  // Тип этой же карточки всегда доступен (чтобы можно было снять выбор)
+  if (typeTicket.id === props.modelValue.ticket_type_id) {
+    return false;
+  }
+  return Boolean(typeTicket.isLiveTicket) !== Boolean(props.lockedLiveMode.isLiveTicket);
+}
+
+const liveLockHint = computed(() => {
+  if (props.lockedLiveMode === null) {
+    return '';
+  }
+  return props.lockedLiveMode.isLiveTicket
+      ? 'В заказе уже есть живой билет — остальные гости только с живыми билетами.'
+      : 'В заказе есть обычные билеты — живые билеты оформите отдельным заказом.';
+});
+
+function emitUpdate(patch) {
+  emit('update:modelValue', { ...props.modelValue, ...patch });
+}
+
+function updateField(field, value) {
+  emitUpdate({ [field]: value });
+}
+
+/**
+ * Поля парковки склеиваются в value уже на уровне родителя при сабмите,
+ * здесь храним их по отдельности в той же модели гостя.
+ */
+function updateParkingField(field, value) {
+  emitUpdate({ [field]: value });
+}
+
+function onSelectTicketType(ticketTypeId) {
+  // При смене типа сбрасываем опции (они привязаны к типу билета)
+  emitUpdate({ ticket_type_id: ticketTypeId, options: [] });
+  emit('select-ticket-type', { index: props.index, ticketTypeId });
+}
+
+function optionQty(optionId) {
+  const found = (props.modelValue.options || []).find((o) => o.option_id === optionId);
+  return found ? found.qty : 0;
+}
+
+function setOptions(nextOptions) {
+  emitUpdate({ options: nextOptions });
+}
+
+function toggleOption(option) {
+  const current = [...(props.modelValue.options || [])];
+  const idx = current.findIndex((o) => o.option_id === option.id);
+  if (idx === -1) {
+    current.push({ option_id: option.id, qty: 1 });
+  } else {
+    current.splice(idx, 1);
+  }
+  setOptions(current);
+}
+
+function changeQty(option, delta) {
+  const current = [...(props.modelValue.options || [])];
+  const idx = current.findIndex((o) => o.option_id === option.id);
+  if (idx === -1) {
+    if (delta > 0) {
+      current.push({ option_id: option.id, qty: 1 });
+    }
+  } else {
+    const nextQty = current[idx].qty + delta;
+    if (nextQty <= 0) {
+      current.splice(idx, 1);
+    } else {
+      current[idx] = { ...current[idx], qty: nextQty };
+    }
+  }
+  setOptions(current);
+}
+</script>
+
+<style scoped>
+.guest-card {
+  border: 1px solid #e3e6ea;
+}
+
+.line-price {
+  margin-top: 8px;
+  border-top: 1px dashed #e3e6ea;
+  padding-top: 8px;
+}
+
+.qty-control {
+  white-space: nowrap;
+}
+</style>

--- a/FrontEnd/src/components/Order/OrderItem.vue
+++ b/FrontEnd/src/components/Order/OrderItem.vue
@@ -1,83 +1,193 @@
 <template>
-    <div class="container-fluid">
-      <div class="title-block text-center"><h1 class="card-title">Заказ # {{ getDateKilter }}</h1></div>
-      <div class="row">
-        <div class="col-lg-12 mx-auto">
-          <div class="card">
+  <div class="container-fluid order-page">
+    <div class="title-block text-center">
+      <h1 class="card-title">Заказ № {{ getDateKilter }}</h1>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-10 col-xl-8 mx-auto">
+
+        <!-- ШАПКА ЗАКАЗА -->
+        <div class="card mb-3 order-summary">
+          <div class="card-body">
+            <div class="d-flex flex-wrap justify-content-between align-items-start">
+              <div class="order-summary__main">
+                <span class="badge order-status-badge"
+                      :style="{ backgroundColor: statusColor(getStatus) }">
+                  {{ getHumanStatus }}
+                </span>
+                <div class="order-summary__total mt-2">
+                  Итого: <strong>{{ formatMoney(getTotalPrice) }} ₽</strong>
+                </div>
+              </div>
+            </div>
+
+            <dl class="row order-meta mt-3 mb-0">
+              <dt class="col-5 col-sm-4 text-muted">Покупатель</dt>
+              <dd class="col-7 col-sm-8">{{ getEmail || '—' }}</dd>
+
+              <template v-if="!getFriendlyId">
+                <dt class="col-5 col-sm-4 text-muted">Тип оплаты</dt>
+                <dd class="col-7 col-sm-8">{{ getTypeOfPayment || '—' }}</dd>
+              </template>
+
+              <dt class="col-5 col-sm-4 text-muted">Дата создания</dt>
+              <dd class="col-7 col-sm-8">{{ getDateCreate || '—' }}</dd>
+
+              <template v-if="!getFriendlyId">
+                <dt class="col-5 col-sm-4 text-muted">Дата оплаты</dt>
+                <dd class="col-7 col-sm-8">{{ getDateBuy || '—' }}</dd>
+              </template>
+
+              <template v-if="getLocationName">
+                <dt class="col-5 col-sm-4 text-muted">Локация</dt>
+                <dd class="col-7 col-sm-8">{{ getLocationName }}</dd>
+              </template>
+            </dl>
+          </div>
+        </div>
+
+        <!-- ГОСТИ (для гостя — только просмотр карточками) -->
+        <div v-if="!(isAdmin || isPusher || isCurator || isPusherCurator)">
+          <h5 class="section-title">Состав заказа ({{ getGuestList.length }})</h5>
+
+          <div v-for="(guest, index) in getGuestList"
+               :key="guest.id || index"
+               class="card mb-2 guest-card">
             <div class="card-body">
-              <table class="table table-hover">
-                <thead>
-                <tr>
-                  <th scope="col">Название</th>
-                  <th scope="col">Гости</th>
-                  <th scope="col" v-if="!getFriendlyId">Тип оплаты</th>
-                  <th scope="col" v-if="!getFriendlyId">Дата оплаты</th>
-                  <th scope="col" v-if="!getFriendlyId">Скидка</th>
-                  <th scope="col">Стоимость{{ (isAdmin && getFriendlyId) ? ' (ред.)' : '' }}</th>
-                  <th scope="col">Статус</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                  <td>{{ getName }}</td>
-                  <td>
-                    <div
-                      v-if="!(isAdmin || isPusher || isCurator)"
-                      v-html="getGuests"
-                    >
-                    </div>
-                    <new-ticket
-                        v-if="(isAdmin || isPusher || isCurator || isPusherCurator)"
-                        :oldGuests="getOrderItem.guests"
-                        :is-list="getCuratorId !== null"
-                    />
-                  </td>
-                  <td v-if="!getFriendlyId">{{ getTypeOfPayment }}</td>
-                  <td v-if="!getFriendlyId">{{ getDateBuy }}</td>
-                  <td class="text-right" v-if="!getFriendlyId">{{ getDiscount }}</td>
-                  <td class="text-right" v-if="getFriendlyId">
-                    <span v-if="!isAdmin">{{ getTotalPrice }}</span>
-                    <correct-price
-                        v-if="isAdmin"
-                        :id="getId"
-                        :oldPrice="getTotalPrice"/>
-                  </td>
-                  <td class="text-right" v-if="!getFriendlyId">{{ getTotalPrice }}</td>
+              <div class="d-flex justify-content-between align-items-start flex-wrap">
+                <div class="guest-card__person">
+                  <div class="guest-card__name">
+                    {{ isParkingGuest(guest) ? '🚗 ' : '' }}{{ guest.value }}
+                  </div>
+                  <div v-if="guest.email" class="guest-card__email text-muted small">
+                    {{ guest.email }}
+                  </div>
+                  <div class="guest-card__type">
+                    <span class="badge badge-light type-badge">{{ ticketTypeName(guest) }}</span>
+                    <span v-if="guest.is_live_ticket && guest.number"
+                          class="badge badge-info ml-1">Живой билет № {{ guest.number }}</span>
+                    <span v-else-if="guest.is_live_ticket"
+                          class="badge badge-secondary ml-1">Живой билет</span>
+                  </div>
+                </div>
+                <div class="guest-card__total text-right">
+                  <strong>{{ formatMoney(guestTotal(guest)) }} ₽</strong>
+                </div>
+              </div>
 
+              <!-- Опции гостя -->
+              <ul v-if="guest.options && guest.options.length" class="guest-options mt-2 mb-0">
+                <li v-for="(opt, oi) in guest.options" :key="oi"
+                    class="d-flex justify-content-between">
+                  <span>+ {{ opt.name }}</span>
+                  <span class="text-muted">{{ formatMoney(opt.price) }} ₽</span>
+                </li>
+              </ul>
 
-                  <td>{{ getHumanStatus }}</td>
-                </tr>
-                </tbody>
-              </table>
+              <!-- Промокод гостя -->
+              <div v-if="guest.promo_code" class="guest-promo mt-2 small">
+                Промокод: <span class="badge badge-success">{{ guest.promo_code }}</span>
+              </div>
 
-                <order-button
-                    :id="getId"
-                    :list-tickets="this.getOrderItem.tickets"
-                    :status="getStatus"/>
+              <!-- Скачать билет (PDF) — только если билет уже создан (заказ оплачен) -->
+              <div v-if="guestTicket(guest)" class="mt-2">
+                <button type="button"
+                        @click="downloadGuestTicket(guest)"
+                        class="btn btn-outline-primary btn-sm guest-pdf-btn">
+                  📄 Скачать билет (PDF)
+                </button>
+              </div>
 
-              <order-autos
-                  :order-id="getId"
-                  :curator-id="getCuratorId"
-                  :autos="getAutos"
-              />
+              <!-- Разбивка цены -->
+              <div v-if="hasPriceSnapshot(guest)" class="guest-price-breakdown mt-2 small text-muted">
+                <span>Билет {{ formatMoney(guest.price_snapshot.base_price) }} ₽</span>
+                <span v-if="guest.price_snapshot.options_sum">
+                  + опции {{ formatMoney(guest.price_snapshot.options_sum) }} ₽</span>
+                <span v-if="guest.price_snapshot.discount">
+                  − скидка {{ formatMoney(guest.price_snapshot.discount) }} ₽</span>
+                <span class="guest-price-breakdown__eq">
+                  = {{ formatMoney(guestTotal(guest)) }} ₽</span>
+              </div>
+            </div>
+          </div>
 
-              <button type="button"
-                      @click="back"
-                      class="btn btn-primary x-button">Назад в МОИ ОРГВЗНОСЫ</button>
-
-              <order-history
-                  v-if="isAdmin"
-                  :order-id="getId"
-              />
+          <!-- ИТОГ -->
+          <div class="card mb-3 order-footer">
+            <div class="card-body py-2">
+              <div class="d-flex justify-content-between">
+                <span class="text-muted">Сумма по гостям</span>
+                <span>{{ formatMoney(getGuestsSum) }} ₽</span>
+              </div>
+              <div v-if="getDiscountValue" class="d-flex justify-content-between text-muted">
+                <span>Скидка</span>
+                <span>− {{ formatMoney(getDiscountValue) }} ₽</span>
+              </div>
+              <hr class="my-2">
+              <div class="d-flex justify-content-between order-footer__total">
+                <strong>Итого к оплате</strong>
+                <strong>{{ formatMoney(getTotalPrice) }} ₽</strong>
+              </div>
             </div>
           </div>
         </div>
+
+        <!-- Режим редактирования (admin / pusher / curator) -->
+        <div v-else class="card mb-3">
+          <div class="card-body">
+            <h5 class="section-title">Гости заказа</h5>
+            <div class="mb-2 text-right">
+              <span class="badge badge-light">Итого: {{ formatMoney(getTotalPrice) }} ₽</span>
+            </div>
+            <new-ticket
+              :oldGuests="getGuestList"
+              :is-list="getCuratorId !== null"
+            />
+          </div>
+        </div>
+
+        <!-- БИЛЕТЫ / PDF / АНКЕТЫ -->
+        <div class="card mb-3">
+          <div class="card-body">
+            <order-button
+              :id="getId"
+              :list-tickets="getTickets"
+              :status="getStatus"/>
+          </div>
+        </div>
+
+        <!-- Автомобили (заказы-списки) -->
+        <order-autos
+          :order-id="getId"
+          :curator-id="getCuratorId"
+          :autos="getAutos"
+        />
+
+        <button type="button"
+                @click="back"
+                class="btn btn-primary x-button mt-3">Назад в МОИ ОРГВЗНОСЫ</button>
+
+        <!-- Изменение цены (admin) для friendly-заказов -->
+        <div v-if="isAdmin && getFriendlyId" class="card mt-3">
+          <div class="card-body">
+            <h6 class="section-title">Изменить стоимость</h6>
+            <correct-price
+              :id="getId"
+              :oldPrice="getTotalPrice"/>
+          </div>
+        </div>
+
+        <order-history
+          v-if="isAdmin"
+          :order-id="getId"
+        />
       </div>
     </div>
+  </div>
 </template>
 
 <script>
-import {mapGetters} from "vuex";
+import {mapGetters, mapActions} from "vuex";
 import OrderButton from "@/components/Order/OrderButton.vue";
 import NewTicket from "@/components/Order/NewTicket.vue";
 import OrderHistory from "@/components/Order/OrderHistory.vue";
@@ -91,6 +201,9 @@ export default {
     ...mapGetters('appOrder', [
       'getOrderItem',
     ]),
+    ...mapGetters('appFestivalTickets', [
+      'getTicketType',
+    ]),
     ...mapGetters('appUser', [
       'isAdmin',
       'isPusher',
@@ -98,43 +211,35 @@ export default {
       'isPusherCurator',
     ]),
     /**
-     * Вывести названия билета
-     *
-     * @returns {string|null}
+     * Список гостей заказа (формат v2.6.0: у каждого свой тип/опции/цена).
+     * @returns {Array}
      */
-    getName: function () {
-      return this.getOrderItem.name;
+    getGuestList: function () {
+      return this.getOrderItem.guests || [];
     },
     /**
-     * Вывести гоастей
-     *
-     * @returns {string}
+     * Созданные билеты (PDF доступны после оплаты).
+     * @returns {Array}
      */
-    getGuests: function () {
-      let result = '';
-      let sign = '';
-      this.getOrderItem.guests.forEach(function (elm) {
-        result = result + sign + elm.value + ' ' + (elm.email ?? '');
-        sign = '<br/> '
-      })
-
-      return result;
+    getTickets: function () {
+      return this.getOrderItem.tickets || [];
     },
-    /**
-     * Вывести стоимость
-     *
-     * @returns {0|number}
-     */
     getTotalPrice: function () {
       return this.getOrderItem.totalPrice;
     },
     /**
-     * Вывести скидку
-     *
-     * @returns {'-'|number}
+     * Сумма итогов по всем гостям (из price_snapshot.total).
+     * @returns {number}
      */
-    getDiscount: function () {
-      return this.getOrderItem.discount || '-';
+    getGuestsSum: function () {
+      return this.getGuestList.reduce((sum, g) => sum + this.guestTotal(g), 0);
+    },
+    /**
+     * Общая скидка заказа (число или 0).
+     * @returns {number}
+     */
+    getDiscountValue: function () {
+      return Number(this.getOrderItem.discount) || 0;
     },
     getTypeOfPayment: function () {
       return this.getOrderItem.typeOfPayment;
@@ -148,8 +253,14 @@ export default {
     getDateBuy: function () {
       return this.getOrderItem.dateBuy;
     },
+    getDateCreate: function () {
+      return this.getOrderItem.dateCreate || this.getOrderItem.dateBuy;
+    },
     getDateKilter: function () {
       return this.getOrderItem.kilter;
+    },
+    getEmail: function () {
+      return this.getOrderItem.email;
     },
     getId: function () {
       return this.getOrderItem.id;
@@ -160,14 +271,128 @@ export default {
     getCuratorId: function () {
       return this.getOrderItem.curator_id || null;
     },
+    getLocationName: function () {
+      return this.getOrderItem.location_name || null;
+    },
     getAutos: function () {
       return this.getOrderItem.autos || [];
     },
   },
+  watch: {
+    /**
+     * Когда заказ загрузился — подтягиваем типы билетов для маппинга UUID → название.
+     */
+    getGuestList: {
+      immediate: true,
+      handler(guests) {
+        this.ensureTicketTypesLoaded(guests);
+      },
+    },
+  },
   methods: {
+    ...mapActions('appFestivalTickets', ['getListPriceFor']),
+    ...mapActions('appOrder', ['getUrlForPdf']),
+    /**
+     * Билет, созданный для этого гостя.
+     * В формате v2.6.0 id билета совпадает с id гостя
+     * (бэкенд создаёт билет с id гостя в TicketApplication::createList).
+     * Если билета ещё нет (заказ не оплачен) — вернёт undefined.
+     * @returns {Object|undefined}
+     */
+    guestTicket(guest) {
+      if (!guest || !guest.id) return undefined;
+      return this.getTickets.find(t => t.id === guest.id);
+    },
+    /**
+     * Открыть PDF билета гостя в новой вкладке.
+     * Использует тот же API-эндпоинт getTicketPdf, что и общий блок скачивания.
+     */
+    async downloadGuestTicket(guest) {
+      const ticket = this.guestTicket(guest);
+      if (!ticket) return;
+      const win = window.open('about:blank', '_blank');
+      const url = await this.getUrlForPdf(ticket.id);
+      win.location = url;
+    },
+    /**
+     * Загрузить типы билетов фестиваля (если ещё не загружены),
+     * чтобы сопоставить guests[].ticket_type_id → name.
+     */
+    ensureTicketTypesLoaded(guests) {
+      if (this.getTicketType && this.getTicketType.length > 0) return;
+      if (!guests || guests.length === 0) return;
+      const festivalId = guests[0].festival_id;
+      if (!festivalId) return;
+      this.getListPriceFor({festival_id: festivalId});
+    },
+    /**
+     * Название типа билета по ticket_type_id гостя.
+     * Запасной текст «Билет», если тип не найден (например заказ-список без типа).
+     * @returns {string}
+     */
+    ticketTypeName(guest) {
+      if (!guest.ticket_type_id) {
+        return this.getLocationName ? this.getLocationName : 'Билет';
+      }
+      const found = (this.getTicketType || []).find(t => t.id === guest.ticket_type_id);
+      return found ? found.name : 'Билет';
+    },
+    /**
+     * Итог строки гостя — из price_snapshot.total (целые рубли).
+     * @returns {number}
+     */
+    guestTotal(guest) {
+      if (guest.price_snapshot && guest.price_snapshot.total != null) {
+        return Number(guest.price_snapshot.total);
+      }
+      return 0;
+    },
+    hasPriceSnapshot(guest) {
+      return guest.price_snapshot && guest.price_snapshot.base_price != null;
+    },
+    /**
+     * Парковка определяется по формату value «номер / марка / водитель».
+     */
+    isParkingGuest(guest) {
+      return typeof guest.value === 'string' && guest.value.split('/').length >= 3;
+    },
+    /**
+     * Формат денег: целые рубли с разделителем тысяч.
+     * @returns {string}
+     */
+    formatMoney(value) {
+      const n = Number(value) || 0;
+      return n.toLocaleString('ru-RU');
+    },
+    /**
+     * Цвет бейджа статуса (по образцу OrderLists/OrderList.vue).
+     * @returns {string}
+     */
+    statusColor(status) {
+      switch (status) {
+        case 'new':
+        case 'new_for_live':
+        case 'new_list':
+          return '#6c757d';
+        case 'paid':
+        case 'paid_for_live':
+        case 'live_ticket_issued':
+        case 'approve_list':
+          return '#1e871c';
+        case 'cancel':
+        case 'cancel_for_live':
+        case 'cancel_list':
+          return '#86201c';
+        case 'difficulties_arose':
+        case 'difficulties_arose_list':
+          return '#d0ba27';
+        default:
+          return '#888888';
+      }
+    },
     back: function () {
       this.$router.back();
-    }
+    },
   },
   created() {
     document.title = "Мой заказ"
@@ -175,3 +400,87 @@ export default {
 }
 </script>
 
+<style scoped>
+.order-page {
+  padding-bottom: 24px;
+}
+
+.section-title {
+  margin: 16px 0 10px;
+  font-weight: 600;
+}
+
+.order-status-badge {
+  font-size: 14px;
+  padding: 6px 12px;
+  color: #fff;
+}
+
+.order-summary__total {
+  font-size: 18px;
+}
+
+.order-meta dt {
+  font-weight: 400;
+}
+
+.order-meta dd {
+  margin-bottom: 4px;
+}
+
+.guest-card__name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.guest-card__total {
+  font-size: 16px;
+  white-space: nowrap;
+}
+
+.type-badge {
+  border: 1px solid #ddd;
+  font-size: 13px;
+}
+
+.guest-options {
+  list-style: none;
+  padding-left: 0;
+  font-size: 14px;
+}
+
+.guest-options li {
+  padding: 2px 0;
+}
+
+.guest-price-breakdown span {
+  margin-right: 6px;
+}
+
+.guest-price-breakdown__eq {
+  font-weight: 600;
+  color: #333;
+}
+
+.order-footer__total {
+  font-size: 16px;
+}
+
+.guest-pdf-btn {
+  font-size: 13px;
+}
+
+/* Мобильная адаптация: на узких экранах карточки гостя — в столбец */
+@media (max-width: 575.98px) {
+  .guest-card .d-flex {
+    flex-direction: column;
+  }
+  .guest-card__total {
+    text-align: left !important;
+    margin-top: 6px;
+  }
+  .order-status-badge {
+    font-size: 13px;
+  }
+}
+</style>

--- a/FrontEnd/src/store/modules/OrderModule/actions.js
+++ b/FrontEnd/src/store/modules/OrderModule/actions.js
@@ -3,20 +3,82 @@ import axios from 'axios';
 const API_ORDER = '/api/v1/order'
 const API_INVITE = '/api/v1/invite'
 /**
- * Отправить данные на создание билета
+ * Отправить данные на создание заказа (формат v2.6.0 — per-guest корзина).
+ *
+ * payload.body — тело запроса (email/phone/city/name/festival_id/types_of_payment_id/comment/invite/guests[]).
+ * payload.callback(success, message, link) — колбэк результата.
+ *
+ * callback не уходит на бэк — формируем чистое тело из payload.body.
  *
  * @param context
  * @param payload
  */
 export const goToCreateOrderTicket = (context, payload) => {
-    let promise = axios.post(API_ORDER + '/create', payload);
+    let promise = axios.post(API_ORDER + '/create', payload.body);
     promise.then(function (response) {
-        console.log(response.data.success);
-        payload.callback(response.data.success, response.data.message, response.data.link ?? null);
+        if (response.data.success) {
+            // На успешном ответе ошибки прошлой попытки сбрасываем
+            context.commit('setError', []);
+        }
+        if (payload.callback) {
+            payload.callback(response.data.success, response.data.message, response.data.link ?? null);
+        }
     }).catch(function (error) {
         console.error(error);
-        context.commit('setError', error.response.data.errors);
+        context.commit('setError', error.response?.data?.errors ?? []);
+        if (payload.callback) {
+            payload.callback(false, error.response?.data?.message ?? 'Ошибка создания заказа', null);
+        }
     });
+}
+
+/**
+ * Live-расчёт цены заказа без сохранения (per-guest) — формат v2.6.0.
+ *
+ * payload.body — { festival_id, guests[] }.
+ * Возвращает Promise<{ success, lines[], totalPrice }>.
+ * lines[] в том же порядке, что guests[]: { basePrice, optionsSum, discount, total } (целые рубли).
+ *
+ * @param context
+ * @param payload
+ */
+export const calculatePrice = (context, payload) => {
+    return axios.post(API_ORDER + '/calculatePrice', payload.body)
+        .then(function (response) {
+            return response.data;
+        })
+        .catch(function (error) {
+            console.error(error);
+            return {
+                success: false,
+                lines: [],
+                totalPrice: null,
+                message: error.response?.data?.message ?? 'Не удалось рассчитать стоимость',
+            };
+        });
+}
+
+/**
+ * Загрузить активные опции для типа билета (read-модель формы покупки).
+ *
+ * payload.ticketTypeId — UUID типа билета.
+ * Возвращает Promise<Array> со списком { id, name, price, description, active }.
+ *
+ * Грузим inline здесь (не в OptionModule), чтобы у каждой карточки гостя был свой
+ * независимый список опций — в OptionModule хранится только один общий слот.
+ *
+ * @param context
+ * @param payload
+ */
+export const loadOptionsForTicketType = (context, payload) => {
+    return axios.get('/api/v1/option/getActiveForTicketType/' + payload.ticketTypeId)
+        .then(function (response) {
+            return response.data.list ?? [];
+        })
+        .catch(function (error) {
+            console.error(error);
+            return [];
+        });
 }
 
 


### PR DESCRIPTION
## Что это

Завершение v2.6.0 на фронте: **новая форма покупки** под per-guest формат заказа (каждый гость — свой тип билета/опции/промокод), **понятный вывод заказа** `/order/:id`, и сопутствующие **инфра-фиксы деплоя/воркера**, найденные при тестах на staging.

Бэкенд per-guest формата (агрегат/DTO/репозиторий/контроллеры) уже в master (PR #72). Эта ветка добавляет фронт + price-preview endpoint + чинит деплой.

## Frontend

### Форма покупки (`BuyTicket.vue` + новый `GuestCard.vue`)
- Корзина: каждый гость — карточка со своим **типом билета**, **опциями** (с количеством `qty`), **промокодом**, ФИО/email (или поля авто для парковки).
- Live-расчёт итога через `POST /order/calculatePrice` (debounce).
- Блокировка смешивания live/non-live, лимит 10 гостей, согласие + сабмит.
- Composition API (`<script setup>`).

### Вывод заказа (`OrderItem.vue`)
- Карточки гостей вместо широкой таблицы: тип билета (name по `ticket_type_id`), опции, промокод, разбивка цены (`base + опции − скидка = total`), номер живого билета, пометка парковки.
- Шапка: №, статус цветным бейджем, итог, мета (оплата/дата/email/локация).
- Ссылка «Скачать билет (PDF)» в карточке гостя.
- Мобильная адаптивность.

### Vuex `OrderModule`
- Новый payload `create` (per-guest `guests[]`), экшены `calculatePrice` и `loadOptionsForTicketType`.

## Backend
- `POST /api/v1/order/calculatePrice` — live-расчёт цены без сохранения (через `OrderPriceCalculator`).
- Фикс бэкапа миграции: `SHOW TABLES LIKE ?` → `information_schema` (MySQL/PDO не поддерживает плейсхолдер в `SHOW TABLES`; ломало `order:migrate-to-guests-format --apply`, в т.ч. для прода).

## Infra (deploy staging)
- Сборка фронта: чистка `dist` под root перед билдом (EACCES unlink из-за UID-несовпадения).
- `storage:link` + создание `storage/app/public/tickets` (иначе PDF 404).
- **Воркер очередей**: бежит под `user`, добавлен в группу `www-data`, storage сделан group-writable + setgid. Иначе билеты/PDF/письма не создавались (под `www-data` `queue:work` не консьюмил очередь; под `user` без группы — Permission denied на запись storage).

## Проверено на staging
- Заказ с оргвзносом + опцией + детским билетом: создаются **оба билета**, **PDF** (HTTP 200), **письма** (SMTP 250 → Mailpit).
- Вывод заказа `/order/:id` — гости карточками с PDF.
- `npm run build` зелёный.

## Деплой-замечание
После мерджа и выката на прод нужно **один раз** прогнать миграцию данных:
`php artisan order:migrate-to-guests-format --apply` (с бэкапом — теперь работает).

🤖 Generated with [Claude Code](https://claude.com/claude-code)