### PR TITLE
feat(qr): интеграция приёма заказов qr→org (S2S + async-pipeline + 4 типа + идемпотентность/история)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -145,6 +145,21 @@ jobs:
             echo "✓ Backend/.env уже существует — пропускаю"
           fi
 
+      # Подключение к БД Baza (el_tickets и пр.) добавляем идемпотентно: на уже
+      # существующем Backend/.env bootstrap пропускается, а DB_BAZA_* могли там
+      # ещё отсутствовать (введены вместе с записью qr-билетов в Baza).
+      - name: Ensure Backend/.env has Baza connection vars
+        working-directory: ${{ env.PROJECT_DIR }}
+        run: |
+          DB_PWD="$(grep ^MYSQL_PASSWORD .env.staging | cut -d= -f2)"
+          add_kv() { grep -qE "^$1=" Backend/.env || echo "$1=$2" >> Backend/.env; }
+          add_kv DB_BAZA_HOST mysql-staging
+          add_kv DB_BAZA_PORT 3306
+          add_kv DB_BAZA_DATABASE baza
+          add_kv DB_BAZA_USERNAME systo
+          add_kv DB_BAZA_PASSWORD "$DB_PWD"
+          echo "✓ DB_BAZA_* присутствуют в Backend/.env (Baza доступна со staging)"
+
       - name: Bootstrap Baza/.env (first deploy)
         working-directory: ${{ env.PROJECT_DIR }}
         run: |

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -18,6 +18,14 @@ DB_DATABASE=systo
 DB_USERNAME=default
 DB_PASSWORD=secret
 
+# Подключение к БД Baza (вход/сканер: el_tickets, spisok_tickets, live_tickets).
+# Дефолты соответствуют dev docker-сервису `database` — можно не задавать локально.
+DB_BAZA_HOST=database
+DB_BAZA_PORT=3306
+DB_BAZA_DATABASE=baza
+DB_BAZA_USERNAME=root
+DB_BAZA_PASSWORD=common404
+
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local

--- a/Backend/.env.staging.example
+++ b/Backend/.env.staging.example
@@ -18,6 +18,15 @@ DB_DATABASE=systo
 DB_USERNAME=systo
 DB_PASSWORD=staging_secret_CHANGE_ME
 
+# === DB Baza (вход/сканер: el_tickets, spisok_tickets, live_tickets) =========
+# Та же MySQL-инстанция staging, БД `baza`. Пользователю systo выдан GRANT на baza.*
+# (шаг "Ensure Baza database exists"). Пароль = MYSQL_PASSWORD (подставляется в деплое).
+DB_BAZA_HOST=mysql-staging
+DB_BAZA_PORT=3306
+DB_BAZA_DATABASE=baza
+DB_BAZA_USERNAME=systo
+DB_BAZA_PASSWORD=staging_secret_CHANGE_ME
+
 BROADCAST_DRIVER=log
 # CACHE_DRIVER=redis/SESSION_DRIVER=redis требуют ext-redis или predis/predis.
 # На staging-контейнере ни того, ни другого пока нет — используем file driver.

--- a/Backend/app/Console/Commands/QrIssueServiceToken.php
+++ b/Backend/app/Console/Commands/QrIssueServiceToken.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Tickets\User\Account\Helpers\AccountRoleHelper;
+
+/**
+ * Выпускает S2S-токен Sanctum для канала qr→org.
+ *
+ * Токен привязан к служебному аккаунту (role qr_service, не человек) и имеет единственный
+ * scope (ability) "qr:ingest" — его проверяет middleware abilities на /qrOrder/create и
+ * /qrOrder/changeStatus. Plaintext токена показывается ОДИН раз: его кладут в .env qr-сервера
+ * и шлют заголовком `Authorization: Bearer <token>`. В БД хранится только sha256-хеш.
+ *
+ * Это ops-инструмент (как key:generate / jwt:secret), а не часть request-потока,
+ * поэтому работа с моделью здесь допустима (Sanctum привязывает токен к Eloquent-модели).
+ */
+class QrIssueServiceToken extends Command
+{
+    protected $signature = 'qr:issue-token {--revoke-old : Отозвать все ранее выпущенные токены сервис-аккаунта}';
+
+    protected $description = 'Выпустить S2S-токен Sanctum для приёма заказов с витрины qr (ability: qr:ingest)';
+
+    /** Email служебного аккаунта витрины qr (не используется для входа — пароль случайный). */
+    private const SERVICE_EMAIL = 'qr-service@system.local';
+
+    /** Единственный scope токена: право принимать заказы и менять их статус. */
+    private const ABILITY = 'qr:ingest';
+
+    public function handle(): int
+    {
+        // Служебный аккаунт создаётся один раз и переиспользуется (id ставит HasUuid).
+        $serviceAccount = User::firstOrCreate(
+            ['email' => self::SERVICE_EMAIL],
+            [
+                'name' => 'QR Service',
+                'role' => AccountRoleHelper::qr_service,
+                'password' => bcrypt(Str::random(64)),
+            ],
+        );
+
+        if ($this->option('revoke-old')) {
+            $revoked = $serviceAccount->tokens()->delete();
+            $this->warn(sprintf('Отозвано старых токенов: %d', $revoked));
+        }
+
+        $token = $serviceAccount->createToken('qr-s2s', [self::ABILITY])->plainTextToken;
+
+        $this->newLine();
+        $this->info('Токен выпущен. Покажется ОДИН раз — положи в .env qr-сервера.');
+        $this->line('Заголовок запроса:  Authorization: Bearer <token>');
+        $this->newLine();
+        $this->line($token);
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+}

--- a/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
+++ b/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Shared\Domain\ValueObject\Uuid;
 use Throwable;
+use Tickets\History\Dto\DomainHistoryDto;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
 use Tickets\QrOrder\Application\QrOrderApplication;
 use Tickets\QrOrder\Dto\QrOrderDto;
 
@@ -86,5 +88,27 @@ class QrOrderController extends Controller
             'item' => $application->getItem(new Uuid($id))?->toArray(),
             'message' => 'Статус обновлён',
         ]);
+    }
+
+    /**
+     * История заказа qr (таймлайн для админа org): created → status_changed → issued.
+     * Actor — ActorType::QR (S2S-канал, не человек).
+     */
+    public function getHistory(
+        string $id,
+        HistoryRepositoryInterface $history,
+    ): JsonResponse {
+        $items = array_map(
+            static fn (DomainHistoryDto $h): array => [
+                'event_name' => $h->eventName,
+                'aggregate_type' => $h->aggregateType,
+                'payload' => $h->payload,
+                'actor_type' => $h->actorType,
+                'occurred_at' => $h->occurredAt->toIso8601String(),
+            ],
+            $history->getByAggregateId($id),
+        );
+
+        return response()->json(['success' => true, 'history' => $items]);
     }
 }

--- a/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
+++ b/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\QrOrder;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\QrOrder\Application\QrOrderApplication;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * API приёма заказов от витрины qr.spaceofjoy.ru.
+ *
+ * API №1 — создание заказа: принимает расширенный JSON-контракт и сохраняет его в qr_orders
+ * (payload as-is + проекция для фильтров). id заказа qr == id заказа org.
+ *
+ * TODO(безопасность): эндпоинт create — server-to-server от qr. Сейчас публичный (как order/create).
+ * Механизм аутентификации канала (service-token / подпись) — отдельное решение владельца.
+ */
+class QrOrderController extends Controller
+{
+    public function create(
+        Request $request,
+        QrOrderApplication $application,
+    ): JsonResponse {
+        try {
+            $dto = QrOrderDto::fromQrContract($request->toArray());
+            $application->create($dto);
+
+            return response()->json([
+                'success' => true,
+                'order_id' => $dto->getId()->value(),
+                'message' => 'Заказ принят',
+            ]);
+        } catch (InvalidArgumentException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 422);
+        } catch (Throwable $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => $exception->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function getItem(
+        string $id,
+        QrOrderApplication $application,
+    ): JsonResponse {
+        $item = $application->getItem(new Uuid($id));
+
+        if ($item === null) {
+            return response()->json(['success' => false, 'message' => 'Заказ не найден'], 404);
+        }
+
+        return response()->json(['success' => true, 'item' => $item->toArray()]);
+    }
+}

--- a/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
+++ b/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
@@ -62,4 +62,29 @@ class QrOrderController extends Controller
 
         return response()->json(['success' => true, 'item' => $item->toArray()]);
     }
+
+    /**
+     * API №2 — смена статуса принятого заказа.
+     * Шаг 2a: обновляет статус. Шаг 2b: при «оплачен» запустит выдачу билетов.
+     */
+    public function changeStatus(
+        string $id,
+        Request $request,
+        QrOrderApplication $application,
+    ): JsonResponse {
+        $status = (string) $request->input('status', '');
+        if ($status === '') {
+            return response()->json(['success' => false, 'message' => 'Не передан status'], 422);
+        }
+
+        if (! $application->changeStatus(new Uuid($id), $status)) {
+            return response()->json(['success' => false, 'message' => 'Заказ не найден'], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'item' => $application->getItem(new Uuid($id))?->toArray(),
+            'message' => 'Статус обновлён',
+        ]);
+    }
 }

--- a/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
+++ b/Backend/app/Http/Controllers/QrOrder/QrOrderController.php
@@ -19,8 +19,8 @@ use Tickets\QrOrder\Dto\QrOrderDto;
  * API №1 — создание заказа: принимает расширенный JSON-контракт и сохраняет его в qr_orders
  * (payload as-is + проекция для фильтров). id заказа qr == id заказа org.
  *
- * TODO(безопасность): эндпоинт create — server-to-server от qr. Сейчас публичный (как order/create).
- * Механизм аутентификации канала (service-token / подпись) — отдельное решение владельца.
+ * Аутентификация канала: create/changeStatus закрыты Sanctum-токеном со scope qr:ingest
+ * (auth:sanctum + abilities:qr:ingest, см. routes/qrOrder.php). getItem — JWT + admin (ПДн).
  */
 class QrOrderController extends Controller
 {

--- a/Backend/app/Http/Kernel.php
+++ b/Backend/app/Http/Kernel.php
@@ -71,5 +71,7 @@ class Kernel extends HttpKernel
         'admin' => IsAdmin::class,
         'role' => \App\Http\Middleware\CheckRole::class,
         'bot' => Bot::class,
+        // Проверка scope (ability) Sanctum-токена — для S2S-канала qr→org.
+        'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
     ];
 }

--- a/Backend/app/Models/QrOrder/QrOrderModel.php
+++ b/Backend/app/Models/QrOrder/QrOrderModel.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\QrOrder;
+
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Shared\Infrastructure\Models\HasUuid;
+
+/**
+ * App\Models\QrOrder\QrOrderModel — входящий заказ от витрины qr.
+ *
+ * @property string $id
+ * @property string $email
+ * @property string $status
+ * @property string|null $festival_id
+ * @property string|null $type_order
+ * @property string|null $city
+ * @property string|null $phone
+ * @property int $total_price
+ * @property array $payload
+ * @property Carbon|null $issued_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @method static Builder|QrOrderModel query()
+ * @method static Builder|QrOrderModel whereId($value)
+ * @mixin Eloquent
+ */
+class QrOrderModel extends Model
+{
+    use HasFactory, HasUuid;
+
+    public const TABLE = 'qr_orders';
+
+    protected $table = self::TABLE;
+
+    protected $fillable = [
+        'id',
+        'email',
+        'status',
+        'festival_id',
+        'type_order',
+        'city',
+        'phone',
+        'total_price',
+        'payload',
+        'issued_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',      // единственный источник кодирования JSON (правило №11)
+        'total_price' => 'integer',
+        'issued_at' => 'datetime',
+    ];
+}

--- a/Backend/app/Providers/RouteServiceProvider.php
+++ b/Backend/app/Providers/RouteServiceProvider.php
@@ -90,6 +90,11 @@ class RouteServiceProvider extends ServiceProvider
                 ->prefix('api')
                 ->group(base_path('routes/ticket.php'));
 
+            // приём заказов от витрины qr.spaceofjoy.ru
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/qrOrder.php'));
+
             Route::middleware('web')
                 ->group(base_path('routes/web.php'));
         });

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -46,6 +46,8 @@ use Tickets\TicketTypePrice\Repositories\InMemoryMySqlTicketTypePriceRepository;
 use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
+use Tickets\QrOrder\Application\Issuance\IssuanceStrategyRegistry;
+use Tickets\QrOrder\Application\Issuance\Strategy\RegularIssuanceStrategy;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrIssuanceRepository;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
 use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
@@ -84,5 +86,13 @@ class TicketsProvider extends ServiceProvider
         // Приём заказов от витрины qr (API №1) + выдача билетов (API №2b)
         $this->app->bind(QrOrderRepositoryInterface::class, InMemoryMySqlQrOrderRepository::class);
         $this->app->bind(QrIssuanceRepositoryInterface::class, InMemoryMySqlQrIssuanceRepository::class);
+
+        // Реестр стратегий выдачи билетов по qr-заказу (type_order → стратегия).
+        // Новая стратегия (friendly/список/live) добавляется одной строкой здесь.
+        $this->app->singleton(IssuanceStrategyRegistry::class, static function ($app): IssuanceStrategyRegistry {
+            return new IssuanceStrategyRegistry([
+                $app->make(RegularIssuanceStrategy::class),
+            ]);
+        });
     }
 }

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -49,6 +49,7 @@ use Tickets\User\Account\Repositories\UserRepositoriesInterface;
 use Tickets\QrOrder\Application\Issuance\IssuanceStrategyRegistry;
 use Tickets\QrOrder\Application\Issuance\Strategy\FriendlyIssuanceStrategy;
 use Tickets\QrOrder\Application\Issuance\Strategy\ListIssuanceStrategy;
+use Tickets\QrOrder\Application\Issuance\Strategy\LiveIssuanceStrategy;
 use Tickets\QrOrder\Application\Issuance\Strategy\RegularIssuanceStrategy;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrIssuanceRepository;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
@@ -96,6 +97,7 @@ class TicketsProvider extends ServiceProvider
                 $app->make(RegularIssuanceStrategy::class),
                 $app->make(FriendlyIssuanceStrategy::class),
                 $app->make(ListIssuanceStrategy::class),
+                $app->make(LiveIssuanceStrategy::class),
             ]);
         });
     }

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -48,6 +48,7 @@ use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
 use Tickets\QrOrder\Application\Issuance\IssuanceStrategyRegistry;
 use Tickets\QrOrder\Application\Issuance\Strategy\FriendlyIssuanceStrategy;
+use Tickets\QrOrder\Application\Issuance\Strategy\ListIssuanceStrategy;
 use Tickets\QrOrder\Application\Issuance\Strategy\RegularIssuanceStrategy;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrIssuanceRepository;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
@@ -94,6 +95,7 @@ class TicketsProvider extends ServiceProvider
             return new IssuanceStrategyRegistry([
                 $app->make(RegularIssuanceStrategy::class),
                 $app->make(FriendlyIssuanceStrategy::class),
+                $app->make(ListIssuanceStrategy::class),
             ]);
         });
     }

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -47,6 +47,7 @@ use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
 use Tickets\QrOrder\Application\Issuance\IssuanceStrategyRegistry;
+use Tickets\QrOrder\Application\Issuance\Strategy\FriendlyIssuanceStrategy;
 use Tickets\QrOrder\Application\Issuance\Strategy\RegularIssuanceStrategy;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrIssuanceRepository;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
@@ -92,6 +93,7 @@ class TicketsProvider extends ServiceProvider
         $this->app->singleton(IssuanceStrategyRegistry::class, static function ($app): IssuanceStrategyRegistry {
             return new IssuanceStrategyRegistry([
                 $app->make(RegularIssuanceStrategy::class),
+                $app->make(FriendlyIssuanceStrategy::class),
             ]);
         });
     }

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -46,7 +46,9 @@ use Tickets\TicketTypePrice\Repositories\InMemoryMySqlTicketTypePriceRepository;
 use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
+use Tickets\QrOrder\Repositories\InMemoryMySqlQrIssuanceRepository;
 use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
+use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
 class TicketsProvider extends ServiceProvider
@@ -79,7 +81,8 @@ class TicketsProvider extends ServiceProvider
         $this->app->bind(OptionRepositoryInterface::class, InMemoryMySqlOptionRepository::class);
         $this->app->bind(OptionPriceRepositoryInterface::class, InMemoryMySqlOptionPriceRepository::class);
         $this->app->bind(AutoRepositoryInterface::class, InMemoryMySqlAutoRepository::class);
-        // Приём заказов от витрины qr (API №1)
+        // Приём заказов от витрины qr (API №1) + выдача билетов (API №2b)
         $this->app->bind(QrOrderRepositoryInterface::class, InMemoryMySqlQrOrderRepository::class);
+        $this->app->bind(QrIssuanceRepositoryInterface::class, InMemoryMySqlQrIssuanceRepository::class);
     }
 }

--- a/Backend/app/Providers/Tickets/TicketsProvider.php
+++ b/Backend/app/Providers/Tickets/TicketsProvider.php
@@ -46,6 +46,8 @@ use Tickets\TicketTypePrice\Repositories\InMemoryMySqlTicketTypePriceRepository;
 use Tickets\TicketTypePrice\Repositories\TicketTypePriceRepositoryInterface;
 use Tickets\User\Account\Repositories\InMemoryMySqlUserRepositories;
 use Tickets\User\Account\Repositories\UserRepositoriesInterface;
+use Tickets\QrOrder\Repositories\InMemoryMySqlQrOrderRepository;
+use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
 class TicketsProvider extends ServiceProvider
 {
@@ -77,5 +79,7 @@ class TicketsProvider extends ServiceProvider
         $this->app->bind(OptionRepositoryInterface::class, InMemoryMySqlOptionRepository::class);
         $this->app->bind(OptionPriceRepositoryInterface::class, InMemoryMySqlOptionPriceRepository::class);
         $this->app->bind(AutoRepositoryInterface::class, InMemoryMySqlAutoRepository::class);
+        // Приём заказов от витрины qr (API №1)
+        $this->app->bind(QrOrderRepositoryInterface::class, InMemoryMySqlQrOrderRepository::class);
     }
 }

