### PR TITLE
feat(baza): VO ролей смены + защищаемых действий (Ф2 PR-1)

### DIFF
--- a/Baza/scr/Shared/Domain/ValueObject/ShiftPermission.php
+++ b/Baza/scr/Shared/Domain/ValueObject/ShiftPermission.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Shared\Domain\ValueObject;
+
+/**
+ * Каталог защищаемых действий КПП — ось 2 матрицы прав «роль × действие» (Ф2).
+ *
+ * Пассивный enum-хелпер (без БД). Наличие строки (role, action) в
+ * baza_role_permissions = право есть; отсутствие = запрет. administrator —
+ * суперроль (короткозамкнута в коде, в таблицу не пишется).
+ *
+ * profile.* / login / logout — ВНЕ матрицы (доступны любому авторизованному).
+ */
+final class ShiftPermission
+{
+    public const TICKET_SCAN = 'ticket.scan';
+    public const TICKET_SEARCH = 'ticket.search';
+    public const TICKET_ENTER = 'ticket.enter';
+    public const REPORT_VIEW = 'report.view';
+    public const SHIFT_COMPOSE = 'shift.compose';
+    public const SHIFT_CLOSE = 'shift.close';
+    public const SHIFT_REMOVE = 'shift.remove';
+    public const SYNC_MANAGE = 'sync.manage';
+    public const FINANCE_VIEW = 'finance.view'; // зарезервировано под Ф7 (финансы смены)
+    public const RBAC_MANAGE = 'rbac.manage';
+
+    public const LABELS = [
+        self::TICKET_SCAN => 'Сканирование билета',
+        self::TICKET_SEARCH => 'Ручной поиск билета',
+        self::TICKET_ENTER => 'Впуск гостя',
+        self::REPORT_VIEW => 'Просмотр отчёта/смен',
+        self::SHIFT_COMPOSE => 'Формирование состава смены',
+        self::SHIFT_CLOSE => 'Закрытие смены',
+        self::SHIFT_REMOVE => 'Удаление смены',
+        self::SYNC_MANAGE => 'Синхронизация (экспорт/импорт)',
+        self::FINANCE_VIEW => 'Просмотр финансов смены',
+        self::RBAC_MANAGE => 'Управление матрицей прав',
+    ];
+
+    /**
+     * @return string[] коды всех действий
+     */
+    public static function all(): array
+    {
+        return array_keys(self::LABELS);
+    }
+
+    public static function isValid(string $action): bool
+    {
+        return isset(self::LABELS[$action]);
+    }
+
+    public static function label(string $action): string
+    {
+        return self::LABELS[$action] ?? $action;
+    }
+
+    /**
+     * Каталог для строк редактора матрицы прав.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function catalog(): array
+    {
+        return array_map(
+            static fn (string $code): array => ['value' => $code, 'label' => self::LABELS[$code]],
+            self::all()
+        );
+    }
+}

--- a/Baza/scr/Shared/Domain/ValueObject/ShiftRole.php
+++ b/Baza/scr/Shared/Domain/ValueObject/ShiftRole.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Shared\Domain\ValueObject;
+
+/**
+ * Каталог 5 ролей в рамках смены КПП (Ф2).
+ *
+ * Пассивный enum-хелпер (без БД), по образцу Status. Коды латиницей —
+ * для middleware/матрицы прав (baza_role_permissions); русские метки — для UI.
+ * administrator — суперроль (в матрице прав короткозамкнута в коде).
+ */
+final class ShiftRole
+{
+    public const ADMINISTRATOR = 'administrator';
+    public const SHIFT_CHIEF = 'shift_chief';
+    public const TICKETER = 'ticketer';
+    public const KPP_COMMANDANT = 'kpp_commandant';
+    public const GUARD = 'guard';
+
+    public const LABELS = [
+        self::ADMINISTRATOR => 'Администратор',
+        self::SHIFT_CHIEF => 'Начальник смены',
+        self::TICKETER => 'Билетёр',
+        self::KPP_COMMANDANT => 'Комендант КПП',
+        self::GUARD => 'Охранник',
+    ];
+
+    /**
+     * @return string[] коды всех ролей
+     */
+    public static function all(): array
+    {
+        return array_keys(self::LABELS);
+    }
+
+    public static function isValid(string $role): bool
+    {
+        return isset(self::LABELS[$role]);
+    }
+
+    public static function label(string $role): string
+    {
+        return self::LABELS[$role] ?? $role;
+    }
+
+    /**
+     * Каталог для селектора в UI.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function catalog(): array
+    {
+        return array_map(
+            static fn (string $code): array => ['value' => $code, 'label' => self::LABELS[$code]],
+            self::all()
+        );
+    }
+
+    /**
+     * Мягкий маппинг текущего пользователя на роль (переходный период Ф2):
+     * явная глобальная роль users.role, иначе is_admin → administrator / ticketer.
+     * Сохраняет текущий вход: is_admin=true → administrator (полный доступ).
+     */
+    public static function fromUser(bool $isAdmin, ?string $role = null): string
+    {
+        if ($role !== null && self::isValid($role)) {
+            return $role;
+        }
+
+        return $isAdmin ? self::ADMINISTRATOR : self::TICKETER;
+    }
+}

--- a/Baza/tests/Unit/ShiftPermissionTest.php
+++ b/Baza/tests/Unit/ShiftPermissionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Тесты VO защищаемых действий (ось 2 матрицы прав, Baza, Ф2 PR-1).
+ */
+class ShiftPermissionTest extends TestCase
+{
+    public function test_all_contains_key_actions(): void
+    {
+        $all = ShiftPermission::all();
+
+        self::assertContains(ShiftPermission::TICKET_ENTER, $all);
+        self::assertContains(ShiftPermission::REPORT_VIEW, $all);
+        self::assertContains(ShiftPermission::SYNC_MANAGE, $all);
+        self::assertContains(ShiftPermission::RBAC_MANAGE, $all);
+        self::assertContains(ShiftPermission::FINANCE_VIEW, $all);
+    }
+
+    public function test_is_valid(): void
+    {
+        self::assertTrue(ShiftPermission::isValid('sync.manage'));
+        self::assertFalse(ShiftPermission::isValid('sync.delete_everything'));
+        self::assertFalse(ShiftPermission::isValid(''));
+    }
+
+    public function test_label(): void
+    {
+        self::assertSame('Синхронизация (экспорт/импорт)', ShiftPermission::label(ShiftPermission::SYNC_MANAGE));
+        self::assertSame('unknown.action', ShiftPermission::label('unknown.action'));
+    }
+
+    public function test_catalog_shape(): void
+    {
+        $catalog = ShiftPermission::catalog();
+
+        self::assertSame(count(ShiftPermission::all()), count($catalog));
+        self::assertSame(['value', 'label'], array_keys($catalog[0]));
+    }
+
+    public function test_codes_use_dot_namespacing(): void
+    {
+        // Коды действий — в формате group.action (для читаемого permission:<action>)
+        foreach (ShiftPermission::all() as $code) {
+            self::assertMatchesRegularExpression('/^[a-z]+\.[a-z_]+$/', $code, "Код '$code' должен быть group.action");
+        }
+    }
+}

--- a/Baza/tests/Unit/ShiftRoleTest.php
+++ b/Baza/tests/Unit/ShiftRoleTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Тесты VO ролей смены (Baza, Ф2 PR-1).
+ */
+class ShiftRoleTest extends TestCase
+{
+    public function test_all_returns_five_roles(): void
+    {
+        self::assertCount(5, ShiftRole::all());
+        self::assertContains(ShiftRole::ADMINISTRATOR, ShiftRole::all());
+        self::assertContains(ShiftRole::SHIFT_CHIEF, ShiftRole::all());
+        self::assertContains(ShiftRole::TICKETER, ShiftRole::all());
+        self::assertContains(ShiftRole::KPP_COMMANDANT, ShiftRole::all());
+        self::assertContains(ShiftRole::GUARD, ShiftRole::all());
+    }
+
+    public function test_is_valid(): void
+    {
+        self::assertTrue(ShiftRole::isValid('shift_chief'));
+        self::assertFalse(ShiftRole::isValid('superuser'));
+        self::assertFalse(ShiftRole::isValid(''));
+    }
+
+    public function test_label(): void
+    {
+        self::assertSame('Начальник смены', ShiftRole::label(ShiftRole::SHIFT_CHIEF));
+        // неизвестный код возвращается как есть (без исключения)
+        self::assertSame('unknown', ShiftRole::label('unknown'));
+    }
+
+    public function test_catalog_shape(): void
+    {
+        $catalog = ShiftRole::catalog();
+
+        self::assertCount(5, $catalog);
+        self::assertSame(['value', 'label'], array_keys($catalog[0]));
+        self::assertSame(ShiftRole::ADMINISTRATOR, $catalog[0]['value']);
+        self::assertSame('Администратор', $catalog[0]['label']);
+    }
+
+    public function test_from_user_maps_is_admin(): void
+    {
+        // Сохранение текущего входа: is_admin=true → administrator, false → ticketer
+        self::assertSame(ShiftRole::ADMINISTRATOR, ShiftRole::fromUser(true));
+        self::assertSame(ShiftRole::TICKETER, ShiftRole::fromUser(false));
+    }
+
+    public function test_explicit_role_overrides_is_admin_mapping(): void
+    {
+        self::assertSame(ShiftRole::GUARD, ShiftRole::fromUser(false, ShiftRole::GUARD));
+        self::assertSame(ShiftRole::SHIFT_CHIEF, ShiftRole::fromUser(true, ShiftRole::SHIFT_CHIEF));
+    }
+
+    public function test_invalid_explicit_role_falls_back_to_is_admin_mapping(): void
+    {
+        self::assertSame(ShiftRole::ADMINISTRATOR, ShiftRole::fromUser(true, 'bogus'));
+        self::assertSame(ShiftRole::TICKETER, ShiftRole::fromUser(false, 'bogus'));
+    }
+}


### PR DESCRIPTION
**Ф2 PR-1** — фундамент RBAC (нулевой риск: только enum-хелперы, без БД/энфорсмента, вход не затрагивается).

- `ShiftRole` — 5 ролей смены (administrator/shift_chief/ticketer/kpp_commandant/guard) + метки RU + `catalog()` + `fromUser()` (мягкий маппинг is_admin→роль, сохраняет текущий вход).
- `ShiftPermission` — каталог действий (ось 2 матрицы прав «роль × действие»): ticket.scan/search/enter, report.view, shift.compose/close/remove, sync.manage, finance.view (зарезервировано под Ф7), rbac.manage.

Решение владельца: матрица — **2 оси** (роль × действие). Готовит дизайн-контракт под незаконченную org-матрицу (`.claude/specs/admin-rbac.md`), без cross-schema.

Тесты: ShiftRoleTest (7) + ShiftPermissionTest (5). **Полный Baza-сьют 39/39.**
Спека: `.claude/specs/baza-f2-roles-rbac.md` (PR #92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)