### PR TITLE
fix(baza): закрыть auth-дыру впуска и двойной впуск на КПП

### DIFF
--- a/Baza/app/Http/Controllers/Api/ScanController.php
+++ b/Baza/app/Http/Controllers/Api/ScanController.php
@@ -42,16 +42,29 @@ class ScanController extends Controller
         }
     }
 
+    /**
+     * Впуск гостя на КПП. Порядок шагов важен:
+     *   1) по сотруднику (Auth::id() — из сессии, НЕ из тела запроса) находим id его
+     *      ТЕКУЩЕЙ открытой смены (getCurrentChanges);
+     *   2) помечаем билет впущенным (skip): change_id = id смены, date_change = now.
+     *      skip() бросает исключение, если билет НЕ найден или УЖЕ был пропущен —
+     *      серверная защита от повторного впуска (не только фронт);
+     *   3) только при успешном skip — +1 к счётчику прошедших билетов в отчёте смены.
+     *
+     * Маршрут защищён middleware('auth') в routes/web.php (web-группа: сессия + CSRF).
+     */
     public function enter(Request $request): JsonResponse
     {
         try {
-            $changeId = $this->getCurrentChanges->getId((int)$request->get('user_id'));
-            $this->addTicketsInReport->increment($changeId, $request->get('type'));
+            $changeId = $this->getCurrentChanges->getId((int) \Auth::id());
+
             $this->enterTicket->skip(
                 $request->get('type'),
                 (int)$request->get('id'),
                 $changeId,
             );
+
+            $this->addTicketsInReport->increment($changeId, $request->get('type'));
 
             return response()->json('OK');
         } catch (Throwable $e) {

--- a/Baza/app/Http/Controllers/Tickets/SearchController.php
+++ b/Baza/app/Http/Controllers/Tickets/SearchController.php
@@ -48,13 +48,16 @@ class SearchController extends Controller
     {
         try {
             $changeId = $this->getCurrentChanges->getId((int)\Auth::id());
-            $this->addTicketsInReport->increment($changeId, $request->get('type'));
 
+            // Сначала впуск (skip бросит исключение, если билет уже был пропущен/не найден),
+            // и только при успехе — +1 в отчёт смены. Иначе повторный впуск накручивал счётчик.
             $this->enterTicket->skip(
                 $request->get('type'),
                 (int)$request->get('id'),
                 $changeId,
             );
+
+            $this->addTicketsInReport->increment($changeId, $request->get('type'));
 
             return Redirect::route('tickets.search', [
                 'q' => $request->get('q'),

--- a/Baza/routes/api.php
+++ b/Baza/routes/api.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Http\Controllers\Api\ScanController;
-use App\Http\Controllers\Api\TicketsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -20,5 +18,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('scan', [ScanController::class, 'search'])->name('tickets.scan.search');
-Route::post('enter', [ScanController::class, 'enter'])->name('tickets.scan.enter');
+// Маршруты сканирования и впуска (POST /api/scan, /api/enter) перенесены в routes/web.php
+// под middleware('auth'): группа `api` не стартует сессию, поэтому раньше эндпоинты были
+// фактически без авторизации, а id сотрудника брался из тела запроса. Теперь они под
+// web-группой (сессия + CSRF) и auth — см. routes/web.php.

--- a/Baza/routes/web.php
+++ b/Baza/routes/web.php
@@ -62,6 +62,14 @@ Route::get('/scan', [ScanController::class, 'scanPage'])->name('tickets.scan');
 Route::get('/search', [SearchController::class, 'searchPage'])->name('tickets.search');
 Route::post('/enterForTable', [SearchController::class, 'enterForTable'])->name('tickets.scan.enterForTable');
 
+// Сканирование QR и впуск гостя (AJAX из scan.blade.php). Перенесено из routes/api.php
+// под middleware('auth'): web-группа стартует сессию + проверяет CSRF (_token уже шлёт фронт),
+// поэтому id сотрудника берётся из сессии (Auth::id()), а не из тела запроса.
+Route::middleware('auth')->group(function () {
+    Route::post('/api/scan', [\App\Http\Controllers\Api\ScanController::class, 'search'])->name('tickets.scan.search');
+    Route::post('/api/enter', [\App\Http\Controllers\Api\ScanController::class, 'enter'])->name('tickets.scan.enter');
+});
+
 // changes
 Route::get('/report', [ChangesController::class, 'report'])->name('changes.report')->middleware('admin');
 Route::get('/change/edit/{id?}', [ChangesController::class, 'viewAddChange'])->name('changes.edit')->middleware('admin');

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlAutoTicket.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlAutoTicket.php
@@ -25,6 +25,14 @@ class InMemoryMySqlAutoTicket implements AutoTicketRepositoryInterface
     {
         $rawData = $this->model::whereId($id)->first();
 
+        // Серверная защита от повторного впуска (см. InMemoryMySqlElTicket::skip).
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
+
         DB::beginTransaction();
         try {
             $rawData->change_id = $userId;

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlElTicket.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlElTicket.php
@@ -11,6 +11,10 @@ use Throwable;
 
 class InMemoryMySqlElTicket implements ElTicketsRepositoryInterface
 {
+    // UUID текущего фестиваля зашит прямо в коде — фильтр, чтобы на входе показывались
+    // билеты только актуального события. Дублируется в Spisok/Friendly/Auto-репозиториях,
+    // в SaveChange и в отчёте смен. В Live и Parking фильтра по festival_id НЕТ вообще.
+    // Кандидат на вынос в конфиг/env — меняется каждый фестиваль. См. .claude/docs/BAZA.md §9.
     private const UUID_FESTIVAL = '9d679bcf-b438-4ddb-ac04-023fa9bff4b8';
 
     public function __construct(
@@ -45,12 +49,30 @@ class InMemoryMySqlElTicket implements ElTicketsRepositoryInterface
     }
 
     /**
+     * Пометить билет впущенным на КПП.
+     *
+     * ВНИМАНИЕ: параметр $userId на деле — это changeId (id открытой смены), а НЕ id
+     * пользователя. Он пишется в колонку change_id, которая одновременно служит флагом
+     * «гость впущен» (NULL = ещё не входил). Имя параметра вводит в заблуждение —
+     * кандидат на переименование в $changeId.
+     * Билет здесь ищется по kilter (число из QR), тогда как search() — по uuid: разные ключи.
+     *
      * @throws Throwable
      */
     public function skip(int $id, int $userId): bool
     {
         $rawData = $this->addFestivalUuid()->whereKilter($id)
             ->first();
+
+        // Серверная защита от повторного впуска: билет должен существовать и ещё не быть
+        // пропущенным (date_change пуст). Раньше проверка жила только на фронте — повторный
+        // запрос перезаписывал отметку и накручивал счётчик смены.
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
 
         DB::beginTransaction();
         try {

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlFriendlyTicket.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlFriendlyTicket.php
@@ -44,6 +44,14 @@ class InMemoryMySqlFriendlyTicket implements FriendlyTicketRepositoryInterface
             ->whereFestivalId(self::UUID_FESTIVAL)
             ->first();
 
+        // Серверная защита от повторного впуска (см. InMemoryMySqlElTicket::skip).
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
+
         DB::beginTransaction();
         try {
             $rawData->change_id = $userId;

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlLiveTicket.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlLiveTicket.php
@@ -39,6 +39,14 @@ class InMemoryMySqlLiveTicket implements LiveTicketRepositoryInterface
     {
         $rawData = $this->liveTicketModel::whereKilter($id)->first();
 
+        // Серверная защита от повторного впуска (см. InMemoryMySqlElTicket::skip).
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
+
         DB::beginTransaction();
         try {
             $rawData->change_id = $userId;

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlParkingTicketRepository.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlParkingTicketRepository.php
@@ -41,6 +41,14 @@ class InMemoryMySqlParkingTicketRepository implements ParkingTicketRepositoryInt
         $rawData = $this->model::whereId($id)
             ->first();
 
+        // Серверная защита от повторного впуска (см. InMemoryMySqlElTicket::skip).
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
+
         DB::beginTransaction();
         try {
             $rawData->change_id = $userId;

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlSpisokTicket.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlSpisokTicket.php
@@ -45,6 +45,14 @@ class InMemoryMySqlSpisokTicket implements SpisokTicketsRepositoryInterface
             ->where('festival_id', '=', self::UUID_FESTIVAL)
             ->first();
 
+        // Серверная защита от повторного впуска (см. InMemoryMySqlElTicket::skip).
+        if ($rawData === null) {
+            throw new \DomainException('Билет не найден в Базе входа');
+        }
+        if ($rawData->date_change !== null) {
+            throw new \DomainException('Билет уже был пропущен ' . $rawData->date_change);
+        }
+
         DB::beginTransaction();
         try {
             $rawData->change_id = $userId;

--- a/Baza/tests/Feature/EnterTicketSecurityTest.php
+++ b/Baza/tests/Feature/EnterTicketSecurityTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\ChangesModel;
+use App\Models\ElTicketsModel;
+use App\Models\User;
+use Baza\Shared\Services\DefineService;
+use Database\Seeders\ChangesTestDataSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Security-тесты впуска на КПП (Baza, фикс A2).
+ *
+ * Проверяют, что после фикса:
+ *  - POST /api/scan и /api/enter требуют аутентификации (раньше были без auth);
+ *  - смена берётся по залогиненному сотруднику (Auth::id()), а НЕ по user_id из тела;
+ *  - повторный впуск того же билета отклоняется и НЕ накручивает счётчик смены.
+ *
+ * Используют отдельную БД `baza_test` (см. phpunit.xml). ChangesTestDataSeeder
+ * создаёт пользователя id=1 (Admin) и одну открытую смену id=1 (festival_id = FESTIVAL_ID,
+ * count_el_tickets = 5).
+ */
+class EnterTicketSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const KILTER = 770077;
+    private const FESTIVAL_ID = ChangesTestDataSeeder::FESTIVAL_ID;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CSRF — отдельный слой защиты (фронт шлёт _token). В этих тестах проверяем
+        // именно auth + защиту от двойного впуска, поэтому CSRF отключаем, чтобы он не
+        // перехватывал запрос раньше auth-middleware (иначе вернётся 419 вместо 401).
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+        $this->seed(ChangesTestDataSeeder::class);
+    }
+
+    /**
+     * Создаёт электронный билет того же фестиваля, что и открытая смена,
+     * ещё не пропущенный (date_change = null).
+     */
+    private function createElTicket(string $status = 'paid'): void
+    {
+        DB::table('el_tickets')->insert([
+            'kilter'      => self::KILTER,
+            'uuid'        => '11111111-1111-1111-1111-111111111111',
+            'city'        => 'Москва',
+            'name'        => 'Тест Гость',
+            'email'       => 'guest@example.com',
+            'phone'       => '+70000000000',
+            'date_order'  => now(),
+            'status'      => $status,
+            'type_ticket' => 'Электронный',
+            'type_ticket_id' => '22222222-2222-2222-2222-222222222222',
+            'is_need_seedling' => 0,
+            'change_id'   => null,
+            'date_change' => null,
+            'festival_id' => self::FESTIVAL_ID,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+    }
+
+    public function test_scan_requires_authentication(): void
+    {
+        $this->postJson('/api/scan', ['search' => 'https://org.spaceofjoy.ru/newTickets/x'])
+            ->assertUnauthorized();
+    }
+
+    public function test_enter_requires_authentication(): void
+    {
+        $this->createElTicket();
+
+        $this->postJson('/api/enter', [
+            'type' => DefineService::ELECTRON_TICKET,
+            'id'   => self::KILTER,
+        ])->assertUnauthorized();
+
+        // Билет не должен быть помечен впущенным неавторизованным запросом.
+        self::assertNull(ElTicketsModel::whereKilter(self::KILTER)->first()->date_change);
+    }
+
+    public function test_authenticated_enter_marks_ticket_and_increments_report_once(): void
+    {
+        $this->createElTicket();
+        // Берём смену динамически: MySQL не откатывает auto-increment между тестами,
+        // поэтому id смены из сидера не обязательно равен 1.
+        $change = ChangesModel::query()->first();
+        $before = $change->count_el_tickets;
+
+        $this->actingAs(User::find(1))
+            ->postJson('/api/enter', [
+                'type' => DefineService::ELECTRON_TICKET,
+                'id'   => self::KILTER,
+            ])
+            ->assertOk();
+
+        $ticket = ElTicketsModel::whereKilter(self::KILTER)->first();
+        self::assertNotNull($ticket->date_change, 'Билет должен быть помечен впущенным');
+        self::assertSame($change->id, (int) $ticket->change_id, 'change_id = id открытой смены сотрудника');
+        self::assertSame($before + 1, ChangesModel::find($change->id)->count_el_tickets, 'Счётчик смены +1');
+    }
+
+    public function test_double_entry_is_rejected_and_report_not_inflated(): void
+    {
+        $this->createElTicket();
+        $change = ChangesModel::query()->first();
+
+        $this->actingAs(User::find(1))
+            ->postJson('/api/enter', [
+                'type' => DefineService::ELECTRON_TICKET,
+                'id'   => self::KILTER,
+            ])
+            ->assertOk();
+
+        $afterFirst = ChangesModel::find($change->id)->count_el_tickets;
+
+        // Повторный впуск того же билета — отклонён, счётчик НЕ растёт.
+        $this->actingAs(User::find(1))
+            ->postJson('/api/enter', [
+                'type' => DefineService::ELECTRON_TICKET,
+                'id'   => self::KILTER,
+            ])
+            ->assertStatus(422);
+
+        self::assertSame(
+            $afterFirst,
+            ChangesModel::find($change->id)->count_el_tickets,
+            'Повторный впуск не должен накручивать счётчик смены'
+        );
+    }
+
+    public function test_enter_uses_session_user_not_body_user_id(): void
+    {
+        $this->createElTicket();
+
+        // В теле подсунут несуществующий user_id=999 (у него нет открытой смены).
+        // Если бы сервер доверял телу — getCurrentChanges бросил бы «смена не найдена» (422).
+        // Должен использоваться Auth::id() = 1 → впуск успешен.
+        $this->actingAs(User::find(1))
+            ->postJson('/api/enter', [
+                'type'    => DefineService::ELECTRON_TICKET,
+                'id'      => self::KILTER,
+                'user_id' => 999,
+            ])
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
## Что и зачем

Security-фикс впуска на КПП в Baza (решение владельца «A2 — чиним»). Закрывает две дыры, найденные при разборе системы Baza:

1. **Эндпоинты впуска были без авторизации.** `POST /api/scan` и `POST /api/enter` жили в группе `api` (без сессии и без `auth`), а id сотрудника приходил из тела запроса (`user_id`). Любой мог дёрнуть впуск.
2. **Двойной впуск + накрутка отчёта.** Сервер не проверял, что билет уже был пропущен (`date_change`), и `increment` отчёта смены шёл **до** `skip`. Повторный/реплейный запрос перезаписывал отметку и снова добавлял +1 к счётчику смены. Защита «уже впущен» жила только на фронте.

## Изменения

- `/api/scan` и `/api/enter` перенесены из `routes/api.php` в `routes/web.php` под `middleware('auth')` (web-группа стартует сессию + проверяет CSRF; фронт `scan.blade.php` уже шлёт `_token` и куки — вызовы не ломаются). В `enter()` id сотрудника берётся из `Auth::id()`, а не из тела.
- В каждом из 6 репозиториев билетов (`el / spisok / live / parking / auto / friendly`) `skip()` теперь проверяет: билет существует и `date_change` ещё пуст — иначе `DomainException` (серверная защита от повторного впуска).
- В `ScanController::enter` и `SearchController::enterForTable` инкремент отчёта смены перенесён **после** успешного `skip` — повторный впуск больше не накручивает счётчик.

## Тесты

`tests/Feature/EnterTicketSecurityTest.php`:
- `/api/scan` и `/api/enter` требуют аутентификации;
- впуск помечает билет и инкрементит отчёт ровно один раз;
- повторный впуск того же билета отклонён (422) и не накручивает счётчик;
- смена берётся из сессии (`Auth::id()`), а не из тела (`user_id` в теле игнорируется).

**PHPUnit Baza: 13/13 зелёный** (локально, БД `baza_test`).

## Совместимость

Фронт (единственный потребитель `/api/scan`+`/api/enter`) не меняется: он уже шлёт `_token` и работает в сессии. Имена маршрутов сохранены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