--- a/Backend/config/auth.php
+++ b/Backend/config/auth.php
@@ -47,6 +47,13 @@ return [
             'provider' => 'users',
         ],
 
+        // Отдельный guard для S2S-канала qr→org (Bearer-токены Sanctum).
+        // Не трогает основной api(jwt) — используется только на /qrOrder/{create,changeStatus}.
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
+
     ],
 
     /*

--- a/Backend/config/database.php
+++ b/Backend/config/database.php
@@ -66,11 +66,13 @@ return [
         'mysqlBaza' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),
-            'host' => 'database',
-            'port' => env('DB_PORT', '3306'),
-            'database' => 'baza',
-            'username' => 'root',
-            'password' => 'common404',
+            // Дефолты = dev/prod docker-сервис `database` (root/common404) — поведение не меняется.
+            // На staging переопределяется через DB_BAZA_* (host mysql-staging, пользователь systo).
+            'host' => env('DB_BAZA_HOST', 'database'),
+            'port' => env('DB_BAZA_PORT', env('DB_PORT', '3306')),
+            'database' => env('DB_BAZA_DATABASE', 'baza'),
+            'username' => env('DB_BAZA_USERNAME', 'root'),
+            'password' => env('DB_BAZA_PASSWORD', 'common404'),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',

--- a/Backend/config/logging.php
+++ b/Backend/config/logging.php
@@ -70,6 +70,15 @@ return [
             'days' => 14,
         ],
 
+        // Канал pipeline выдачи билетов по заказам qr (структурированный JSON, без ПДн). См. TD-10.
+        'qr_pipeline' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/qr_pipeline.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 30,
+            'formatter' => \Monolog\Formatter\JsonFormatter::class,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),

--- a/Backend/database/migrations/2026_06_14_140000_create_qr_orders_table.php
+++ b/Backend/database/migrations/2026_06_14_140000_create_qr_orders_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Таблица входящих заказов от витрины qr.spaceofjoy.ru (anti-corruption staging-таблица).
+ *
+ * Хранит расширенный JSON-контракт заказа as-is в `payload` (источник истины) + плоские
+ * проекционные колонки для фильтрации в админке (email/status/festival_id/type_order/city).
+ * PK = id заказа из qr (он же РАВЕН id заказа в org — маппинг не нужен).
+ *
+ * Решение tech-lead (2026-06-14): отдельная таблица в БД systo, НЕ переиспользуем order_tickets;
+ * паттерн «JSON + индексируемые проекции» как в questionnaire.data.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('qr_orders', static function (Blueprint $table): void {
+            $table->uuid('id')->primary(); // == id заказа в qr (== org)
+
+            // Проекция полей контракта для фильтрации (денормализация из payload при приёме).
+            $table->string('email')->index();
+            $table->string('status')->index();
+            $table->uuid('festival_id')->nullable()->index();
+            $table->string('type_order')->nullable()->index();
+            $table->string('city')->nullable()->index();
+            $table->string('phone')->nullable();
+            $table->unsignedBigInteger('total_price')->default(0); // целые рубли (как Money VO)
+
+            // Сырой контракт qr целиком — источник истины.
+            $table->json('payload');
+
+            // Когда заказ переведён в выдачу (отработал API №2 смены статуса).
+            $table->timestamp('issued_at')->nullable();
+
+            $table->timestamps();
+
+            // Составные индексы под типовые фильтры админки.
+            $table->index(['festival_id', 'status']);
+            $table->index(['festival_id', 'type_order']);
+            $table->index(['status', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('qr_orders');
+    }
+};

--- a/Backend/database/migrations/2026_06_14_150000_drop_tickets_order_ticket_id_foreign.php
+++ b/Backend/database/migrations/2026_06_14_150000_drop_tickets_order_ticket_id_foreign.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Снимает внешний ключ tickets.order_ticket_id → order_tickets(id).
+ *
+ * Зачем: билеты заказов из витрины qr хранятся в той же таблице tickets, но их «заказ» живёт
+ * в qr_orders (id заказа qr == order_ticket_id билета), а не в order_tickets. FK блокировал
+ * автономную выдачу (решение B). После снятия FK поле order_ticket_id — обычный uuid,
+ * указывающий на order_tickets ЛИБО на qr_orders; валидность гарантирует код приложения.
+ *
+ * Индекс на order_ticket_id (создавался под FK) сохраняется — JOIN'ы в getTicket не страдают.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', static function (Blueprint $table): void {
+            $table->dropForeign(['order_ticket_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        // Откат вернёт FK. Сработает только если все order_ticket_id ссылаются на order_tickets
+        // (т.е. до появления qr-билетов).
+        Schema::table('tickets', static function (Blueprint $table): void {
+            $table->foreign('order_ticket_id')->references('id')->on('order_tickets');
+        });
+    }
+};

--- a/Backend/database/migrations/2026_06_14_160000_recreate_personal_access_tokens_for_uuid.php
+++ b/Backend/database/migrations/2026_06_14_160000_recreate_personal_access_tokens_for_uuid.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Пересоздаёт personal_access_tokens под UUID-владельцев.
+ *
+ * Проектная таблица — старой схемы Sanctum: tokenable_id = BIGINT (morphs) и нет expires_at.
+ * Но id пользователя в проекте — UUID, поэтому createToken() падал
+ * («Incorrect integer value … for column tokenable_id»). Sanctum в проекте раньше не
+ * использовался → таблица пустая везде, безопасно дропнуть и создать заново с uuidMorphs
+ * и колонкой expires_at (актуальная схема Sanctum 3.x).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+
+        Schema::create('personal_access_tokens', static function (Blueprint $table): void {
+            $table->id();
+            $table->uuidMorphs('tokenable'); // tokenable_id = char(36) под UUID пользователя
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        // Откат к старой схеме Sanctum (BIGINT-владелец, без expires_at).
+        Schema::dropIfExists('personal_access_tokens');
+
+        Schema::create('personal_access_tokens', static function (Blueprint $table): void {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamps();
+        });
+    }
+};

--- a/Backend/routes/qrOrder.php
+++ b/Backend/routes/qrOrder.php
@@ -6,15 +6,18 @@ use App\Http\Controllers\QrOrder\QrOrderController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/qrOrder')->group(static function (): void {
-    // API №1 — приём заказа от витрины qr (server-to-server).
-    // TODO(безопасность): добавить аутентификацию канала (service-token/подпись).
-    Route::post('/create', [QrOrderController::class, 'create']);
+    // S2S-канал qr→org: Sanctum-токен сервис-аккаунта со scope (ability) "qr:ingest".
+    // Токен выпускается командой `php artisan qr:issue-token` и хранится в .env qr-сервера;
+    // qr шлёт его заголовком `Authorization: Bearer <token>`.
+    Route::middleware(['auth:sanctum', 'abilities:qr:ingest'])->group(static function (): void {
+        // API №1 — приём заказа от витрины qr.
+        Route::post('/create', [QrOrderController::class, 'create']);
 
-    // API №2 — смена статуса заказа (server-to-server от qr; шаг 2b запустит выдачу билетов).
-    // TODO(безопасность): аутентификация канала.
-    Route::post('/changeStatus/{id}', [QrOrderController::class, 'changeStatus']);
+        // API №2 — смена статуса заказа (шаг 2b при «оплачен» запускает выдачу билетов).
+        Route::post('/changeStatus/{id}', [QrOrderController::class, 'changeStatus']);
+    });
 
-    // Чтение принятого заказа — только админ (содержит ПДн).
+    // Чтение принятого заказа — только админ org (JWT), содержит ПДн.
     Route::get('/getItem/{id}', [QrOrderController::class, 'getItem'])
         ->middleware('auth:api')
         ->middleware('admin');

--- a/Backend/routes/qrOrder.php
+++ b/Backend/routes/qrOrder.php
@@ -21,4 +21,9 @@ Route::prefix('v1/qrOrder')->group(static function (): void {
     Route::get('/getItem/{id}', [QrOrderController::class, 'getItem'])
         ->middleware('auth:api')
         ->middleware('admin');
+
+    // История заказа (created/status_changed/issued, actor=qr) — только админ org.
+    Route::get('/getHistory/{id}', [QrOrderController::class, 'getHistory'])
+        ->middleware('auth:api')
+        ->middleware('admin');
 });

--- a/Backend/routes/qrOrder.php
+++ b/Backend/routes/qrOrder.php
@@ -10,6 +10,10 @@ Route::prefix('v1/qrOrder')->group(static function (): void {
     // TODO(безопасность): добавить аутентификацию канала (service-token/подпись).
     Route::post('/create', [QrOrderController::class, 'create']);
 
+    // API №2 — смена статуса заказа (server-to-server от qr; шаг 2b запустит выдачу билетов).
+    // TODO(безопасность): аутентификация канала.
+    Route::post('/changeStatus/{id}', [QrOrderController::class, 'changeStatus']);
+
     // Чтение принятого заказа — только админ (содержит ПДн).
     Route::get('/getItem/{id}', [QrOrderController::class, 'getItem'])
         ->middleware('auth:api')

--- a/Backend/routes/qrOrder.php
+++ b/Backend/routes/qrOrder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\QrOrder\QrOrderController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('v1/qrOrder')->group(static function (): void {
+    // API №1 — приём заказа от витрины qr (server-to-server).
+    // TODO(безопасность): добавить аутентификацию канала (service-token/подпись).
+    Route::post('/create', [QrOrderController::class, 'create']);
+
+    // Чтение принятого заказа — только админ (содержит ПДн).
+    Route::get('/getItem/{id}', [QrOrderController::class, 'getItem'])
+        ->middleware('auth:api')
+        ->middleware('admin');
+});

--- a/Backend/src/History/Domain/ActorType.php
+++ b/Backend/src/History/Domain/ActorType.php
@@ -11,4 +11,6 @@ final class ActorType
     public const ARTISAN      = 'artisan';
     // Автоматическое одобрение заказа по заголовку AutoPayment на /api/v1/order/create
     public const AUTO_PAYMENT = 'auto_payment';
+    // Действия по заказам, пришедшим от витрины qr (S2S-канал, не человек)
+    public const QR           = 'qr';
 }

--- a/Backend/src/QrOrder/Application/Issuance/IssuanceStrategyInterface.php
+++ b/Backend/src/QrOrder/Application/Issuance/IssuanceStrategyInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance;
+
+use Tickets\QrOrder\Application\Step\PipelineStepInterface;
+
+/**
+ * Стратегия выдачи по типу заказа (type_order). Определяет НАБОР и ПОРЯДОК шагов pipeline.
+ *
+ * Новый тип заказа = новый класс-стратегия + одна строка в реестре (TicketsProvider),
+ * без правок оркестратора (Open-Closed Principle, Р. Мартин «Чистая архитектура»).
+ */
+interface IssuanceStrategyInterface
+{
+    /** Нормализованный ключ type_order, который обслуживает стратегия (см. TypeOrder). */
+    public function typeOrder(): string;
+
+    /**
+     * Классы шагов в порядке выполнения. Резолвятся из контейнера (DI), реализуют PipelineStepInterface.
+     *
+     * @return array<int, class-string<PipelineStepInterface>>
+     */
+    public function steps(): array;
+}

--- a/Backend/src/QrOrder/Application/Issuance/IssuanceStrategyRegistry.php
+++ b/Backend/src/QrOrder/Application/Issuance/IssuanceStrategyRegistry.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance;
+
+use LogicException;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Реестр стратегий выдачи: type_order → стратегия. Состав регистрируется в TicketsProvider.
+ *
+ * Неизвестный/пустой type_order → fallback на стратегию REGULAR (владелец — связующее звено,
+ * гарантирует корректность данных контракта).
+ */
+final class IssuanceStrategyRegistry
+{
+    /** @var array<string, IssuanceStrategyInterface> */
+    private array $map = [];
+
+    /**
+     * @param iterable<IssuanceStrategyInterface> $strategies
+     */
+    public function __construct(iterable $strategies)
+    {
+        foreach ($strategies as $strategy) {
+            $this->map[$strategy->typeOrder()] = $strategy;
+        }
+    }
+
+    public function resolve(?string $typeOrder): IssuanceStrategyInterface
+    {
+        $key = TypeOrder::normalize($typeOrder);
+
+        return $this->map[$key]
+            ?? $this->map[TypeOrder::REGULAR]
+            ?? throw new LogicException('Не зарегистрирована стратегия выдачи REGULAR');
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/IssueOrderJob.php
+++ b/Backend/src/QrOrder/Application/Issuance/IssueOrderJob.php
@@ -12,8 +12,12 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Shared\Domain\ValueObject\Uuid;
 use Throwable;
+use Tickets\History\Domain\ActorType;
+use Tickets\History\Dto\SaveHistoryDto;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
 use Tickets\QrOrder\Application\Step\PipelineStepInterface;
 use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Domain\QrOrderHistoryEvent;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
 /**
@@ -47,6 +51,7 @@ final class IssueOrderJob implements ShouldQueue
         QrOrderRepositoryInterface $repository,
         IssuanceStrategyRegistry $registry,
         Container $container,
+        HistoryRepositoryInterface $history,
     ): void {
         $log = PipelineLog::logger();
         $order = $repository->findById(new Uuid($this->orderId));
@@ -85,6 +90,13 @@ final class IssueOrderJob implements ShouldQueue
         }
 
         $log->info('pipeline.done', ['order_id' => $this->orderId]);
+
+        $history->save(new SaveHistoryDto(
+            $this->orderId,
+            new QrOrderHistoryEvent('issued', ['strategy' => $strategy->typeOrder()]),
+            null,
+            ActorType::QR,
+        ));
     }
 
     /**

--- a/Backend/src/QrOrder/Application/Issuance/IssueOrderJob.php
+++ b/Backend/src/QrOrder/Application/Issuance/IssueOrderJob.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\QrOrder\Application\Step\PipelineStepInterface;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
+
+/**
+ * Оркестратор выдачи билетов по qr-заказу (асинхронно, вне HTTP-запроса qr).
+ *
+ * Резолвит стратегию по type_order и выполняет её шаги последовательно, логируя каждый
+ * (start/ok/fail) в канал qr_pipeline. Данные между шагами идут через $carry. Шаги с
+ * зависимостью по данным (билеты → письмо) потому и выполняются по порядку.
+ *
+ * tries=1: при сбое не перезапускаем автоматически (иначе дубль билетов/писем). issued_at
+ * выставляется при dispatch (см. QrOrderApplication::changeStatus), повторного запуска нет.
+ * Полноценная идемпотентность per-step добавляется в фазе 5.
+ */
+final class IssueOrderJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    private string $orderId;
+
+    public function __construct(Uuid $orderId)
+    {
+        $this->orderId = $orderId->value();
+    }
+
+    public function handle(
+        QrOrderRepositoryInterface $repository,
+        IssuanceStrategyRegistry $registry,
+        Container $container,
+    ): void {
+        $log = PipelineLog::logger();
+        $order = $repository->findById(new Uuid($this->orderId));
+
+        if ($order === null) {
+            $log->error('pipeline.order_not_found', ['order_id' => $this->orderId]);
+
+            return;
+        }
+
+        $strategy = $registry->resolve($order->getTypeOrder());
+        $log->info('pipeline.start', [
+            'order_id' => $this->orderId,
+            'type_order' => $order->getTypeOrder(),
+            'strategy' => $strategy->typeOrder(),
+        ]);
+
+        $carry = [];
+        foreach ($strategy->steps() as $stepClass) {
+            /** @var PipelineStepInterface $step */
+            $step = $container->make($stepClass);
+
+            $log->info('step.start', ['order_id' => $this->orderId, 'step' => $step->name()]);
+            try {
+                $carry = $step->handle($order, $carry);
+                $log->info('step.ok', ['order_id' => $this->orderId, 'step' => $step->name()]);
+            } catch (Throwable $e) {
+                $log->error('step.fail', [
+                    'order_id' => $this->orderId,
+                    'step' => $step->name(),
+                    'error' => $e->getMessage(),
+                ]);
+
+                throw $e;
+            }
+        }
+
+        $log->info('pipeline.done', ['order_id' => $this->orderId]);
+    }
+
+    /**
+     * Вызывается очередью при окончательном сбое задачи (tries исчерпаны).
+     *
+     * Снимаем отметку issued_at, чтобы заказ можно было выдать повторно (qr пришлёт «оплачен»
+     * снова) — иначе заказ навсегда остался бы «выдан без билетов». Так восстанавливается
+     * семантика старого синхронного flow (issued_at — только при фактическом успехе).
+     */
+    public function failed(Throwable $e): void
+    {
+        PipelineLog::logger()->critical('pipeline.failed', [
+            'order_id' => $this->orderId,
+            'error' => $e->getMessage(),
+        ]);
+
+        app(QrOrderRepositoryInterface::class)->clearIssued(new Uuid($this->orderId));
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/FriendlyIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/FriendlyIssuanceStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance\Strategy;
+
+use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
+use Tickets\QrOrder\Application\Step\CreateTicketsStep;
+use Tickets\QrOrder\Application\Step\PushToBazaStep;
+use Tickets\QrOrder\Application\Step\SendOrderEmailStep;
+use Tickets\QrOrder\Application\Step\SendTelegramStep;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Friendly-заказ: набор шагов как у обычного (билеты + el_tickets + telegram), но письмо —
+ * friendly-вариант. Сам выбор Mailable (OrderToPaidFriendly) делает OrderEmailResolver по
+ * type_order внутри SendOrderEmailStep, поэтому список шагов совпадает с Regular (DRY).
+ */
+final class FriendlyIssuanceStrategy implements IssuanceStrategyInterface
+{
+    public function typeOrder(): string
+    {
+        return TypeOrder::FRIENDLY;
+    }
+
+    public function steps(): array
+    {
+        return [
+            CreateTicketsStep::class,
+            SendOrderEmailStep::class,
+            PushToBazaStep::class,
+            SendTelegramStep::class,
+        ];
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/ListIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/ListIssuanceStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance\Strategy;
+
+use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
+use Tickets\QrOrder\Application\Step\CreateTicketsStep;
+use Tickets\QrOrder\Application\Step\PushToBazaStep;
+use Tickets\QrOrder\Application\Step\SendListEmailStep;
+use Tickets\QrOrder\Application\Step\SendTelegramStep;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Заказ-список: билеты + PDF → письмо OrderListApproved (по локации) → запись в spisok_tickets
+ * (PushTicketToBazaJob маршрутизирует по isList) → telegram.
+ *
+ * CreateTicketsStep заполняет curator/location/project из контракта → TicketResponse::isList()=true.
+ * Цены у списка нет (price игнорируется).
+ */
+final class ListIssuanceStrategy implements IssuanceStrategyInterface
+{
+    public function typeOrder(): string
+    {
+        return TypeOrder::LIST;
+    }
+
+    public function steps(): array
+    {
+        return [
+            CreateTicketsStep::class,
+            SendListEmailStep::class,
+            PushToBazaStep::class,
+            SendTelegramStep::class,
+        ];
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/LiveIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/LiveIssuanceStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance\Strategy;
+
+use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
+use Tickets\QrOrder\Application\Step\CreateLiveTicketsStep;
+use Tickets\QrOrder\Application\Step\LinkLiveStep;
+use Tickets\QrOrder\Application\Step\SendLiveEmailStep;
+use Tickets\QrOrder\Application\Step\SendTelegramStep;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Живой заказ: билеты БЕЗ PDF → письмо о выдаче (без PDF) → связка с live_tickets по номеру
+ * (setInBazaLive) → telegram. В el_tickets живой билет не пишется.
+ *
+ * qr присылает номер живого билета (guests[].number); строка live_tickets с этим номером уже
+ * существует — задача LinkLiveTicketJob проставляет ей el_ticket_id.
+ */
+final class LiveIssuanceStrategy implements IssuanceStrategyInterface
+{
+    public function typeOrder(): string
+    {
+        return TypeOrder::LIVE;
+    }
+
+    public function steps(): array
+    {
+        return [
+            CreateLiveTicketsStep::class,
+            SendLiveEmailStep::class,
+            LinkLiveStep::class,
+            SendTelegramStep::class,
+        ];
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Issuance\Strategy;
+
+use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
+use Tickets\QrOrder\Application\Step\CreateTicketsStep;
+use Tickets\QrOrder\Application\Step\SendOrderEmailStep;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Обычный заказ: создать билеты + PDF/QR → одно письмо со всеми PDF.
+ *
+ * Фаза 2 добавит сюда PushToBazaStep (запись в Baza), фаза 3 — SendTelegramStep.
+ */
+final class RegularIssuanceStrategy implements IssuanceStrategyInterface
+{
+    public function typeOrder(): string
+    {
+        return TypeOrder::REGULAR;
+    }
+
+    public function steps(): array
+    {
+        return [
+            CreateTicketsStep::class,
+            SendOrderEmailStep::class,
+        ];
+    }
+}

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
@@ -6,13 +6,14 @@ namespace Tickets\QrOrder\Application\Issuance\Strategy;
 
 use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
 use Tickets\QrOrder\Application\Step\CreateTicketsStep;
+use Tickets\QrOrder\Application\Step\PushToBazaStep;
 use Tickets\QrOrder\Application\Step\SendOrderEmailStep;
 use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
 
 /**
- * Обычный заказ: создать билеты + PDF/QR → одно письмо со всеми PDF.
+ * Обычный заказ: создать билеты + PDF/QR → одно письмо со всеми PDF → запись в Baza (el_tickets).
  *
- * Фаза 2 добавит сюда PushToBazaStep (запись в Baza), фаза 3 — SendTelegramStep.
+ * Фаза 3 добавит сюда SendTelegramStep.
  */
 final class RegularIssuanceStrategy implements IssuanceStrategyInterface
 {
@@ -26,6 +27,7 @@ final class RegularIssuanceStrategy implements IssuanceStrategyInterface
         return [
             CreateTicketsStep::class,
             SendOrderEmailStep::class,
+            PushToBazaStep::class,
         ];
     }
 }

--- a/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
+++ b/Backend/src/QrOrder/Application/Issuance/Strategy/RegularIssuanceStrategy.php
@@ -8,12 +8,12 @@ use Tickets\QrOrder\Application\Issuance\IssuanceStrategyInterface;
 use Tickets\QrOrder\Application\Step\CreateTicketsStep;
 use Tickets\QrOrder\Application\Step\PushToBazaStep;
 use Tickets\QrOrder\Application\Step\SendOrderEmailStep;
+use Tickets\QrOrder\Application\Step\SendTelegramStep;
 use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
 
 /**
- * Обычный заказ: создать билеты + PDF/QR → одно письмо со всеми PDF → запись в Baza (el_tickets).
- *
- * Фаза 3 добавит сюда SendTelegramStep.
+ * Обычный заказ: создать билеты + PDF/QR → одно письмо со всеми PDF → запись в Baza (el_tickets)
+ * → уведомление гостей в Telegram.
  */
 final class RegularIssuanceStrategy implements IssuanceStrategyInterface
 {
@@ -28,6 +28,7 @@ final class RegularIssuanceStrategy implements IssuanceStrategyInterface
             CreateTicketsStep::class,
             SendOrderEmailStep::class,
             PushToBazaStep::class,
+            SendTelegramStep::class,
         ];
     }
 }

--- a/Backend/src/QrOrder/Application/Job/LinkLiveTicketJob.php
+++ b/Backend/src/QrOrder/Application/Job/LinkLiveTicketJob.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Job;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Shared\Domain\ValueObject\Uuid;
+use Throwable;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Связывает созданный el_ticket с существующей строкой live_tickets по номеру (setInBazaLive).
+ *
+ * Изолированно от основного pipeline (свои ретраи): setInBazaLive кидает, если строки live_tickets
+ * с таким номером ещё нет — задача ретраится (строка может появиться). Идемпотентно: повторная
+ * привязка того же el_ticket_id к тому же номеру ничего не ломает.
+ */
+final class LinkLiveTicketJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 30;
+
+    public function __construct(
+        private string $ticketId,
+        private int $number,
+    ) {
+    }
+
+    public function handle(TicketsRepositoryInterface $ticketsRepository): void
+    {
+        $log = PipelineLog::logger();
+
+        try {
+            $ticketsRepository->setInBazaLive($this->number, new Uuid($this->ticketId));
+
+            $log->info('link_live.ok', ['ticket_id' => $this->ticketId, 'number' => $this->number]);
+        } catch (Throwable $e) {
+            $log->error('link_live.fail', [
+                'ticket_id' => $this->ticketId,
+                'number' => $this->number,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+}

--- a/Backend/src/QrOrder/Application/Job/PushTicketToBazaJob.php
+++ b/Backend/src/QrOrder/Application/Job/PushTicketToBazaJob.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Job;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use RuntimeException;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Запись одного билета qr-заказа в Baza (таблица el_tickets) — изолированно от основного pipeline.
+ *
+ * Зачем отдельная задача: сбой шины Baza не должен отменять уже созданный билет/письмо и не
+ * должен приводить к повторной выдаче (дублям). setInBaza идемпотентен (upsert по uuid), поэтому
+ * у задачи свои ретраи (tries=3) — Baza доедет, когда поднимется, без участия основного flow.
+ */
+final class PushTicketToBazaJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 30;
+
+    public function __construct(
+        private TicketResponse $ticket,
+    ) {
+    }
+
+    public function handle(TicketsRepositoryInterface $ticketsRepository): void
+    {
+        $log = PipelineLog::logger();
+
+        // setInBaza уже логирует причину сбоя и возвращает false. Бросаем для ретрая —
+        // upsert по uuid гарантирует, что повтор не создаст дубль.
+        if (! $ticketsRepository->setInBaza($this->ticket)) {
+            $log->error('push_baza.fail', ['ticket_id' => $this->ticket->getId()->value()]);
+
+            throw new RuntimeException('Не удалось записать билет в Baza: ' . $this->ticket->getId()->value());
+        }
+
+        $log->info('push_baza.ok', [
+            'ticket_id' => $this->ticket->getId()->value(),
+            'kilter' => $this->ticket->getKilter(),
+        ]);
+    }
+}

--- a/Backend/src/QrOrder/Application/Job/PushTicketToBazaJob.php
+++ b/Backend/src/QrOrder/Application/Job/PushTicketToBazaJob.php
@@ -40,11 +40,16 @@ final class PushTicketToBazaJob implements ShouldQueue
     public function handle(TicketsRepositoryInterface $ticketsRepository): void
     {
         $log = PipelineLog::logger();
+        $isList = $this->ticket->isList();
 
-        // setInBaza уже логирует причину сбоя и возвращает false. Бросаем для ретрая —
-        // upsert по uuid гарантирует, что повтор не создаст дубль.
-        if (! $ticketsRepository->setInBaza($this->ticket)) {
-            $log->error('push_baza.fail', ['ticket_id' => $this->ticket->getId()->value()]);
+        // Маршрутизация как в классике (PushTicketsCommandHandler): списочный билет → spisok_tickets,
+        // обычный → el_tickets. Оба идемпотентны (upsert по uuid/ticket_uuid). На false — ретрай.
+        $ok = $isList
+            ? $ticketsRepository->setInBazaList($this->ticket)
+            : $ticketsRepository->setInBaza($this->ticket);
+
+        if (! $ok) {
+            $log->error('push_baza.fail', ['ticket_id' => $this->ticket->getId()->value(), 'list' => $isList]);
 
             throw new RuntimeException('Не удалось записать билет в Baza: ' . $this->ticket->getId()->value());
         }
@@ -52,6 +57,7 @@ final class PushTicketToBazaJob implements ShouldQueue
         $log->info('push_baza.ok', [
             'ticket_id' => $this->ticket->getId()->value(),
             'kilter' => $this->ticket->getKilter(),
+            'list' => $isList,
         ]);
     }
 }

--- a/Backend/src/QrOrder/Application/QrOrderApplication.php
+++ b/Backend/src/QrOrder/Application/QrOrderApplication.php
@@ -4,18 +4,23 @@ declare(strict_types=1);
 
 namespace Tickets\QrOrder\Application;
 
+use Carbon\Carbon;
 use Shared\Domain\ValueObject\Uuid;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
 /**
- * Приём заказов от витрины qr (API №1) + чтение принятого заказа.
+ * Приём заказов от витрины qr (API №1) + смена статуса с выдачей билетов (API №2).
  * Тонкий слой над репозиторием (БД — только в репозитории, правило №1).
  */
 final class QrOrderApplication
 {
+    /** Статусы контракта qr, означающие «оплачено» → запускают выдачу билетов. */
+    private const PAID_STATUSES = ['оплачен', 'paid'];
+
     public function __construct(
         private readonly QrOrderRepositoryInterface $repository,
+        private readonly QrOrderIssuer $issuer,
     ) {
     }
 
@@ -38,17 +43,31 @@ final class QrOrderApplication
     }
 
     /**
-     * Сменить статус принятого заказа (API №2, шаг 2a).
-     * Возвращает false, если заказа с таким id нет.
+     * Сменить статус принятого заказа (API №2). Возвращает false, если заказа нет.
      *
-     * TODO(2b): при переходе в «оплачен»/выдать — запустить выдачу билетов (PDF/письма).
+     * При переходе в «оплачен» запускается выдача билетов (PDF/письма) — один раз
+     * (защита по issued_at: повторный «оплачен» не выдаёт билеты снова).
      */
     public function changeStatus(Uuid $id, string $status): bool
     {
-        if (! $this->repository->existsById($id)) {
+        $order = $this->repository->findById($id);
+        if ($order === null) {
             return false;
         }
 
-        return $this->repository->changeStatus($id, $status);
+        $this->repository->changeStatus($id, $status);
+
+        if ($this->isPaid($status) && $order->getIssuedAt() === null) {
+            // Перечитываем заказ с новым статусом для выдачи.
+            $this->issuer->issue($this->repository->findById($id) ?? $order);
+            $this->repository->markIssued($id, Carbon::now());
+        }
+
+        return true;
+    }
+
+    private function isPaid(string $status): bool
+    {
+        return in_array(mb_strtolower(trim($status)), self::PAID_STATUSES, true);
     }
 }

--- a/Backend/src/QrOrder/Application/QrOrderApplication.php
+++ b/Backend/src/QrOrder/Application/QrOrderApplication.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application;
+
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Dto\QrOrderDto;
+use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
+
+/**
+ * Приём заказов от витрины qr (API №1) + чтение принятого заказа.
+ * Тонкий слой над репозиторием (БД — только в репозитории, правило №1).
+ */
+final class QrOrderApplication
+{
+    public function __construct(
+        private readonly QrOrderRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * Принять заказ. Идемпотентно: повторный приём заказа с тем же id (== id заказа qr/org)
+     * не создаёт дубль — возвращает true без повторной записи.
+     */
+    public function create(QrOrderDto $dto): bool
+    {
+        if ($this->repository->existsById($dto->getId())) {
+            return true;
+        }
+
+        return $this->repository->create($dto);
+    }
+
+    public function getItem(Uuid $id): ?QrOrderDto
+    {
+        return $this->repository->findById($id);
+    }
+}

--- a/Backend/src/QrOrder/Application/QrOrderApplication.php
+++ b/Backend/src/QrOrder/Application/QrOrderApplication.php
@@ -6,7 +6,11 @@ namespace Tickets\QrOrder\Application;
 
 use Carbon\Carbon;
 use Shared\Domain\ValueObject\Uuid;
+use Tickets\History\Domain\ActorType;
+use Tickets\History\Dto\SaveHistoryDto;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
 use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
+use Tickets\QrOrder\Domain\QrOrderHistoryEvent;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
@@ -21,6 +25,7 @@ final class QrOrderApplication
 
     public function __construct(
         private readonly QrOrderRepositoryInterface $repository,
+        private readonly HistoryRepositoryInterface $history,
     ) {
     }
 
@@ -34,7 +39,21 @@ final class QrOrderApplication
             return true;
         }
 
-        return $this->repository->create($dto);
+        $created = $this->repository->create($dto);
+
+        if ($created) {
+            $this->history->save(new SaveHistoryDto(
+                $dto->getId()->value(),
+                new QrOrderHistoryEvent('created', [
+                    'status' => $dto->getStatus(),
+                    'type_order' => $dto->getTypeOrder(),
+                ]),
+                null,
+                ActorType::QR,
+            ));
+        }
+
+        return $created;
     }
 
     public function getItem(Uuid $id): ?QrOrderDto
@@ -56,6 +75,16 @@ final class QrOrderApplication
         }
 
         $this->repository->changeStatus($id, $status);
+
+        $this->history->save(new SaveHistoryDto(
+            $id->value(),
+            new QrOrderHistoryEvent('status_changed', [
+                'from' => $order->getStatus(),
+                'to' => $status,
+            ]),
+            null,
+            ActorType::QR,
+        ));
 
         if ($this->isPaid($status) && $order->getIssuedAt() === null) {
             // Помечаем выданным ДО постановки задачи — защита от повторного запуска при

--- a/Backend/src/QrOrder/Application/QrOrderApplication.php
+++ b/Backend/src/QrOrder/Application/QrOrderApplication.php
@@ -36,4 +36,19 @@ final class QrOrderApplication
     {
         return $this->repository->findById($id);
     }
+
+    /**
+     * Сменить статус принятого заказа (API №2, шаг 2a).
+     * Возвращает false, если заказа с таким id нет.
+     *
+     * TODO(2b): при переходе в «оплачен»/выдать — запустить выдачу билетов (PDF/письма).
+     */
+    public function changeStatus(Uuid $id, string $status): bool
+    {
+        if (! $this->repository->existsById($id)) {
+            return false;
+        }
+
+        return $this->repository->changeStatus($id, $status);
+    }
 }

--- a/Backend/src/QrOrder/Application/QrOrderApplication.php
+++ b/Backend/src/QrOrder/Application/QrOrderApplication.php
@@ -6,6 +6,7 @@ namespace Tickets\QrOrder\Application;
 
 use Carbon\Carbon;
 use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 
@@ -20,7 +21,6 @@ final class QrOrderApplication
 
     public function __construct(
         private readonly QrOrderRepositoryInterface $repository,
-        private readonly QrOrderIssuer $issuer,
     ) {
     }
 
@@ -58,9 +58,10 @@ final class QrOrderApplication
         $this->repository->changeStatus($id, $status);
 
         if ($this->isPaid($status) && $order->getIssuedAt() === null) {
-            // Перечитываем заказ с новым статусом для выдачи.
-            $this->issuer->issue($this->repository->findById($id) ?? $order);
+            // Помечаем выданным ДО постановки задачи — защита от повторного запуска при
+            // повторном «оплачен» (qr-ретраи). Сама выдача — асинхронно, вне HTTP-запроса qr.
             $this->repository->markIssued($id, Carbon::now());
+            IssueOrderJob::dispatch($id);
         }
 
         return true;

--- a/Backend/src/QrOrder/Application/QrOrderIssuer.php
+++ b/Backend/src/QrOrder/Application/QrOrderIssuer.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application;
+
+use App\Mail\OrderToPaid;
+use Carbon\Carbon;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\Mail;
+use Psr\Log\LoggerInterface;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Dto\QrOrderDto;
+use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
+use Tickets\Ticket\CreateTickets\Dto\TicketDto;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Автономная выдача билетов по qr-заказу (API №2b, решение B — без order_tickets).
+ *
+ * На каждого гостя: вставляем билет в tickets (order_ticket_id == id qr-заказа), читаем kilter,
+ * собираем TicketResponse ВРУЧНУЮ (шаблоны PDF/email — из ticket_type_festival по
+ * festival_id + type_ticket гостя, минуя getTicket с JOIN на order_tickets), генерируем PDF/QR
+ * (ProcessCreatingQRCode) и шлём письмо с билетами (OrderToPaid). См. CONTRACT_RFC §6/§7.
+ */
+final class QrOrderIssuer
+{
+    public function __construct(
+        private readonly TicketsRepositoryInterface $ticketsRepository,
+        private readonly QrIssuanceRepositoryInterface $issuanceRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function issue(QrOrderDto $order): void
+    {
+        $festivalId = $order->getFestivalId();
+        if ($festivalId === null) {
+            throw new InvalidArgumentException('Выдача невозможна: у заказа нет festival_id');
+        }
+
+        $payload = $order->getPayload();
+        $guests = is_array($payload['guests'] ?? null) ? $payload['guests'] : [];
+        $comment = $payload['order_data']['comment'] ?? null;
+
+        /** @var TicketResponse[] $responses */
+        $responses = [];
+        $firstTicketTypeId = null;
+
+        foreach ($guests as $guest) {
+            if (! is_array($guest)) {
+                continue;
+            }
+            $ticketTypeId = $this->guestTicketTypeId($guest);
+            $firstTicketTypeId ??= $ticketTypeId;
+
+            $ticketId = Uuid::random();
+            $email = (string) ($guest['email'] ?? $order->getEmail());
+
+            // 1. Создаём строку билета (kilter — auto-increment в БД).
+            $this->ticketsRepository->createTickets(new TicketDto(
+                $order->getId(),
+                (string) ($guest['name'] ?? ''),
+                $festivalId,
+                $ticketId,
+                email: $email,
+            ));
+
+            // 2. Читаем kilter + шаблоны под тип билета гостя.
+            $kilter = $this->issuanceRepository->getKilter($ticketId) ?? 0;
+            $template = $ticketTypeId !== null
+                ? $this->issuanceRepository->findTemplate($festivalId, $ticketTypeId)
+                : null;
+
+            // 3. Собираем TicketResponse вручную (без getTicket → без зависимости от order_tickets).
+            $response = new TicketResponse(
+                name: (string) ($guest['name'] ?? ''),
+                kilter: $kilter,
+                uuid: $ticketId,
+                status: 'paid',
+                email: $email,
+                phone: (string) ($order->getPhone() ?? ''),
+                city: (string) ($order->getCity() ?? ''),
+                comment: $comment,
+                date_order: Carbon::now(),
+                festivalView: $template['pdf'] ?? 'pdf',
+                emailView: $template['email'] ?? null,
+                festival_id: $festivalId,
+                type_ticket_id: $ticketTypeId,
+                type_ticket: isset($guest['type_ticket']['title']) ? (string) $guest['type_ticket']['title'] : null,
+                order_id: $order->getId(),
+            );
+
+            // 4. Сохраняем PDF/QR (для скачивания) — очередь.
+            ProcessCreatingQRCode::dispatch($response);
+
+            $responses[] = $response;
+        }
+
+        if ($responses === []) {
+            $this->logger->warning('[qr-issue] Нет гостей для выдачи', ['order_id' => $order->getId()->value()]);
+
+            return;
+        }
+
+        // 5. Письмо получателю с PDF-билетами (PDF рендерится в самом письме).
+        Mail::to($order->getEmail())->send(new OrderToPaid(
+            $responses,
+            $firstTicketTypeId ?? Uuid::random(),
+            $comment,
+            null,
+        ));
+
+        $this->logger->info('[qr-issue] Билеты выданы', [
+            'order_id' => $order->getId()->value(),
+            'tickets' => count($responses),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $guest
+     */
+    private function guestTicketTypeId(array $guest): ?Uuid
+    {
+        $id = $guest['type_ticket']['id'] ?? null;
+
+        return is_string($id) && $id !== '' ? new Uuid($id) : null;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/CreateLiveTicketsStep.php
+++ b/Backend/src/QrOrder/Application/Step/CreateLiveTicketsStep.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use Carbon\Carbon;
+use InvalidArgumentException;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Dto\TicketDto;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Шаг создания билетов живого заказа: на каждого гостя создаёт el_ticket в tickets БЕЗ PDF
+ * (festivalView=null → письмо PDF не прикрепит; ProcessCreatingQRCode НЕ ставим). Номер живого
+ * билета берётся из guests[].number и кладётся в carry['liveLinks'] для шага связки с live_tickets.
+ *
+ * В отличие от обычного билета, в el_tickets живой билет не пишется — он связывается с уже
+ * существующей строкой live_tickets по номеру (см. LinkLiveStep / setInBazaLive).
+ */
+final class CreateLiveTicketsStep implements PipelineStepInterface
+{
+    public function __construct(
+        private readonly TicketsRepositoryInterface $ticketsRepository,
+        private readonly QrIssuanceRepositoryInterface $issuanceRepository,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'create_live_tickets';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        $festivalId = $order->getFestivalId();
+        if ($festivalId === null) {
+            throw new InvalidArgumentException('Выдача live невозможна: у заказа нет festival_id');
+        }
+
+        $payload = $order->getPayload();
+        $guests = is_array($payload['guests'] ?? null) ? $payload['guests'] : [];
+        $comment = $payload['order_data']['comment'] ?? null;
+
+        /** @var TicketResponse[] $responses */
+        $responses = [];
+        $liveLinks = [];
+        $firstTicketTypeId = null;
+        $log = PipelineLog::logger();
+
+        foreach ($guests as $index => $guest) {
+            if (! is_array($guest)) {
+                continue;
+            }
+
+            $ticketTypeId = $this->guestTicketTypeId($guest);
+            $firstTicketTypeId ??= $ticketTypeId;
+            $number = isset($guest['number']) ? (int) $guest['number'] : null;
+
+            $ticketId = Uuid::random();
+            $email = (string) ($guest['email'] ?? $order->getEmail());
+
+            $this->ticketsRepository->createTickets(new TicketDto(
+                $order->getId(),
+                (string) ($guest['name'] ?? ''),
+                $festivalId,
+                $ticketId,
+                email: $email,
+            ));
+
+            $kilter = $this->issuanceRepository->getKilter($ticketId) ?? 0;
+
+            // Живой билет — без PDF: festivalView=null (письмо не прикрепит PDF), QR не генерим.
+            $responses[] = new TicketResponse(
+                name: (string) ($guest['name'] ?? ''),
+                kilter: $kilter,
+                uuid: $ticketId,
+                status: 'paid',
+                email: $email,
+                phone: (string) ($order->getPhone() ?? ''),
+                city: (string) ($order->getCity() ?? ''),
+                comment: $comment,
+                date_order: Carbon::now(),
+                festivalView: null,
+                emailView: null,
+                festival_id: $festivalId,
+                type_ticket_id: $ticketTypeId,
+                type_ticket: isset($guest['type_ticket']['title']) ? (string) $guest['type_ticket']['title'] : null,
+                order_id: $order->getId(),
+            );
+
+            if ($number !== null) {
+                $liveLinks[] = ['ticket_id' => $ticketId->value(), 'number' => $number];
+            } else {
+                // Мягко: нет номера — нечего связывать с live_tickets (владелец гарантирует данные).
+                $log->warning('create_live_tickets.no_number', [
+                    'order_id' => $order->getId()->value(),
+                    'guest_index' => $index,
+                ]);
+            }
+
+            $log->info('create_live_tickets.guest_ok', [
+                'order_id' => $order->getId()->value(),
+                'guest_index' => $index,
+                'number' => $number,
+                'email' => PipelineLog::maskEmail($email),
+            ]);
+        }
+
+        if ($responses === []) {
+            $log->warning('create_live_tickets.no_guests', ['order_id' => $order->getId()->value()]);
+        }
+
+        $carry['responses'] = $responses;
+        $carry['liveLinks'] = $liveLinks;
+        $carry['firstTicketTypeId'] = $firstTicketTypeId;
+        $carry['comment'] = $comment;
+
+        return $carry;
+    }
+
+    /**
+     * @param array<string, mixed> $guest
+     */
+    private function guestTicketTypeId(array $guest): ?Uuid
+    {
+        $id = $guest['type_ticket']['id'] ?? null;
+
+        return is_string($id) && $id !== '' ? new Uuid($id) : null;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/CreateLiveTicketsStep.php
+++ b/Backend/src/QrOrder/Application/Step/CreateLiveTicketsStep.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use InvalidArgumentException;
 use Shared\Domain\ValueObject\Uuid;
 use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Application\Support\QrTicketId;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
 use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
@@ -61,18 +62,22 @@ final class CreateLiveTicketsStep implements PipelineStepInterface
             $firstTicketTypeId ??= $ticketTypeId;
             $number = isset($guest['number']) ? (int) $guest['number'] : null;
 
-            $ticketId = Uuid::random();
+            // Детерминированный id → идемпотентность: повтор выдачи не создаст дубль билета.
+            $ticketId = QrTicketId::forGuest($order->getId(), $index);
             $email = (string) ($guest['email'] ?? $order->getEmail());
 
-            $this->ticketsRepository->createTickets(new TicketDto(
-                $order->getId(),
-                (string) ($guest['name'] ?? ''),
-                $festivalId,
-                $ticketId,
-                email: $email,
-            ));
+            $existingKilter = $this->issuanceRepository->getKilter($ticketId);
+            if ($existingKilter === null) {
+                $this->ticketsRepository->createTickets(new TicketDto(
+                    $order->getId(),
+                    (string) ($guest['name'] ?? ''),
+                    $festivalId,
+                    $ticketId,
+                    email: $email,
+                ));
+            }
 
-            $kilter = $this->issuanceRepository->getKilter($ticketId) ?? 0;
+            $kilter = $existingKilter ?? $this->issuanceRepository->getKilter($ticketId) ?? 0;
 
             // Живой билет — без PDF: festivalView=null (письмо не прикрепит PDF), QR не генерим.
             $responses[] = new TicketResponse(

--- a/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
+++ b/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
@@ -46,8 +46,19 @@ final class CreateTicketsStep implements PipelineStepInterface
         }
 
         $payload = $order->getPayload();
+        $orderData = is_array($payload['order_data'] ?? null) ? $payload['order_data'] : [];
         $guests = is_array($payload['guests'] ?? null) ? $payload['guests'] : [];
-        $comment = $payload['order_data']['comment'] ?? null;
+        $comment = $orderData['comment'] ?? null;
+
+        // Поля заказа-списка. Для regular/friendly отсутствуют → null → TicketResponse::isList()
+        // вернёт false → билет уйдёт в el_tickets. Для list — заполнены → spisok_tickets.
+        $curator = is_array($orderData['curator'] ?? null) ? $orderData['curator'] : [];
+        $location = is_array($orderData['location'] ?? null) ? $orderData['location'] : [];
+        $curatorId = empty($curator['id']) ? null : new Uuid((string) $curator['id']);
+        $curatorEmail = isset($curator['email']) ? (string) $curator['email'] : null;
+        $curatorName = isset($curator['name']) ? (string) $curator['name'] : null;
+        $project = isset($orderData['project']) ? (string) $orderData['project'] : null;
+        $locationId = empty($location['id']) ? null : new Uuid((string) $location['id']);
 
         /** @var TicketResponse[] $responses */
         $responses = [];
@@ -97,6 +108,11 @@ final class CreateTicketsStep implements PipelineStepInterface
                 type_ticket_id: $ticketTypeId,
                 type_ticket: isset($guest['type_ticket']['title']) ? (string) $guest['type_ticket']['title'] : null,
                 order_id: $order->getId(),
+                curator_id: $curatorId,
+                curator_email: $curatorEmail,
+                curator_name: $curatorName,
+                project: $project,
+                location_id: $locationId,
             );
 
             // 4. Сохраняем PDF/QR (для скачивания) — очередь.

--- a/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
+++ b/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use InvalidArgumentException;
 use Shared\Domain\ValueObject\Uuid;
 use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Application\Support\QrTicketId;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
 use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
@@ -73,20 +74,25 @@ final class CreateTicketsStep implements PipelineStepInterface
             $ticketTypeId = $this->guestTicketTypeId($guest);
             $firstTicketTypeId ??= $ticketTypeId;
 
-            $ticketId = Uuid::random();
+            // Детерминированный id → идемпотентность: повтор выдачи не создаст дубль билета.
+            $ticketId = QrTicketId::forGuest($order->getId(), $index);
             $email = (string) ($guest['email'] ?? $order->getEmail());
 
-            // 1. Создаём строку билета (kilter — auto-increment в БД).
-            $this->ticketsRepository->createTickets(new TicketDto(
-                $order->getId(),
-                (string) ($guest['name'] ?? ''),
-                $festivalId,
-                $ticketId,
-                email: $email,
-            ));
+            // 1. Создаём строку билета, только если её ещё нет (kilter — auto-increment в БД).
+            $existingKilter = $this->issuanceRepository->getKilter($ticketId);
+            $isNew = $existingKilter === null;
+            if ($isNew) {
+                $this->ticketsRepository->createTickets(new TicketDto(
+                    $order->getId(),
+                    (string) ($guest['name'] ?? ''),
+                    $festivalId,
+                    $ticketId,
+                    email: $email,
+                ));
+            }
 
             // 2. Читаем kilter + шаблоны под тип билета гостя.
-            $kilter = $this->issuanceRepository->getKilter($ticketId) ?? 0;
+            $kilter = $existingKilter ?? $this->issuanceRepository->getKilter($ticketId) ?? 0;
             $template = $ticketTypeId !== null
                 ? $this->issuanceRepository->findTemplate($festivalId, $ticketTypeId)
                 : null;
@@ -115,12 +121,14 @@ final class CreateTicketsStep implements PipelineStepInterface
                 location_id: $locationId,
             );
 
-            // 4. Сохраняем PDF/QR (для скачивания) — очередь.
-            ProcessCreatingQRCode::dispatch($response);
+            // 4. PDF/QR — только для новых билетов (повторная выдача не перегенерирует).
+            if ($isNew) {
+                ProcessCreatingQRCode::dispatch($response);
+            }
 
             $responses[] = $response;
 
-            $log->info('create_tickets.guest_ok', [
+            $log->info($isNew ? 'create_tickets.guest_ok' : 'create_tickets.guest_reused', [
                 'order_id' => $order->getId()->value(),
                 'guest_index' => $index,
                 'kilter' => $kilter,

--- a/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
+++ b/Backend/src/QrOrder/Application/Step/CreateTicketsStep.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tickets\QrOrder\Application;
+namespace Tickets\QrOrder\Application\Step;
 
-use App\Mail\OrderToPaid;
 use Carbon\Carbon;
 use InvalidArgumentException;
-use Illuminate\Support\Facades\Mail;
-use Psr\Log\LoggerInterface;
 use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\PipelineLog;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\QrOrder\Repositories\QrIssuanceRepositoryInterface;
 use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
@@ -18,23 +16,29 @@ use Tickets\Ticket\CreateTickets\Dto\TicketDto;
 use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
 
 /**
- * Автономная выдача билетов по qr-заказу (API №2b, решение B — без order_tickets).
+ * Шаг 1: на каждого гостя создаёт билет в tickets (order_ticket_id == id qr-заказа),
+ * читает kilter, собирает TicketResponse (шаблоны из ticket_type_festival по festival + type
+ * билета гостя, минуя getTicket с JOIN на order_tickets) и ставит PDF/QR в очередь
+ * (ProcessCreatingQRCode). Собранные TicketResponse кладутся в carry['responses'] для шага письма.
  *
- * На каждого гостя: вставляем билет в tickets (order_ticket_id == id qr-заказа), читаем kilter,
- * собираем TicketResponse ВРУЧНУЮ (шаблоны PDF/email — из ticket_type_festival по
- * festival_id + type_ticket гостя, минуя getTicket с JOIN на order_tickets), генерируем PDF/QR
- * (ProcessCreatingQRCode) и шлём письмо с билетами (OrderToPaid). См. CONTRACT_RFC §6/§7.
+ * Поведение «всё или ничего» (как в старом синхронном flow): любая ошибка пробрасывается →
+ * оркестратор валит задачу → IssueOrderJob::failed() снимет issued_at, заказ можно выдать повторно.
+ * (Per-guest изоляция вернётся позже — с per-guest шагами и отслеживанием частичного состояния.)
  */
-final class QrOrderIssuer
+final class CreateTicketsStep implements PipelineStepInterface
 {
     public function __construct(
         private readonly TicketsRepositoryInterface $ticketsRepository,
         private readonly QrIssuanceRepositoryInterface $issuanceRepository,
-        private readonly LoggerInterface $logger,
     ) {
     }
 
-    public function issue(QrOrderDto $order): void
+    public function name(): string
+    {
+        return 'create_tickets';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
     {
         $festivalId = $order->getFestivalId();
         if ($festivalId === null) {
@@ -48,11 +52,13 @@ final class QrOrderIssuer
         /** @var TicketResponse[] $responses */
         $responses = [];
         $firstTicketTypeId = null;
+        $log = PipelineLog::logger();
 
-        foreach ($guests as $guest) {
+        foreach ($guests as $index => $guest) {
             if (! is_array($guest)) {
                 continue;
             }
+
             $ticketTypeId = $this->guestTicketTypeId($guest);
             $firstTicketTypeId ??= $ticketTypeId;
 
@@ -97,26 +103,24 @@ final class QrOrderIssuer
             ProcessCreatingQRCode::dispatch($response);
 
             $responses[] = $response;
+
+            $log->info('create_tickets.guest_ok', [
+                'order_id' => $order->getId()->value(),
+                'guest_index' => $index,
+                'kilter' => $kilter,
+                'email' => PipelineLog::maskEmail($email),
+            ]);
         }
 
         if ($responses === []) {
-            $this->logger->warning('[qr-issue] Нет гостей для выдачи', ['order_id' => $order->getId()->value()]);
-
-            return;
+            $log->warning('create_tickets.no_guests', ['order_id' => $order->getId()->value()]);
         }
 
-        // 5. Письмо получателю с PDF-билетами (PDF рендерится в самом письме).
-        Mail::to($order->getEmail())->send(new OrderToPaid(
-            $responses,
-            $firstTicketTypeId ?? Uuid::random(),
-            $comment,
-            null,
-        ));
+        $carry['responses'] = $responses;
+        $carry['firstTicketTypeId'] = $firstTicketTypeId;
+        $carry['comment'] = $comment;
 
-        $this->logger->info('[qr-issue] Билеты выданы', [
-            'order_id' => $order->getId()->value(),
-            'tickets' => count($responses),
-        ]);
+        return $carry;
     }
 
     /**

--- a/Backend/src/QrOrder/Application/Step/LinkLiveStep.php
+++ b/Backend/src/QrOrder/Application/Step/LinkLiveStep.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use Tickets\QrOrder\Application\Job\LinkLiveTicketJob;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Шаг связки живых билетов с live_tickets: на каждую пару (ticket_id, number) из carry['liveLinks']
+ * ставит изолированную задачу LinkLiveTicketJob (свои ретраи). Сам шаг не падает — только ставит задачи.
+ */
+final class LinkLiveStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'link_live';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        /** @var array<int, array{ticket_id: string, number: int}> $links */
+        $links = $carry['liveLinks'] ?? [];
+        $log = PipelineLog::logger();
+        $queued = 0;
+
+        foreach ($links as $link) {
+            LinkLiveTicketJob::dispatch($link['ticket_id'], $link['number']);
+            $queued++;
+        }
+
+        $log->info('link_live.queued', [
+            'order_id' => $order->getId()->value(),
+            'count' => $queued,
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/PipelineStepInterface.php
+++ b/Backend/src/QrOrder/Application/Step/PipelineStepInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Один шаг pipeline выдачи билета. Шаги выполняются последовательно оркестратором
+ * (IssueOrderJob); данные между шагами передаются через $carry (ассоц. массив). Каждый шаг —
+ * одна зона ответственности (SRP), логируется оркестратором по имени name().
+ */
+interface PipelineStepInterface
+{
+    /** Короткое имя шага для логов (например, "create_tickets"). */
+    public function name(): string;
+
+    /**
+     * @param array<string, mixed> $carry данные предыдущих шагов
+     * @return array<string, mixed> обновлённый carry
+     */
+    public function handle(QrOrderDto $order, array $carry): array;
+}

--- a/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
+++ b/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
@@ -31,7 +31,9 @@ final class PushToBazaStep implements PipelineStepInterface
         $queued = 0;
 
         foreach ($responses as $response) {
-            if ($response->getTypeTicketId() === null) {
+            // el_tickets-билету нужен type_ticket_id (как в классике). Списочный билет (isList)
+            // пишется в spisok_tickets и в типе билета не нуждается.
+            if (! $response->isList() && $response->getTypeTicketId() === null) {
                 $log->warning('push_to_baza.skip_no_type', [
                     'order_id' => $order->getId()->value(),
                     'ticket_id' => $response->getId()->value(),

--- a/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
+++ b/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use Tickets\QrOrder\Application\Job\PushTicketToBazaJob;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+
+/**
+ * Шаг 3: запись билетов заказа в Baza (el_tickets). На каждый билет ставит ИЗОЛИРОВАННУЮ
+ * задачу PushTicketToBazaJob (свои ретраи, идемпотентно) — сбой Baza не валит выдачу/письмо.
+ *
+ * Билеты без type_ticket_id в Baza не пишутся (нечего записать) — как в классическом флоу
+ * (PushTicketsCommandHandler пропускает такие). Шаг сам никогда не бросает: только ставит задачи.
+ */
+final class PushToBazaStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'push_to_baza';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        /** @var TicketResponse[] $responses */
+        $responses = $carry['responses'] ?? [];
+        $log = PipelineLog::logger();
+        $queued = 0;
+
+        foreach ($responses as $response) {
+            if ($response->getTypeTicketId() === null) {
+                $log->warning('push_to_baza.skip_no_type', [
+                    'order_id' => $order->getId()->value(),
+                    'ticket_id' => $response->getId()->value(),
+                ]);
+
+                continue;
+            }
+
+            PushTicketToBazaJob::dispatch($response);
+            $queued++;
+        }
+
+        $log->info('push_to_baza.queued', [
+            'order_id' => $order->getId()->value(),
+            'count' => $queued,
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/SendListEmailStep.php
+++ b/Backend/src/QrOrder/Application/Step/SendListEmailStep.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use App\Mail\OrderListApproved;
+use Illuminate\Support\Facades\Mail;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Шаг письма для заказа-списка: одно письмо получателю (order.email) со всеми PDF-билетами —
+ * Mailable OrderListApproved (берёт blade-шаблон письма из Location.email_template).
+ *
+ * Требует festival_id (обязателен) + location_id (из order_data.location.id). PDF рендерится
+ * внутри письма из TicketResponse, поэтому шаг не зависит от завершения ProcessCreatingQRCode.
+ */
+final class SendListEmailStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'send_list_email';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        $responses = $carry['responses'] ?? [];
+        $log = PipelineLog::logger();
+
+        if ($responses === []) {
+            $log->warning('send_list_email.skipped_no_tickets', ['order_id' => $order->getId()->value()]);
+
+            return $carry;
+        }
+
+        $festivalId = $order->getFestivalId();
+        if ($festivalId === null) {
+            $log->error('send_list_email.no_festival', ['order_id' => $order->getId()->value()]);
+
+            return $carry;
+        }
+
+        $location = is_array($order->getPayload()['order_data']['location'] ?? null)
+            ? $order->getPayload()['order_data']['location']
+            : [];
+        $locationId = empty($location['id']) ? null : new Uuid((string) $location['id']);
+
+        Mail::to($order->getEmail())->send(new OrderListApproved($responses, $festivalId, $locationId));
+
+        $log->info('send_list_email.sent', [
+            'order_id' => $order->getId()->value(),
+            'to' => PipelineLog::maskEmail($order->getEmail()),
+            'tickets' => count($responses),
+            'location_id' => $locationId?->value(),
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/SendLiveEmailStep.php
+++ b/Backend/src/QrOrder/Application/Step/SendLiveEmailStep.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use App\Mail\OrderToLiveTicketIssued;
+use Illuminate\Support\Facades\Mail;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Письмо для живого заказа: уведомление о выдаче живого билета (OrderToLiveTicketIssued), БЕЗ PDF.
+ * Одно письмо на заказ по типу билета первого гостя.
+ */
+final class SendLiveEmailStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'send_live_email';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        $responses = $carry['responses'] ?? [];
+        $log = PipelineLog::logger();
+
+        if ($responses === []) {
+            $log->warning('send_live_email.skipped_no_tickets', ['order_id' => $order->getId()->value()]);
+
+            return $carry;
+        }
+
+        $ticketTypeId = $carry['firstTicketTypeId'] ?? Uuid::random();
+
+        Mail::to($order->getEmail())->send(new OrderToLiveTicketIssued($ticketTypeId));
+
+        $log->info('send_live_email.sent', [
+            'order_id' => $order->getId()->value(),
+            'to' => PipelineLog::maskEmail($order->getEmail()),
+            'tickets' => count($responses),
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/SendOrderEmailStep.php
+++ b/Backend/src/QrOrder/Application/Step/SendOrderEmailStep.php
@@ -4,20 +4,25 @@ declare(strict_types=1);
 
 namespace Tickets\QrOrder\Application\Step;
 
-use App\Mail\OrderToPaid;
 use Illuminate\Support\Facades\Mail;
-use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\OrderEmailResolver;
 use Tickets\QrOrder\Application\Support\PipelineLog;
 use Tickets\QrOrder\Dto\QrOrderDto;
 
 /**
  * Шаг 2: одно письмо получателю (order.email) со всеми PDF-билетами заказа.
  *
- * PDF рендерится внутри письма (OrderToPaid) из TicketResponse — поэтому шаг НЕ зависит от
- * завершения ProcessCreatingQRCode. Берёт responses из carry (шаг create_tickets).
+ * Mailable выбирается по type_order через OrderEmailResolver (regular → OrderToPaid,
+ * friendly → OrderToPaidFriendly). PDF и blade-шаблон (парковка/детский) рендерятся внутри
+ * письма из TicketResponse — шаг НЕ зависит от завершения ProcessCreatingQRCode.
  */
 final class SendOrderEmailStep implements PipelineStepInterface
 {
+    public function __construct(
+        private readonly OrderEmailResolver $emailResolver,
+    ) {
+    }
+
     public function name(): string
     {
         return 'send_order_email';
@@ -34,17 +39,21 @@ final class SendOrderEmailStep implements PipelineStepInterface
             return $carry;
         }
 
-        Mail::to($order->getEmail())->send(new OrderToPaid(
+        $mailable = $this->emailResolver->resolve(
+            $order->getTypeOrder(),
             $responses,
-            $carry['firstTicketTypeId'] ?? Uuid::random(),
+            $carry['firstTicketTypeId'] ?? null,
             $carry['comment'] ?? null,
-            null,
-        ));
+        );
+
+        Mail::to($order->getEmail())->send($mailable);
 
         $log->info('send_order_email.sent', [
             'order_id' => $order->getId()->value(),
             'to' => PipelineLog::maskEmail($order->getEmail()),
             'tickets' => count($responses),
+            'type_order' => $order->getTypeOrder(),
+            'mailable' => get_class($mailable),
         ]);
 
         return $carry;

--- a/Backend/src/QrOrder/Application/Step/SendOrderEmailStep.php
+++ b/Backend/src/QrOrder/Application/Step/SendOrderEmailStep.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use App\Mail\OrderToPaid;
+use Illuminate\Support\Facades\Mail;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Шаг 2: одно письмо получателю (order.email) со всеми PDF-билетами заказа.
+ *
+ * PDF рендерится внутри письма (OrderToPaid) из TicketResponse — поэтому шаг НЕ зависит от
+ * завершения ProcessCreatingQRCode. Берёт responses из carry (шаг create_tickets).
+ */
+final class SendOrderEmailStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'send_order_email';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        $responses = $carry['responses'] ?? [];
+        $log = PipelineLog::logger();
+
+        if ($responses === []) {
+            $log->warning('send_order_email.skipped_no_tickets', ['order_id' => $order->getId()->value()]);
+
+            return $carry;
+        }
+
+        Mail::to($order->getEmail())->send(new OrderToPaid(
+            $responses,
+            $carry['firstTicketTypeId'] ?? Uuid::random(),
+            $carry['comment'] ?? null,
+            null,
+        ));
+
+        $log->info('send_order_email.sent', [
+            'order_id' => $order->getId()->value(),
+            'to' => PipelineLog::maskEmail($order->getEmail()),
+            'tickets' => count($responses),
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Step/SendTelegramStep.php
+++ b/Backend/src/QrOrder/Application/Step/SendTelegramStep.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Step;
+
+use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Dto\QrOrderDto;
+use Tickets\Questionnaire\Domain\DomainEvent\ProcessTelegramSend;
+
+/**
+ * Шаг 4: уведомление гостей в Telegram-бот по username из контракта (guests[].telegram).
+ *
+ * Для qr анкеты в момент выдачи ещё нет, поэтому telegram приходит прямо в контракте (а не
+ * ищется по анкете). На каждого гостя с непустым telegram ставит готовую задачу ProcessTelegramSend
+ * (она шлёт в бот и имеет свой ретрай/обработку). Telegram-бот — сторонний чёрный ящик, поэтому
+ * шаг изолирован: только ставит задачи и сам не падает.
+ *
+ * Мягкая валидация (по договорённости с владельцем — он связующее звено): telegram обязателен
+ * на стороне qr, но org его НЕ требует — пустой/отсутствующий просто пропускается.
+ */
+final class SendTelegramStep implements PipelineStepInterface
+{
+    public function name(): string
+    {
+        return 'send_telegram';
+    }
+
+    public function handle(QrOrderDto $order, array $carry): array
+    {
+        $payload = $order->getPayload();
+        $guests = is_array($payload['guests'] ?? null) ? $payload['guests'] : [];
+        $log = PipelineLog::logger();
+        $queued = 0;
+
+        foreach ($guests as $index => $guest) {
+            if (! is_array($guest)) {
+                continue;
+            }
+
+            // Срезаем ведущий '@' и пробелы — бот ждёт чистый username.
+            $telegram = ltrim(trim((string) ($guest['telegram'] ?? '')), '@');
+
+            if ($telegram === '') {
+                $log->info('send_telegram.skip_empty', [
+                    'order_id' => $order->getId()->value(),
+                    'guest_index' => $index,
+                ]);
+
+                continue;
+            }
+
+            ProcessTelegramSend::dispatch($telegram);
+            $queued++;
+        }
+
+        $log->info('send_telegram.queued', [
+            'order_id' => $order->getId()->value(),
+            'count' => $queued,
+        ]);
+
+        return $carry;
+    }
+}

--- a/Backend/src/QrOrder/Application/Support/OrderEmailResolver.php
+++ b/Backend/src/QrOrder/Application/Support/OrderEmailResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Support;
+
+use App\Mail\OrderToPaid;
+use App\Mail\OrderToPaidFriendly;
+use Illuminate\Mail\Mailable;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Domain\ValueObject\TypeOrder;
+
+/**
+ * Резолвер письма с билетами по типу заказа (C3, уровень order-type).
+ *
+ * Mailable выбирается по type_order: friendly → OrderToPaidFriendly, иначе → OrderToPaid.
+ * Blade-шаблон ВНУТРИ письма (парковка orderToPaidAvto, детский ...Child) определяется по типу
+ * билета из ticket_type_festival (TicketResponse.emailView) — это ДРУГОЙ уровень (ticket-type),
+ * поэтому парковка-override корректно работает поверх любого type_order, не конфликтуя.
+ *
+ * list/live имеют принципиально иные письма и собственные шаги — здесь не обрабатываются.
+ */
+final class OrderEmailResolver
+{
+    /**
+     * @param array<int, \Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse> $responses
+     */
+    public function resolve(?string $typeOrder, array $responses, ?Uuid $ticketTypeId, ?string $comment): Mailable
+    {
+        $ticketTypeId ??= Uuid::random();
+
+        return match (TypeOrder::normalize($typeOrder)) {
+            TypeOrder::FRIENDLY => new OrderToPaidFriendly($responses, $ticketTypeId, $comment, null),
+            default => new OrderToPaid($responses, $ticketTypeId, $comment, null),
+        };
+    }
+}

--- a/Backend/src/QrOrder/Application/Support/PipelineLog.php
+++ b/Backend/src/QrOrder/Application/Support/PipelineLog.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Support;
+
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Логирование pipeline выдачи qr: отдельный канал qr_pipeline (JSON), без ПДн в открытом виде.
+ * Канал описан в config/logging.php. См. TD-10 (единый структурированный поток логов).
+ */
+final class PipelineLog
+{
+    public const CHANNEL = 'qr_pipeline';
+
+    public static function logger(): LoggerInterface
+    {
+        return Log::channel(self::CHANNEL);
+    }
+
+    /** Маскирует email для логов: ivan@mail.ru → i***@mail.ru (152-ФЗ: не пишем ПДн открыто). */
+    public static function maskEmail(?string $email): string
+    {
+        if ($email === null || $email === '') {
+            return '';
+        }
+
+        $at = mb_strpos($email, '@');
+        if ($at === false || $at < 1) {
+            return '***';
+        }
+
+        return mb_substr($email, 0, 1) . '***' . mb_substr($email, $at);
+    }
+}

--- a/Backend/src/QrOrder/Application/Support/QrTicketId.php
+++ b/Backend/src/QrOrder/Application/Support/QrTicketId.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Application\Support;
+
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Детерминированный UUID билета из (order_id, индекс гостя) — uuid5.
+ *
+ * Зачем: делает создание билета ИДЕМПОТЕНТНЫМ. При повторном прогоне выдачи (ретрай/переотправка
+ * «оплачен» после сбоя) тот же гость даёт тот же ticket_id → шаг видит существующий билет и не
+ * создаёт дубль. До этого id был random() → повтор плодил дубликаты билетов.
+ */
+final class QrTicketId
+{
+    /** Фиксированное пространство имён для билетов qr (стабильно между прогонами). */
+    private const NAMESPACE = 'a3c8e1d2-5b4f-4e6a-9c7d-1f2e3a4b5c6d';
+
+    public static function forGuest(Uuid $orderId, int $index): Uuid
+    {
+        return new Uuid(
+            RamseyUuid::uuid5(self::NAMESPACE, $orderId->value() . ':' . $index)->toString(),
+        );
+    }
+}

--- a/Backend/src/QrOrder/Domain/QrOrderHistoryEvent.php
+++ b/Backend/src/QrOrder/Domain/QrOrderHistoryEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Domain;
+
+use Tickets\History\Domain\HistoryEventInterface;
+
+/**
+ * Событие истории заказа qr (таблица domain_history, aggregate_type = 'qr_order').
+ *
+ * Универсальное: имя события (created / status_changed / issued) + payload (без ПДн —
+ * статусы/тип заказа/стратегия, но не email/телефон/ФИО).
+ */
+final class QrOrderHistoryEvent implements HistoryEventInterface
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        private readonly string $eventName,
+        private readonly array $payload = [],
+    ) {
+    }
+
+    public function getAggregateType(): string
+    {
+        return 'qr_order';
+    }
+
+    public function getEventName(): string
+    {
+        return $this->eventName;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+}

--- a/Backend/src/QrOrder/Domain/ValueObject/TypeOrder.php
+++ b/Backend/src/QrOrder/Domain/ValueObject/TypeOrder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Domain\ValueObject;
+
+/**
+ * Тип заказа из контракта qr (order_data.type_order). Определяет стратегию выдачи билета.
+ *
+ * Значение 'обычный' подтверждено контрактом; friendly/список/live — заготовки под фазу 4
+ * (точные строки от qr уточняются). Неизвестный/пустой тип → fallback на REGULAR в реестре.
+ */
+final class TypeOrder
+{
+    public const REGULAR = 'обычный';
+    public const FRIENDLY = 'friendly';
+    public const LIST = 'список';
+    public const LIVE = 'live';
+
+    /** Нормализует значение из контракта для сопоставления со стратегией в реестре. */
+    public static function normalize(?string $value): string
+    {
+        return $value !== null ? mb_strtolower(trim($value)) : '';
+    }
+}

--- a/Backend/src/QrOrder/Domain/ValueObject/TypeOrder.php
+++ b/Backend/src/QrOrder/Domain/ValueObject/TypeOrder.php
@@ -7,14 +7,14 @@ namespace Tickets\QrOrder\Domain\ValueObject;
 /**
  * Тип заказа из контракта qr (order_data.type_order). Определяет стратегию выдачи билета.
  *
- * Значение 'обычный' подтверждено контрактом; friendly/список/live — заготовки под фазу 4
- * (точные строки от qr уточняются). Неизвестный/пустой тип → fallback на REGULAR в реестре.
+ * Контракт (английские строки): regular / friendly / list / live.
+ * Неизвестный/пустой тип → fallback на REGULAR в реестре стратегий.
  */
 final class TypeOrder
 {
-    public const REGULAR = 'обычный';
+    public const REGULAR = 'regular';
     public const FRIENDLY = 'friendly';
-    public const LIST = 'список';
+    public const LIST = 'list';
     public const LIVE = 'live';
 
     /** Нормализует значение из контракта для сопоставления со стратегией в реестре. */

--- a/Backend/src/QrOrder/Dto/QrOrderDto.php
+++ b/Backend/src/QrOrder/Dto/QrOrderDto.php
@@ -64,6 +64,10 @@ class QrOrderDto extends AbstractionEntity implements Response
      * Сборка из расширенного JSON-контракта витрины qr (см. CONTRACT JSON в задаче).
      * Проекционные поля денормализуются из вложенных секций, весь JSON кладётся в payload.
      *
+     * Поле `guests[].telegram` (per-guest): обязательно на стороне qr, на org валидируется мягко
+     * (пустое — пропускается). Используется шагом SendTelegramStep для уведомления в бот;
+     * хранится в payload, в проекцию qr_orders НЕ выносится (по нему не фильтруем).
+     *
      * @param array<string, mixed> $json
      * @throws InvalidArgumentException при отсутствии обязательных полей
      */

--- a/Backend/src/QrOrder/Dto/QrOrderDto.php
+++ b/Backend/src/QrOrder/Dto/QrOrderDto.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Dto;
+
+use Carbon\Carbon;
+use InvalidArgumentException;
+use Shared\Domain\Bus\Query\Response;
+use Shared\Domain\Entity\AbstractionEntity;
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Заказ, пришедший от витрины qr. Источник истины — `payload` (весь контракт as-is);
+ * остальные поля — денормализованная проекция для фильтрации (см. миграцию qr_orders).
+ *
+ * id заказа qr РАВЕН id заказа org (маппинг не нужен).
+ */
+class QrOrderDto extends AbstractionEntity implements Response
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        protected Uuid $id,
+        protected string $email,
+        protected string $status,
+        protected ?Uuid $festival_id,
+        protected ?string $type_order,
+        protected ?string $city,
+        protected ?string $phone,
+        protected int $total_price,
+        protected array $payload,
+        protected ?Carbon $issued_at = null,
+        protected ?Carbon $created_at = null,
+        protected ?Carbon $updated_at = null,
+    ) {
+    }
+
+    /**
+     * Сборка из строки БД (qr_orders.*).
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromState(array $data): self
+    {
+        return new self(
+            new Uuid($data['id']),
+            $data['email'],
+            $data['status'],
+            empty($data['festival_id']) ? null : new Uuid($data['festival_id']),
+            $data['type_order'] ?? null,
+            $data['city'] ?? null,
+            $data['phone'] ?? null,
+            (int) ($data['total_price'] ?? 0),
+            is_array($data['payload'] ?? null) ? $data['payload'] : (json_decode((string) ($data['payload'] ?? '[]'), true) ?? []),
+            empty($data['issued_at']) ? null : new Carbon($data['issued_at']),
+            empty($data['created_at']) ? null : new Carbon($data['created_at']),
+            empty($data['updated_at']) ? null : new Carbon($data['updated_at']),
+        );
+    }
+
+    /**
+     * Сборка из расширенного JSON-контракта витрины qr (см. CONTRACT JSON в задаче).
+     * Проекционные поля денормализуются из вложенных секций, весь JSON кладётся в payload.
+     *
+     * @param array<string, mixed> $json
+     * @throws InvalidArgumentException при отсутствии обязательных полей
+     */
+    public static function fromQrContract(array $json): self
+    {
+        $orderId = $json['order_id'] ?? null;
+        if (! is_string($orderId) || $orderId === '') {
+            throw new InvalidArgumentException('qr-контракт: отсутствует "order_id"');
+        }
+
+        $orderData = is_array($json['order_data'] ?? null) ? $json['order_data'] : [];
+        $user = is_array($json['user'] ?? null) ? $json['user'] : [];
+        $price = is_array($json['price'] ?? null) ? $json['price'] : [];
+
+        $email = $orderData['email'] ?? null;
+        if (! is_string($email) || $email === '') {
+            throw new InvalidArgumentException('qr-контракт: отсутствует "order_data.email" (куда отправлять билеты)');
+        }
+
+        // Фестиваль приходит объектом order_data.festival = {id, title} (как types_of_payment/location).
+        $festival = is_array($orderData['festival'] ?? null) ? $orderData['festival'] : [];
+        $festivalId = $festival['id'] ?? ($orderData['festival_id'] ?? ($json['festival_id'] ?? null));
+
+        return new self(
+            new Uuid($orderId),
+            $email,
+            (string) ($orderData['status'] ?? 'создан'),
+            empty($festivalId) ? null : new Uuid((string) $festivalId),
+            isset($orderData['type_order']) ? (string) $orderData['type_order'] : null,
+            isset($user['city']) ? (string) $user['city'] : null,
+            isset($user['phone']) ? (string) $user['phone'] : null,
+            (int) ($price['total'] ?? 0),
+            $json,
+        );
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getFestivalId(): ?Uuid
+    {
+        return $this->festival_id;
+    }
+
+    public function getTypeOrder(): ?string
+    {
+        return $this->type_order;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function getTotalPrice(): int
+    {
+        return $this->total_price;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getIssuedAt(): ?Carbon
+    {
+        return $this->issued_at;
+    }
+}

--- a/Backend/src/QrOrder/Repositories/InMemoryMySqlQrIssuanceRepository.php
+++ b/Backend/src/QrOrder/Repositories/InMemoryMySqlQrIssuanceRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Repositories;
+
+use App\Models\Festival\TicketTypeFestivalModel;
+use App\Models\Tickets\TicketModel;
+use Shared\Domain\ValueObject\Uuid;
+
+final class InMemoryMySqlQrIssuanceRepository implements QrIssuanceRepositoryInterface
+{
+    public function getKilter(Uuid $ticketId): ?int
+    {
+        $kilter = TicketModel::whereId($ticketId->value())->value('kilter');
+
+        return $kilter === null ? null : (int) $kilter;
+    }
+
+    public function findTemplate(Uuid $festivalId, Uuid $ticketTypeId): ?array
+    {
+        $row = TicketTypeFestivalModel::query()
+            ->where('festival_id', $festivalId->value())
+            ->where('ticket_type_id', $ticketTypeId->value())
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return ['pdf' => $row->pdf, 'email' => $row->email];
+    }
+}

--- a/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
+++ b/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tickets\QrOrder\Repositories;
 
 use App\Models\QrOrder\QrOrderModel;
+use Carbon\Carbon;
 use Shared\Domain\ValueObject\Uuid;
 use Tickets\QrOrder\Dto\QrOrderDto;
 
@@ -46,5 +47,10 @@ final class InMemoryMySqlQrOrderRepository implements QrOrderRepositoryInterface
     public function changeStatus(Uuid $id, string $status): bool
     {
         return (bool) $this->model::whereId($id->value())->update(['status' => $status]);
+    }
+
+    public function markIssued(Uuid $id, Carbon $issuedAt): bool
+    {
+        return (bool) $this->model::whereId($id->value())->update(['issued_at' => $issuedAt]);
     }
 }

--- a/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
+++ b/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Repositories;
+
+use App\Models\QrOrder\QrOrderModel;
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+final class InMemoryMySqlQrOrderRepository implements QrOrderRepositoryInterface
+{
+    public function __construct(
+        private QrOrderModel $model,
+    ) {
+    }
+
+    public function create(QrOrderDto $dto): bool
+    {
+        // create() (а не insert) — чтобы сработал каст 'payload' => 'array' (JSON кодируется один раз).
+        return (bool) $this->model::create([
+            'id' => $dto->getId()->value(),
+            'email' => $dto->getEmail(),
+            'status' => $dto->getStatus(),
+            'festival_id' => $dto->getFestivalId()?->value(),
+            'type_order' => $dto->getTypeOrder(),
+            'city' => $dto->getCity(),
+            'phone' => $dto->getPhone(),
+            'total_price' => $dto->getTotalPrice(),
+            'payload' => $dto->getPayload(),
+        ]);
+    }
+
+    public function existsById(Uuid $id): bool
+    {
+        return $this->model::whereId($id->value())->exists();
+    }
+
+    public function findById(Uuid $id): ?QrOrderDto
+    {
+        $row = $this->model::whereId($id->value())->first();
+
+        return $row === null ? null : QrOrderDto::fromState($row->toArray());
+    }
+}

--- a/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
+++ b/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
@@ -53,4 +53,9 @@ final class InMemoryMySqlQrOrderRepository implements QrOrderRepositoryInterface
     {
         return (bool) $this->model::whereId($id->value())->update(['issued_at' => $issuedAt]);
     }
+
+    public function clearIssued(Uuid $id): bool
+    {
+        return (bool) $this->model::whereId($id->value())->update(['issued_at' => null]);
+    }
 }

--- a/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
+++ b/Backend/src/QrOrder/Repositories/InMemoryMySqlQrOrderRepository.php
@@ -42,4 +42,9 @@ final class InMemoryMySqlQrOrderRepository implements QrOrderRepositoryInterface
 
         return $row === null ? null : QrOrderDto::fromState($row->toArray());
     }
+
+    public function changeStatus(Uuid $id, string $status): bool
+    {
+        return (bool) $this->model::whereId($id->value())->update(['status' => $status]);
+    }
 }

--- a/Backend/src/QrOrder/Repositories/QrIssuanceRepositoryInterface.php
+++ b/Backend/src/QrOrder/Repositories/QrIssuanceRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Repositories;
+
+use Shared\Domain\ValueObject\Uuid;
+
+/**
+ * Чтения, нужные для АВТОНОМНОЙ выдачи билетов qr-заказа (без order_tickets):
+ * номер билета (kilter, auto-increment) и шаблоны PDF/email по паре фестиваль+тип билета.
+ */
+interface QrIssuanceRepositoryInterface
+{
+    /** Номер билета (kilter) после вставки строки в tickets. */
+    public function getKilter(Uuid $ticketId): ?int;
+
+    /**
+     * Шаблоны (pdf, email) из ticket_type_festival по (festival_id, ticket_type_id).
+     * В штатном flow это резолвится через JOIN order_tickets — у qr заказа его нет,
+     * поэтому резолвим напрямую по типу билета гостя.
+     *
+     * @return array{pdf: ?string, email: ?string}|null
+     */
+    public function findTemplate(Uuid $festivalId, Uuid $ticketTypeId): ?array;
+}

--- a/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
+++ b/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
@@ -15,4 +15,7 @@ interface QrOrderRepositoryInterface
     public function existsById(Uuid $id): bool;
 
     public function findById(Uuid $id): ?QrOrderDto;
+
+    /** Сменить статус принятого заказа (API №2). */
+    public function changeStatus(Uuid $id, string $status): bool;
 }

--- a/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
+++ b/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tickets\QrOrder\Repositories;
 
+use Carbon\Carbon;
 use Shared\Domain\ValueObject\Uuid;
 use Tickets\QrOrder\Dto\QrOrderDto;
 
@@ -18,4 +19,7 @@ interface QrOrderRepositoryInterface
 
     /** Сменить статус принятого заказа (API №2). */
     public function changeStatus(Uuid $id, string $status): bool;
+
+    /** Отметить заказ как выданный (билеты созданы) — защита от повторной выдачи. */
+    public function markIssued(Uuid $id, Carbon $issuedAt): bool;
 }

--- a/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
+++ b/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
@@ -22,4 +22,7 @@ interface QrOrderRepositoryInterface
 
     /** Отметить заказ как выданный (билеты созданы) — защита от повторной выдачи. */
     public function markIssued(Uuid $id, Carbon $issuedAt): bool;
+
+    /** Снять отметку выдачи (issued_at = null) — при сбое выдачи, чтобы заказ можно было выдать повторно. */
+    public function clearIssued(Uuid $id): bool;
 }

--- a/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
+++ b/Backend/src/QrOrder/Repositories/QrOrderRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\QrOrder\Repositories;
+
+use Shared\Domain\ValueObject\Uuid;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+interface QrOrderRepositoryInterface
+{
+    public function create(QrOrderDto $dto): bool;
+
+    /** Заказ qr с таким id уже принят (id == id заказа org → идемпотентность приёма). */
+    public function existsById(Uuid $id): bool;
+
+    public function findById(Uuid $id): ?QrOrderDto;
+}

--- a/Backend/src/User/Account/Helpers/AccountRoleHelper.php
+++ b/Backend/src/User/Account/Helpers/AccountRoleHelper.php
@@ -13,6 +13,7 @@ class AccountRoleHelper
     public const manager = 'manager'; // реализатор френдли билетов
     public const curator = 'curator'; // куратор — создаёт заказы-списки на локации/сцены
     public const pusher_curator = 'pusher_curator'; // мульти-роль: pusher + curator
+    public const qr_service = 'qr_service'; // сервис-аккаунт витрины qr (S2S, не человек)
 
     public static function isValid(string $role): bool
     {
@@ -24,6 +25,7 @@ class AccountRoleHelper
             self::manager,
             self::curator,
             self::pusher_curator,
+            self::qr_service,
         ]);
     }
 }

--- a/Backend/tests/Feature/QrOrder/LinkLiveTicketJobTest.php
+++ b/Backend/tests/Feature/QrOrder/LinkLiveTicketJobTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use Shared\Domain\ValueObject\Uuid;
+use Tests\TestCase;
+use Tickets\QrOrder\Application\Job\LinkLiveTicketJob;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Связка живого билета с live_tickets: задача вызывает setInBazaLive(номер, el_ticket_id).
+ */
+class LinkLiveTicketJobTest extends TestCase
+{
+    public function test_calls_set_in_baza_live_with_number_and_ticket(): void
+    {
+        $ticketId = Uuid::random()->value();
+
+        $repository = $this->createMock(TicketsRepositoryInterface::class);
+        $repository->expects($this->once())
+            ->method('setInBazaLive')
+            ->with(777, $this->callback(static fn ($id) => $id instanceof Uuid && $id->value() === $ticketId))
+            ->willReturn(true);
+
+        (new LinkLiveTicketJob($ticketId, 777))->handle($repository);
+
+        $this->assertTrue(true);
+    }
+}

--- a/Backend/tests/Feature/QrOrder/PushTicketToBazaJobTest.php
+++ b/Backend/tests/Feature/QrOrder/PushTicketToBazaJobTest.php
@@ -36,6 +36,27 @@ class PushTicketToBazaJobTest extends TestCase
         );
     }
 
+    /** Билет заказа-списка: задан curator_id → TicketResponse::isList() = true. */
+    private function listResponse(): TicketResponse
+    {
+        return new TicketResponse(
+            name: 'Списочник',
+            kilter: 20002,
+            uuid: Uuid::random(),
+            status: 'paid',
+            email: 'list@example.com',
+            phone: '+70000000000',
+            city: 'Москва',
+            comment: null,
+            date_order: Carbon::now(),
+            festival_id: Uuid::random(),
+            curator_id: Uuid::random(),
+            curator_email: 'curator@example.com',
+            curator_name: 'Иван Куратор',
+            project: 'Смена 1',
+        );
+    }
+
     public function test_throws_on_baza_failure_to_trigger_retry(): void
     {
         $repository = $this->createMock(TicketsRepositoryInterface::class);
@@ -54,6 +75,18 @@ class PushTicketToBazaJobTest extends TestCase
         (new PushTicketToBazaJob($this->response()))->handle($repository);
 
         // Дошли сюда без исключения — запись прошла.
+        $this->assertTrue(true);
+    }
+
+    public function test_routes_list_ticket_to_spisok(): void
+    {
+        // Списочный билет (isList) → spisok_tickets, а не el_tickets.
+        $repository = $this->createMock(TicketsRepositoryInterface::class);
+        $repository->expects($this->once())->method('setInBazaList')->willReturn(true);
+        $repository->expects($this->never())->method('setInBaza');
+
+        (new PushTicketToBazaJob($this->listResponse()))->handle($repository);
+
         $this->assertTrue(true);
     }
 }

--- a/Backend/tests/Feature/QrOrder/PushTicketToBazaJobTest.php
+++ b/Backend/tests/Feature/QrOrder/PushTicketToBazaJobTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use Carbon\Carbon;
+use RuntimeException;
+use Shared\Domain\ValueObject\Uuid;
+use Tests\TestCase;
+use Tickets\QrOrder\Application\Job\PushTicketToBazaJob;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Изолированная задача записи билета в Baza:
+ *  - setInBaza вернул false (шина Baza недоступна) → задача бросает исключение → очередь ретраит;
+ *  - setInBaza вернул true → успех, без исключения (setInBaza идемпотентен, дублей нет).
+ */
+class PushTicketToBazaJobTest extends TestCase
+{
+    private function response(): TicketResponse
+    {
+        return new TicketResponse(
+            name: 'Тест Гость',
+            kilter: 20001,
+            uuid: Uuid::random(),
+            status: 'paid',
+            email: 'test@example.com',
+            phone: '+70000000000',
+            city: 'Москва',
+            comment: null,
+            date_order: Carbon::now(),
+            festival_id: Uuid::random(),
+            type_ticket_id: Uuid::random(),
+        );
+    }
+
+    public function test_throws_on_baza_failure_to_trigger_retry(): void
+    {
+        $repository = $this->createMock(TicketsRepositoryInterface::class);
+        $repository->method('setInBaza')->willReturn(false);
+
+        $this->expectException(RuntimeException::class);
+
+        (new PushTicketToBazaJob($this->response()))->handle($repository);
+    }
+
+    public function test_succeeds_when_baza_write_ok(): void
+    {
+        $repository = $this->createMock(TicketsRepositoryInterface::class);
+        $repository->expects($this->once())->method('setInBaza')->willReturn(true);
+
+        (new PushTicketToBazaJob($this->response()))->handle($repository);
+
+        // Дошли сюда без исключения — запись прошла.
+        $this->assertTrue(true);
+    }
+}

--- a/Backend/tests/Feature/QrOrder/QrOrderAuthApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderAuthApiTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Защита S2S-канала qr→org: эндпоинты /qrOrder/create и /qrOrder/changeStatus
+ * закрыты Sanctum-токеном со scope (ability) "qr:ingest".
+ *  - без токена          → 401
+ *  - токен без scope      → 403
+ *  - токен с qr:ingest    → доступ есть (бизнес-логика отрабатывает)
+ */
+class QrOrderAuthApiTest extends TestCase
+{
+    private function contract(): array
+    {
+        return [
+            'order_id' => '11111111-1111-1111-1111-111111111111',
+            'user' => ['city' => 'Москва', 'phone' => '+70000000000'],
+            'price' => ['total' => 4000],
+            'order_data' => [
+                'type_order' => 'обычный',
+                'festival' => ['id' => '55555555-5555-5555-5555-555555555555', 'title' => 'Систо'],
+                'status' => 'создан',
+                'email' => 'buyer@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com',
+                 'type_ticket' => ['id' => '44444444-4444-4444-4444-444444444444', 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+    }
+
+    public function test_create_requires_token(): void
+    {
+        // Без аутентификации канал закрыт.
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertStatus(401);
+    }
+
+    public function test_change_status_requires_token(): void
+    {
+        $this->postJson('/api/v1/qrOrder/changeStatus/11111111-1111-1111-1111-111111111111', ['status' => 'оплачен'])
+            ->assertStatus(401);
+    }
+
+    public function test_create_rejects_token_without_ability(): void
+    {
+        // Валидный Sanctum-токен, но без scope qr:ingest → доступ запрещён (least privilege).
+        Sanctum::actingAs(User::factory()->create(), ['some:other']);
+
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertStatus(403);
+    }
+
+    public function test_create_accepts_token_with_ability(): void
+    {
+        // Токен со scope qr:ingest → канал открыт, заказ принят.
+        Sanctum::actingAs(User::factory()->create(), ['qr:ingest']);
+
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())
+            ->assertOk()
+            ->assertJson(['success' => true]);
+    }
+}

--- a/Backend/tests/Feature/QrOrder/QrOrderAuthApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderAuthApiTest.php
@@ -24,7 +24,7 @@ class QrOrderAuthApiTest extends TestCase
             'user' => ['city' => 'Москва', 'phone' => '+70000000000'],
             'price' => ['total' => 4000],
             'order_data' => [
-                'type_order' => 'обычный',
+                'type_order' => 'regular',
                 'festival' => ['id' => '55555555-5555-5555-5555-555555555555', 'title' => 'Систо'],
                 'status' => 'создан',
                 'email' => 'buyer@example.com',

--- a/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
@@ -30,7 +30,7 @@ class QrOrderCreateApiTest extends TestCase
             'user' => ['user_id' => '22222222-2222-2222-2222-222222222222', 'name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
             'price' => ['price' => 4200, 'discount' => 200, 'total' => 4000],
             'order_data' => [
-                'type_order' => 'обычный',
+                'type_order' => 'regular',
                 'festival' => ['id' => '55555555-5555-5555-5555-555555555555', 'title' => 'Систо 2026'],
                 'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
                 'comment' => 'коммент',
@@ -55,7 +55,7 @@ class QrOrderCreateApiTest extends TestCase
             'id' => '11111111-1111-1111-1111-111111111111',
             'email' => 'buyer@example.com',
             'status' => 'оплачен',
-            'type_order' => 'обычный',
+            'type_order' => 'regular',
             'festival_id' => '55555555-5555-5555-5555-555555555555',
             'city' => 'Москва',
             'total_price' => 4000,

--- a/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use App\Models\QrOrder\QrOrderModel;
+use Tests\TestCase;
+
+/**
+ * API №1 — приём заказа от витрины qr (POST /api/v1/qrOrder/create):
+ * расширенный JSON сохраняется в qr_orders (проекция для фильтров + payload as-is),
+ * приём идемпотентен по id, обязательные поля валидируются.
+ */
+class QrOrderCreateApiTest extends TestCase
+{
+    private function contract(string $orderId = '11111111-1111-1111-1111-111111111111'): array
+    {
+        return [
+            'order_id' => $orderId,
+            'user' => ['user_id' => '22222222-2222-2222-2222-222222222222', 'name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
+            'price' => ['price' => 4200, 'discount' => 200, 'total' => 4000],
+            'order_data' => [
+                'type_order' => 'обычный',
+                'festival' => ['id' => '55555555-5555-5555-5555-555555555555', 'title' => 'Систо 2026'],
+                'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
+                'comment' => 'коммент',
+                'status' => 'оплачен',
+                'email' => 'buyer@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com', 'promocode' => 'SUMMER',
+                 'type_ticket' => ['id' => '44444444-4444-4444-4444-444444444444', 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+    }
+
+    public function test_creates_qr_order_from_extended_json(): void
+    {
+        // Расширенный JSON → строка в qr_orders с заполненной проекцией под фильтры.
+        $response = $this->postJson('/api/v1/qrOrder/create', $this->contract());
+
+        $response->assertOk()->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('qr_orders', [
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'email' => 'buyer@example.com',
+            'status' => 'оплачен',
+            'type_order' => 'обычный',
+            'festival_id' => '55555555-5555-5555-5555-555555555555',
+            'city' => 'Москва',
+            'total_price' => 4000,
+        ]);
+
+        // payload сохранён целиком (гости доступны для последующей выдачи билетов).
+        $row = QrOrderModel::whereId('11111111-1111-1111-1111-111111111111')->firstOrFail();
+        self::assertCount(1, $row->payload['guests']);
+        self::assertSame('Иван Гость', $row->payload['guests'][0]['name']);
+    }
+
+    public function test_create_is_idempotent_by_order_id(): void
+    {
+        // Повторный приём того же заказа (id == id заказа org) не создаёт дубль.
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+
+        self::assertSame(1, QrOrderModel::whereId('11111111-1111-1111-1111-111111111111')->count());
+    }
+
+    public function test_rejects_contract_without_email(): void
+    {
+        // Нет email — некуда слать билеты → 422, заказ не создаётся.
+        $contract = $this->contract();
+        unset($contract['order_data']['email']);
+
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertStatus(422);
+        $this->assertDatabaseMissing('qr_orders', ['id' => '11111111-1111-1111-1111-111111111111']);
+    }
+}

--- a/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
@@ -76,4 +76,26 @@ class QrOrderCreateApiTest extends TestCase
         $this->postJson('/api/v1/qrOrder/create', $contract)->assertStatus(422);
         $this->assertDatabaseMissing('qr_orders', ['id' => '11111111-1111-1111-1111-111111111111']);
     }
+
+    public function test_change_status_updates_accepted_order(): void
+    {
+        // API №2 (шаг 2a): смена статуса обновляет колонку status принятого заказа.
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+
+        $this->postJson('/api/v1/qrOrder/changeStatus/11111111-1111-1111-1111-111111111111', ['status' => 'отменён'])
+            ->assertOk()
+            ->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('qr_orders', [
+            'id' => '11111111-1111-1111-1111-111111111111',
+            'status' => 'отменён',
+        ]);
+    }
+
+    public function test_change_status_404_for_unknown_order(): void
+    {
+        // Смена статуса несуществующего заказа → 404.
+        $this->postJson('/api/v1/qrOrder/changeStatus/99999999-9999-9999-9999-999999999999', ['status' => 'оплачен'])
+            ->assertStatus(404);
+    }
 }

--- a/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
@@ -107,4 +107,23 @@ class QrOrderCreateApiTest extends TestCase
         $this->postJson('/api/v1/qrOrder/changeStatus/99999999-9999-9999-9999-999999999999', ['status' => 'оплачен'])
             ->assertStatus(404);
     }
+
+    public function test_create_and_status_change_record_history(): void
+    {
+        // История пишется с actor=qr: created при приёме, status_changed при смене статуса.
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+        $this->postJson('/api/v1/qrOrder/changeStatus/11111111-1111-1111-1111-111111111111', ['status' => 'отменён'])->assertOk();
+
+        $this->assertDatabaseHas('domain_history', [
+            'aggregate_id' => '11111111-1111-1111-1111-111111111111',
+            'aggregate_type' => 'qr_order',
+            'event_name' => 'created',
+            'actor_type' => 'qr',
+        ]);
+        $this->assertDatabaseHas('domain_history', [
+            'aggregate_id' => '11111111-1111-1111-1111-111111111111',
+            'event_name' => 'status_changed',
+            'actor_type' => 'qr',
+        ]);
+    }
 }

--- a/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderCreateApiTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\QrOrder;
 
 use App\Models\QrOrder\QrOrderModel;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 /**
@@ -14,6 +16,13 @@ use Tests\TestCase;
  */
 class QrOrderCreateApiTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // S2S-канал защищён: аутентифицируем сервис-токеном со scope qr:ingest.
+        Sanctum::actingAs(User::factory()->create(), ['qr:ingest']);
+    }
+
     private function contract(string $orderId = '11111111-1111-1111-1111-111111111111'): array
     {
         return [

--- a/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
@@ -6,9 +6,11 @@ namespace Tests\Feature\QrOrder;
 
 use App\Mail\OrderToPaid;
 use App\Models\Tickets\TicketModel;
+use App\Models\User;
 use Database\Seeders\TypeTicketsSeeder;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
 use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
@@ -21,6 +23,13 @@ use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
 class QrOrderIssueApiTest extends TestCase
 {
     private const ORDER_ID = '11111111-1111-1111-1111-111111111111';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // S2S-канал защищён: аутентифицируем сервис-токеном со scope qr:ingest.
+        Sanctum::actingAs(User::factory()->create(), ['qr:ingest']);
+    }
 
     private function contract(): array
     {

--- a/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
@@ -35,7 +35,7 @@ class QrOrderIssueApiTest extends TestCase
             'user' => ['user_id' => '22222222-2222-2222-2222-222222222222', 'name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
             'price' => ['price' => 4200, 'discount' => 0, 'total' => 4200],
             'order_data' => [
-                'type_order' => 'обычный',
+                'type_order' => 'regular',
                 'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
                 'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
                 'comment' => null,

--- a/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Feature\QrOrder;
 
-use App\Mail\OrderToPaid;
-use App\Models\Tickets\TicketModel;
 use App\Models\User;
 use Database\Seeders\TypeTicketsSeeder;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
-use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
+use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
 
 /**
- * API №2b — выдача билетов при переходе заказа в «оплачен» (автономно по qr_orders):
- * на каждого гостя создаётся билет в tickets (order_ticket_id == id qr-заказа),
- * ставится PDF/QR в очередь и отправляется письмо с билетами; повторный «оплачен» не дублирует.
+ * API №2b — при переходе заказа в «оплачен» выдача запускается АСИНХРОННО:
+ * ставится оркестратор IssueOrderJob (вне HTTP-запроса qr), заказ помечается issued_at,
+ * повторный «оплачен» не ставит задачу снова, неоплаченный статус не запускает выдачу.
  */
 class QrOrderIssueApiTest extends TestCase
 {
@@ -39,7 +36,6 @@ class QrOrderIssueApiTest extends TestCase
             'price' => ['price' => 4200, 'discount' => 0, 'total' => 4200],
             'order_data' => [
                 'type_order' => 'обычный',
-                // фестиваль и тип билета — сидерные, чтобы билет корректно создался и нашёлся шаблон
                 'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
                 'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
                 'comment' => null,
@@ -53,53 +49,40 @@ class QrOrderIssueApiTest extends TestCase
         ];
     }
 
-    public function test_paid_status_issues_ticket_and_sends_email(): void
+    public function test_paid_status_dispatches_issue_job(): void
     {
-        Mail::fake();
         Queue::fake();
 
-        // Принимаем заказ, затем переводим в «оплачен» → должна сработать выдача.
+        // Принимаем заказ, затем переводим в «оплачен» → должна встать задача выдачи.
         $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
         $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
 
-        // Билет создан и привязан к заказу qr (order_ticket_id == id qr-заказа).
-        $this->assertDatabaseHas('tickets', [
-            'order_ticket_id' => self::ORDER_ID,
-            'name' => 'Иван Гость',
-        ]);
-        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+        Queue::assertPushed(IssueOrderJob::class);
 
-        // PDF/QR поставлен в очередь, письмо с билетами отправлено.
-        Queue::assertPushed(ProcessCreatingQRCode::class);
-        Mail::assertSent(OrderToPaid::class);
-
-        // Заказ помечен выданным.
+        // Заказ помечен выданным (issued_at != null).
         $this->assertDatabaseMissing('qr_orders', ['id' => self::ORDER_ID, 'issued_at' => null]);
     }
 
     public function test_issue_is_idempotent_on_repeated_paid(): void
     {
-        Mail::fake();
         Queue::fake();
 
         $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
         $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
-        // Повторный «оплачен» не должен выдать билеты снова (защита по issued_at).
+        // Повторный «оплачен» не должен поставить вторую задачу выдачи (защита по issued_at).
         $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
 
-        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+        Queue::assertPushed(IssueOrderJob::class, 1);
     }
 
-    public function test_non_paid_status_does_not_issue(): void
+    public function test_non_paid_status_does_not_dispatch(): void
     {
-        Mail::fake();
         Queue::fake();
 
         $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
         // Статус «отменён» не запускает выдачу.
         $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'отменён'])->assertOk();
 
-        self::assertSame(0, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
-        Mail::assertNothingSent();
+        Queue::assertNotPushed(IssueOrderJob::class);
     }
 }

--- a/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderIssueApiTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use App\Mail\OrderToPaid;
+use App\Models\Tickets\TicketModel;
+use Database\Seeders\TypeTicketsSeeder;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
+use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
+
+/**
+ * API №2b — выдача билетов при переходе заказа в «оплачен» (автономно по qr_orders):
+ * на каждого гостя создаётся билет в tickets (order_ticket_id == id qr-заказа),
+ * ставится PDF/QR в очередь и отправляется письмо с билетами; повторный «оплачен» не дублирует.
+ */
+class QrOrderIssueApiTest extends TestCase
+{
+    private const ORDER_ID = '11111111-1111-1111-1111-111111111111';
+
+    private function contract(): array
+    {
+        return [
+            'order_id' => self::ORDER_ID,
+            'user' => ['user_id' => '22222222-2222-2222-2222-222222222222', 'name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
+            'price' => ['price' => 4200, 'discount' => 0, 'total' => 4200],
+            'order_data' => [
+                'type_order' => 'обычный',
+                // фестиваль и тип билета — сидерные, чтобы билет корректно создался и нашёлся шаблон
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
+                'comment' => null,
+                'status' => 'создан',
+                'email' => 'buyer@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com',
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+    }
+
+    public function test_paid_status_issues_ticket_and_sends_email(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        // Принимаем заказ, затем переводим в «оплачен» → должна сработать выдача.
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+        $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
+
+        // Билет создан и привязан к заказу qr (order_ticket_id == id qr-заказа).
+        $this->assertDatabaseHas('tickets', [
+            'order_ticket_id' => self::ORDER_ID,
+            'name' => 'Иван Гость',
+        ]);
+        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+
+        // PDF/QR поставлен в очередь, письмо с билетами отправлено.
+        Queue::assertPushed(ProcessCreatingQRCode::class);
+        Mail::assertSent(OrderToPaid::class);
+
+        // Заказ помечен выданным.
+        $this->assertDatabaseMissing('qr_orders', ['id' => self::ORDER_ID, 'issued_at' => null]);
+    }
+
+    public function test_issue_is_idempotent_on_repeated_paid(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+        $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
+        // Повторный «оплачен» не должен выдать билеты снова (защита по issued_at).
+        $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'оплачен'])->assertOk();
+
+        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+    }
+
+    public function test_non_paid_status_does_not_issue(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $this->postJson('/api/v1/qrOrder/create', $this->contract())->assertOk();
+        // Статус «отменён» не запускает выдачу.
+        $this->postJson('/api/v1/qrOrder/changeStatus/' . self::ORDER_ID, ['status' => 'отменён'])->assertOk();
+
+        self::assertSame(0, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+        Mail::assertNothingSent();
+    }
+}

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\QrOrder;
 
 use App\Mail\OrderToPaid;
+use App\Mail\OrderToPaidFriendly;
 use App\Models\Tickets\TicketModel;
 use App\Models\User;
 use Database\Seeders\TypeTicketsSeeder;
@@ -43,7 +44,7 @@ class QrOrderPipelineTest extends TestCase
             'user' => ['name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
             'price' => ['total' => 4200],
             'order_data' => [
-                'type_order' => 'обычный',
+                'type_order' => 'regular',
                 'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
                 'status' => 'создан',
                 'email' => 'buyer@example.com',
@@ -94,7 +95,7 @@ class QrOrderPipelineTest extends TestCase
             'user' => ['name' => 'Без ТГ', 'city' => 'Тверь', 'phone' => '+70000000001'],
             'price' => ['total' => 4200],
             'order_data' => [
-                'type_order' => 'обычный',
+                'type_order' => 'regular',
                 'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
                 'status' => 'создан',
                 'email' => 'notg@example.com',
@@ -124,5 +125,39 @@ class QrOrderPipelineTest extends TestCase
 
         // issued_at сброшен → повторный «оплачен» от qr сможет переподнять выдачу (нет «выдан без билетов»).
         $this->assertDatabaseHas('qr_orders', ['id' => self::ORDER_ID, 'issued_at' => null]);
+    }
+
+    public function test_friendly_order_sends_friendly_email(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $oid = '66666666-6666-6666-6666-666666666666';
+        $contract = [
+            'order_id' => $oid,
+            'user' => ['name' => 'Френд', 'city' => 'Пермь', 'phone' => '+70000000002'],
+            'price' => ['total' => 4200],
+            'order_data' => [
+                'type_order' => 'friendly',
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'status' => 'создан',
+                'email' => 'friend@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Френд Гость', 'email' => 'friend@example.com',
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertOk();
+
+        app()->call([new IssueOrderJob(new Uuid($oid)), 'handle']);
+
+        // Friendly-заказ → friendly-письмо; обычное OrderToPaid НЕ отправляется.
+        Mail::assertSent(OrderToPaidFriendly::class, 1);
+        Mail::assertNotSent(OrderToPaid::class);
+
+        // Билет всё равно создаётся и пишется в Baza.
+        self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
+        Queue::assertPushed(PushTicketToBazaJob::class, 1);
     }
 }

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\QrOrder;
+
+use App\Mail\OrderToPaid;
+use App\Models\Tickets\TicketModel;
+use App\Models\User;
+use Database\Seeders\TypeTicketsSeeder;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use RuntimeException;
+use Shared\Domain\ValueObject\Uuid;
+use Tests\TestCase;
+use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
+use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
+use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
+use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
+
+/**
+ * Pipeline выдачи (оркестратор IssueOrderJob, стратегия REGULAR): на каждого гостя создаётся
+ * билет в tickets (order_ticket_id == id qr-заказа), ставится PDF/QR в очередь и отправляется
+ * ОДНО письмо со всеми PDF. Оркестратор запускаем синхронно (handle), очередь/почта — fake.
+ */
+class QrOrderPipelineTest extends TestCase
+{
+    private const ORDER_ID = '44444444-4444-4444-4444-444444444444';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Sanctum::actingAs(User::factory()->create(), ['qr:ingest']);
+    }
+
+    private function persistOrder(): void
+    {
+        $contract = [
+            'order_id' => self::ORDER_ID,
+            'user' => ['name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
+            'price' => ['total' => 4200],
+            'order_data' => [
+                'type_order' => 'обычный',
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'status' => 'создан',
+                'email' => 'buyer@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com',
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertOk();
+    }
+
+    public function test_orchestrator_issues_tickets_and_sends_one_email(): void
+    {
+        Mail::fake();
+        Queue::fake();
+        $this->persistOrder();
+
+        // Запускаем оркестратор синхронно (в проде — асинхронно через очередь).
+        app()->call([new IssueOrderJob(new Uuid(self::ORDER_ID)), 'handle']);
+
+        // Билет создан и привязан к заказу qr (order_ticket_id == id qr-заказа).
+        $this->assertDatabaseHas('tickets', [
+            'order_ticket_id' => self::ORDER_ID,
+            'name' => 'Иван Гость',
+        ]);
+        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+
+        // PDF/QR поставлен в очередь; письмо со всеми PDF отправлено ровно одно.
+        Queue::assertPushed(ProcessCreatingQRCode::class);
+        Mail::assertSent(OrderToPaid::class, 1);
+    }
+
+    public function test_failed_job_resets_issued_at_for_retry(): void
+    {
+        $this->persistOrder();
+
+        // Имитируем: при dispatch заказ помечен выданным, затем задача упала окончательно.
+        $repository = app(QrOrderRepositoryInterface::class);
+        $repository->markIssued(new Uuid(self::ORDER_ID), now());
+        (new IssueOrderJob(new Uuid(self::ORDER_ID)))->failed(new RuntimeException('boom'));
+
+        // issued_at сброшен → повторный «оплачен» от qr сможет переподнять выдачу (нет «выдан без билетов»).
+        $this->assertDatabaseHas('qr_orders', ['id' => self::ORDER_ID, 'issued_at' => null]);
+    }
+}

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -16,6 +16,7 @@ use Shared\Domain\ValueObject\Uuid;
 use Tests\TestCase;
 use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
 use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
+use Tickets\QrOrder\Application\Job\PushTicketToBazaJob;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
 
@@ -73,6 +74,9 @@ class QrOrderPipelineTest extends TestCase
         // PDF/QR поставлен в очередь; письмо со всеми PDF отправлено ровно одно.
         Queue::assertPushed(ProcessCreatingQRCode::class);
         Mail::assertSent(OrderToPaid::class, 1);
+
+        // Запись билета в Baza — отдельной изолированной задачей (на каждый билет).
+        Queue::assertPushed(PushTicketToBazaJob::class, 1);
     }
 
     public function test_failed_job_resets_issued_at_for_retry(): void

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -18,6 +18,7 @@ use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
 use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
 use Tickets\QrOrder\Application\Job\PushTicketToBazaJob;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
+use Tickets\Questionnaire\Domain\DomainEvent\ProcessTelegramSend;
 use Tickets\Ticket\CreateTickets\Domain\ProcessCreatingQRCode;
 
 /**
@@ -48,7 +49,7 @@ class QrOrderPipelineTest extends TestCase
                 'email' => 'buyer@example.com',
             ],
             'guests' => [
-                ['name' => 'Иван Гость', 'email' => 'guest@example.com',
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com', 'telegram' => 'ivan_guest',
                  'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
             ],
         ];
@@ -76,6 +77,39 @@ class QrOrderPipelineTest extends TestCase
         Mail::assertSent(OrderToPaid::class, 1);
 
         // Запись билета в Baza — отдельной изолированной задачей (на каждый билет).
+        Queue::assertPushed(PushTicketToBazaJob::class, 1);
+
+        // Уведомление гостя в Telegram — отдельной задачей (у гостя задан telegram).
+        Queue::assertPushed(ProcessTelegramSend::class, 1);
+    }
+
+    public function test_skips_telegram_when_guest_has_none(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $oid = '55555555-5555-5555-5555-555555555555';
+        $contract = [
+            'order_id' => $oid,
+            'user' => ['name' => 'Без ТГ', 'city' => 'Тверь', 'phone' => '+70000000001'],
+            'price' => ['total' => 4200],
+            'order_data' => [
+                'type_order' => 'обычный',
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'status' => 'создан',
+                'email' => 'notg@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Гость Без ТГ', 'email' => 'notg@example.com',
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertOk();
+
+        app()->call([new IssueOrderJob(new Uuid($oid)), 'handle']);
+
+        // Нет telegram у гостя → задача в бот не ставится (мягкая валидация), остальное работает.
+        Queue::assertNotPushed(ProcessTelegramSend::class);
         Queue::assertPushed(PushTicketToBazaJob::class, 1);
     }
 

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\QrOrder;
 
 use App\Mail\OrderListApproved;
+use App\Mail\OrderToLiveTicketIssued;
 use App\Mail\OrderToPaid;
 use App\Mail\OrderToPaidFriendly;
 use App\Models\Tickets\TicketModel;
@@ -18,6 +19,7 @@ use Shared\Domain\ValueObject\Uuid;
 use Tests\TestCase;
 use Tickets\Order\OrderTicket\Helpers\FestivalHelper;
 use Tickets\QrOrder\Application\Issuance\IssueOrderJob;
+use Tickets\QrOrder\Application\Job\LinkLiveTicketJob;
 use Tickets\QrOrder\Application\Job\PushTicketToBazaJob;
 use Tickets\QrOrder\Repositories\QrOrderRepositoryInterface;
 use Tickets\Questionnaire\Domain\DomainEvent\ProcessTelegramSend;
@@ -195,5 +197,38 @@ class QrOrderPipelineTest extends TestCase
         Mail::assertNotSent(OrderToPaid::class);
         self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
         Queue::assertPushed(PushTicketToBazaJob::class, 1);
+    }
+
+    public function test_live_order_no_pdf_links_and_sends_live_email(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $oid = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $contract = [
+            'order_id' => $oid,
+            'user' => ['name' => 'Лайв', 'city' => 'Уфа', 'phone' => '+70000000004'],
+            'order_data' => [
+                'type_order' => 'live',
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'status' => 'создан',
+                'email' => 'live.recipient@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Лайв Гость', 'email' => 'g.live@example.com', 'number' => 777,
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Живой', 'options' => []]],
+            ],
+        ];
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertOk();
+
+        app()->call([new IssueOrderJob(new Uuid($oid)), 'handle']);
+
+        // Живой: письмо о выдаче (без PDF), связка с live_tickets поставлена;
+        // PDF (ProcessCreatingQRCode) и el_tickets (PushTicketToBazaJob) НЕ задействованы.
+        Mail::assertSent(OrderToLiveTicketIssued::class, 1);
+        Queue::assertPushed(LinkLiveTicketJob::class, 1);
+        Queue::assertNotPushed(ProcessCreatingQRCode::class);
+        Queue::assertNotPushed(PushTicketToBazaJob::class);
+        self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
     }
 }

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\QrOrder;
 
+use App\Mail\OrderListApproved;
 use App\Mail\OrderToPaid;
 use App\Mail\OrderToPaidFriendly;
 use App\Models\Tickets\TicketModel;
@@ -157,6 +158,41 @@ class QrOrderPipelineTest extends TestCase
         Mail::assertNotSent(OrderToPaid::class);
 
         // Билет всё равно создаётся и пишется в Baza.
+        self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
+        Queue::assertPushed(PushTicketToBazaJob::class, 1);
+    }
+
+    public function test_list_order_sends_list_email_and_creates_ticket(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $oid = '77777777-7777-7777-7777-777777777777';
+        $contract = [
+            'order_id' => $oid,
+            'user' => ['name' => 'Получатель', 'city' => 'Сочи', 'phone' => '+70000000003'],
+            // цены нет
+            'order_data' => [
+                'type_order' => 'list',
+                'festival' => ['id' => FestivalHelper::UUID_FESTIVAL, 'title' => 'Систо'],
+                'curator' => ['id' => '88888888-8888-8888-8888-888888888888', 'email' => 'curator@example.com', 'name' => 'Иван Куратор'],
+                'location' => ['id' => '99999999-9999-9999-9999-999999999999', 'name' => 'Сцена А'],
+                'project' => 'Смена 1',
+                'status' => 'создан',
+                'email' => 'recipient@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Гость Списка', 'email' => 'g.list@example.com',
+                 'type_ticket' => ['id' => TypeTicketsSeeder::ID_FOR_FIRST_WAVE, 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+        $this->postJson('/api/v1/qrOrder/create', $contract)->assertOk();
+
+        app()->call([new IssueOrderJob(new Uuid($oid)), 'handle']);
+
+        // Список → письмо OrderListApproved (а не OrderToPaid), билет создан, Baza-задача поставлена.
+        Mail::assertSent(OrderListApproved::class, 1);
+        Mail::assertNotSent(OrderToPaid::class);
         self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
         Queue::assertPushed(PushTicketToBazaJob::class, 1);
     }

--- a/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
+++ b/Backend/tests/Feature/QrOrder/QrOrderPipelineTest.php
@@ -85,6 +85,13 @@ class QrOrderPipelineTest extends TestCase
 
         // Уведомление гостя в Telegram — отдельной задачей (у гостя задан telegram).
         Queue::assertPushed(ProcessTelegramSend::class, 1);
+
+        // История: при выдаче записано событие issued (actor=qr).
+        $this->assertDatabaseHas('domain_history', [
+            'aggregate_id' => self::ORDER_ID,
+            'event_name' => 'issued',
+            'actor_type' => 'qr',
+        ]);
     }
 
     public function test_skips_telegram_when_guest_has_none(): void
@@ -230,5 +237,20 @@ class QrOrderPipelineTest extends TestCase
         Queue::assertNotPushed(ProcessCreatingQRCode::class);
         Queue::assertNotPushed(PushTicketToBazaJob::class);
         self::assertSame(1, TicketModel::where('order_ticket_id', $oid)->count());
+    }
+
+    public function test_rerun_does_not_duplicate_tickets(): void
+    {
+        Mail::fake();
+        Queue::fake();
+        $this->persistOrder();
+
+        // Двойной прогон оркестратора (имитация ретрая/переотправки «оплачен» после сбоя).
+        app()->call([new IssueOrderJob(new Uuid(self::ORDER_ID)), 'handle']);
+        app()->call([new IssueOrderJob(new Uuid(self::ORDER_ID)), 'handle']);
+
+        // Билет не задублировался (детерминированный id), PDF поставлен один раз (только для нового).
+        self::assertSame(1, TicketModel::where('order_ticket_id', self::ORDER_ID)->count());
+        Queue::assertPushed(ProcessCreatingQRCode::class, 1);
     }
 }

--- a/Backend/tests/Unit/QrOrder/QrOrderDtoTest.php
+++ b/Backend/tests/Unit/QrOrder/QrOrderDtoTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\QrOrder;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Tickets\QrOrder\Dto\QrOrderDto;
+
+/**
+ * Разбор расширенного JSON-контракта витрины qr в QrOrderDto:
+ * денормализация проекционных полей и валидация обязательных.
+ */
+class QrOrderDtoTest extends TestCase
+{
+    private function contract(): array
+    {
+        return [
+            'order_id' => '11111111-1111-1111-1111-111111111111',
+            'user' => ['user_id' => '22222222-2222-2222-2222-222222222222', 'name' => 'Иван', 'city' => 'Москва', 'phone' => '+70000000000'],
+            'price' => ['price' => 4200, 'discount' => 200, 'total' => 4000],
+            'order_data' => [
+                'type_order' => 'обычный',
+                'festival' => ['id' => '55555555-5555-5555-5555-555555555555', 'title' => 'Систо 2026'],
+                'types_of_payment' => ['title' => 'СБП', 'id' => '33333333-3333-3333-3333-333333333333'],
+                'comment' => 'коммент',
+                'status' => 'оплачен',
+                'email' => 'buyer@example.com',
+            ],
+            'guests' => [
+                ['name' => 'Иван Гость', 'email' => 'guest@example.com', 'promocode' => 'SUMMER',
+                 'type_ticket' => ['id' => '44444444-4444-4444-4444-444444444444', 'title' => 'Оргвзнос', 'options' => []]],
+            ],
+        ];
+    }
+
+    public function test_maps_projection_fields_and_keeps_full_payload(): void
+    {
+        // Проекционные поля берутся из вложенных секций контракта, а весь JSON сохраняется в payload.
+        $dto = QrOrderDto::fromQrContract($this->contract());
+
+        self::assertSame('11111111-1111-1111-1111-111111111111', $dto->getId()->value());
+        self::assertSame('buyer@example.com', $dto->getEmail());
+        self::assertSame('оплачен', $dto->getStatus());
+        self::assertSame('обычный', $dto->getTypeOrder());
+        self::assertSame('Москва', $dto->getCity());
+        self::assertSame('+70000000000', $dto->getPhone());
+        self::assertSame(4000, $dto->getTotalPrice());
+        // festival приходит объектом {id, title} в order_data → в проекцию берём id.
+        self::assertSame('55555555-5555-5555-5555-555555555555', $dto->getFestivalId()?->value());
+        // payload сохранён целиком (гости на месте).
+        self::assertCount(1, $dto->getPayload()['guests']);
+    }
+
+    public function test_festival_id_is_null_when_absent_in_contract(): void
+    {
+        // Если объекта festival нет в контракте → проекция festival_id = null (колонка nullable).
+        $contract = $this->contract();
+        unset($contract['order_data']['festival']);
+
+        $dto = QrOrderDto::fromQrContract($contract);
+        self::assertNull($dto->getFestivalId());
+    }
+
+    public function test_rejects_missing_order_id(): void
+    {
+        // Без order_id заказ принять нельзя (это и есть общий с org идентификатор).
+        $contract = $this->contract();
+        unset($contract['order_id']);
+
+        $this->expectException(InvalidArgumentException::class);
+        QrOrderDto::fromQrContract($contract);
+    }
+
+    public function test_rejects_missing_email(): void
+    {
+        // Без email некуда отправлять билеты → отказ.
+        $contract = $this->contract();
+        unset($contract['order_data']['email']);
+
+        $this->expectException(InvalidArgumentException::class);
+        QrOrderDto::fromQrContract($contract);
+    }
+}


### PR DESCRIPTION
## Что

Полная интеграция приёма заказов от витрины **qr.spaceofjoy.ru** в org (Backend): принять расширенный JSON, при оплате — асинхронно выдать билеты (PDF/письмо/Baza/Telegram). `id` заказа qr == `id` заказа org (без маппинга), отдельная таблица `qr_orders`.

## Как (архитектура)

- **S2S-аутентификация** канала: Sanctum-токен сервис-аккаунта (`role qr_service`) со scope `qr:ingest` на `create`/`changeStatus`; `getItem`/`getHistory` — JWT+admin. Команда `php artisan qr:issue-token`.
- **Async-оркестратор** `IssueOrderJob` (штатная Laravel queue, без RabbitMQ): `changeStatus(оплачен)` отдаёт qr быстрый 200 и ставит выдачу в очередь.
- **Strategy + Registry по `type_order`** (OCP): `regular` / `friendly` / `list` / `live`. Шаги pipeline — отдельные классы (SRP), резолвятся через DI.
- **Запись в Baza** — изолированными job'ами с ретраями (`PushTicketToBazaJob` маршрутизирует el_tickets/spisok_tickets по `isList`; `LinkLiveTicketJob` — `setInBazaLive` по номеру). Сбой Baza не валит выдачу/письмо.
- **Резолвер письма** (C3): Mailable по type_order; blade (парковка/детский) — по типу билета из `ticket_type_festival`, override не конфликтует.
- **Логирование** каждого шага в отдельный JSON-канал `qr_pipeline` (без ПДн — email маскируется).
- **Идемпотентность**: детерминированный `uuid5` билета (order_id+индекс) → повтор пайплайна не дублирует билеты/el_tickets. `IssueOrderJob::failed()` сбрасывает `issued_at` (восстанавливаемость).
- **История** по `qr_orders` (`domain_history`, `ActorType::QR`): created / status_changed / issued.

## Типы заказа

| type_order | PDF | Письмо | Baza |
|-----------|-----|--------|------|
| regular | ✅ | OrderToPaid | el_tickets |
| friendly | ✅ | OrderToPaidFriendly | el_tickets |
| list | ✅ | OrderListApproved | spisok_tickets |
| live | ❌ | OrderToLiveTicketIssued | live_tickets (связка по №) |

## Контракт

`order_data.type_order` ∈ {regular, friendly, list, live}. List: `curator{id,email,name}` + `location{id,name}` + `project`. Live: `guests[].number`. Telegram: `guests[].telegram` (на org мягко). Парковка — тип билета `is_parking`.

## Инфра

`mysqlBaza` env-ифицирован (`DB_BAZA_*`, dev/prod-дефолты = прежний хардкод) + idempotent-шаг в `deploy-staging.yml`. Раньше Baza была недостижима со staging.

## Миграции

- `qr_orders` (payload JSON + проекции + индексы)
- снят FK `tickets.order_ticket_id` (билеты qr ссылаются на `qr_orders.id`)
- `personal_access_tokens` пересоздана под UUID (`uuidMorphs` + `expires_at`)

## Тесты

246 passed / 3 skipped. Каждая фаза проверена end-to-end на staging (билеты, el_tickets/spisok/live-связка, письма, telegram-изоляция, идемпотентность — повтор не дублирует, история).

## Известное ограничение

Билеты/el_tickets/live-связка — полностью идемпотентны. Письмо/telegram при полном ре-ране (ретрай после сбоя) могут уйти повторно — приемлемо (сбой пайплайна обычно и есть падение письма). Строгое «письмо один раз» — отдельный небольшой шаг (флаг email_sent), намеренно отложено.

🤖 Generated with [Claude Code](https://claude.com/claude-code)