### PR TITLE
feat(baza): change_user + двойная запись состава смены (Ф2 PR-2)

### DIFF
--- a/Baza/app/Models/ChangeUserModel.php
+++ b/Baza/app/Models/ChangeUserModel.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Участник смены с ролью (Ф2) — строка на каждого участника смены.
+ *
+ * role — код из Baza\Shared\Domain\ValueObject\ShiftRole. Сразу в $fillable
+ * (иначе через create()/fill() молча не сохранится — урок count_auto_tickets/
+ * is_admin, см. BAZA.md §6).
+ *
+ * @property int $id
+ * @property int $change_id
+ * @property int $user_id
+ * @property string $role
+ */
+class ChangeUserModel extends Model
+{
+    protected $table = self::TABLE;
+
+    public const TABLE = 'change_user';
+
+    protected $fillable = [
+        'change_id',
+        'user_id',
+        'role',
+    ];
+
+    protected $casts = [
+        'change_id' => 'integer',
+        'user_id' => 'integer',
+    ];
+}

--- a/Baza/database/migrations/2026_06_19_170000_create_change_user_table.php
+++ b/Baza/database/migrations/2026_06_19_170000_create_change_user_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Состав смены с ролями (Ф2).
+ *
+ * Двойная запись параллельно changes.user_id (JSON): на переходный период
+ * читающие экраны (getChangeId/getAllReport) используют старый JSON, а change_user
+ * наполняется для будущего RBAC/UI (PR-4..6). Вход НЕ меняется.
+ *
+ * Без FK — целостность на уровне приложения (паттерн Baza). Schema::hasTable()
+ * — на случай ручного создания таблицы на проде (паттерн 2026_05_29_180000).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('change_user')) {
+            return;
+        }
+
+        Schema::create('change_user', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('change_id')->index();
+            $table->unsignedBigInteger('user_id')->index();
+            $table->string('role', 40); // код из Baza\Shared\Domain\ValueObject\ShiftRole
+            $table->timestamps();
+
+            // один человек в смене ровно один раз
+            $table->unique(['change_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('change_user');
+    }
+};

--- a/Baza/scr/Changes/Repositories/InMemoryMySqlChangesRepository.php
+++ b/Baza/scr/Changes/Repositories/InMemoryMySqlChangesRepository.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Baza\Changes\Repositories;
 
 use App\Models\ChangesModel;
+use App\Models\ChangeUserModel;
+use App\Models\User;
 use Baza\Changes\Applications\Report\ReportForChangesDto;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
 use Carbon\Carbon;
 use DB;
 use Nette\Utils\Json;
@@ -80,16 +83,62 @@ group by `changes`.`id`", [
 
     public function updateOrCreate(array $userList, Carbon $start, string $festivalId, ?int $id = null): bool
     {
-        if (!is_null($id)) {
-            $model = $this->model::find($id);
-        } else {
-            $model = $this->model;
-        }
-        $model->user_id = Json::encode($userList);
-        $model->festival_id = $festivalId;
-        $model->start = $start;
+        return DB::transaction(function () use ($userList, $start, $festivalId, $id) {
+            // Дедуп состава: один человек в смене ровно один раз. Защита от кривого
+            // POST compound[] с дублем — иначе UNIQUE(change_id,user_id) в change_user
+            // уронил бы сохранение. JSON и change_user пишем одинаковым составом.
+            $userList = array_values(array_unique(array_map('intval', $userList)));
 
-        return $model->save();
+            if (!is_null($id)) {
+                $model = $this->model::find($id);
+            } else {
+                $model = $this->model;
+            }
+            $model->user_id = Json::encode($userList);
+            $model->festival_id = $festivalId;
+            $model->start = $start;
+
+            if (!$model->save()) {
+                return false;
+            }
+
+            // Двойная запись (Ф2): состав смены с ролями в change_user — параллельно
+            // changes.user_id JSON выше. Читающие экраны пока используют JSON → вход цел.
+            $this->syncChangeUsers((int) $model->id, $userList);
+
+            return true;
+        });
+    }
+
+    /**
+     * Пересобирает состав change_user для смены (delete старые → insert текущие).
+     * Роль участника — производная (ShiftRole::fromUser по is_admin); явное
+     * назначение ролей и главного смены делается из UI в PR-6.
+     *
+     * @param int[] $userList
+     */
+    private function syncChangeUsers(int $changeId, array $userList): void
+    {
+        ChangeUserModel::where('change_id', $changeId)->delete();
+
+        if ($userList === []) {
+            return;
+        }
+
+        $users = User::whereIn('id', array_map('intval', $userList))
+            ->get(['id', 'is_admin'])
+            ->keyBy('id');
+
+        foreach ($userList as $userId) {
+            $userId = (int) $userId;
+            $user = $users->get($userId);
+
+            ChangeUserModel::create([
+                'change_id' => $changeId,
+                'user_id'   => $userId,
+                'role'      => ShiftRole::fromUser((bool) ($user?->is_admin ?? false)),
+            ]);
+        }
     }
 
     /**
@@ -102,6 +151,13 @@ group by `changes`.`id`", [
 
     public function remove(int $id): bool
     {
-        return $this->model::find($id)->delete($id);
+        return DB::transaction(function () use ($id) {
+            // Нет FK/каскада → состав смены чистим явно, иначе осиротевшие строки (Ф2).
+            ChangeUserModel::where('change_id', $id)->delete();
+
+            $model = $this->model::find($id);
+
+            return $model !== null && (bool) $model->delete();
+        });
     }
 }

--- a/Baza/tests/Feature/ChangeUserDoubleWriteTest.php
+++ b/Baza/tests/Feature/ChangeUserDoubleWriteTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\ChangesModel;
+use App\Models\ChangeUserModel;
+use Baza\Changes\Applications\SaveChange\SaveChange;
+use Baza\Changes\Repositories\ChangesRepositoryInterface;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Carbon\Carbon;
+use Database\Seeders\UsersTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nette\Utils\Json;
+use Tests\TestCase;
+
+/**
+ * Тесты двойной записи состава смены в change_user (Baza, Ф2 PR-2).
+ *
+ * Сохранение смены (SaveChange) пишет состав И в changes.user_id (JSON, старый
+ * путь — вход/отчёты не ломаются), И в change_user (новая таблица с ролями).
+ * Роль производная (ShiftRole::fromUser по is_admin) — явное назначение в PR-6.
+ *
+ * БД baza_test (phpunit.xml). UsersTableSeeder: id=1 admin (is_admin=true),
+ * id=3 обычный (is_admin=false).
+ */
+class ChangeUserDoubleWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(UsersTableSeeder::class);
+    }
+
+    public function test_save_double_writes_change_user_with_derived_roles(): void
+    {
+        app(SaveChange::class)->save([1, 3], Carbon::now());
+
+        $change = ChangesModel::query()->latest('id')->first();
+        self::assertNotNull($change);
+
+        // старый путь цел: changes.user_id JSON содержит обоих
+        $ids = array_map('intval', (array) Json::decode($change->user_id));
+        self::assertEqualsCanonicalizing([1, 3], $ids);
+
+        // двойная запись: change_user строки с производными ролями
+        $rows = ChangeUserModel::where('change_id', $change->id)->get()->keyBy('user_id');
+        self::assertCount(2, $rows);
+        self::assertSame(ShiftRole::ADMINISTRATOR, $rows[1]->role, 'is_admin=true → administrator');
+        self::assertSame(ShiftRole::TICKETER, $rows[3]->role, 'is_admin=false → ticketer');
+    }
+
+    public function test_remove_deletes_change_user_rows(): void
+    {
+        app(SaveChange::class)->save([1, 3], Carbon::now());
+        $change = ChangesModel::query()->latest('id')->first();
+        self::assertSame(2, ChangeUserModel::where('change_id', $change->id)->count());
+
+        app(ChangesRepositoryInterface::class)->remove($change->id);
+
+        self::assertSame(0, ChangeUserModel::where('change_id', $change->id)->count(), 'нет осиротевших change_user');
+        self::assertNull(ChangesModel::find($change->id));
+    }
+
+    public function test_get_change_id_still_resolves_active_shift(): void
+    {
+        app(SaveChange::class)->save([1], Carbon::now());
+        $change = ChangesModel::query()->latest('id')->first();
+
+        self::assertSame($change->id, app(ChangesRepositoryInterface::class)->getChangeId(1));
+    }
+
+    public function test_resave_replaces_change_user_rows(): void
+    {
+        app(SaveChange::class)->save([1, 3], Carbon::now());
+        $change = ChangesModel::query()->latest('id')->first();
+
+        // пересохранить ту же смену с другим составом (по id)
+        app(SaveChange::class)->save([3], Carbon::now(), $change->id);
+
+        $rows = ChangeUserModel::where('change_id', $change->id)->get();
+        self::assertCount(1, $rows, 'старый состав заменён, без дублей');
+        self::assertSame(3, (int) $rows->first()->user_id);
+    }
+
+    public function test_duplicate_user_id_in_compound_is_deduped_not_fatal(): void
+    {
+        // Кривой POST compound[] с дублем не должен ронять сохранение (UNIQUE):
+        // состав дедуплицируется одинаково в JSON и в change_user.
+        app(SaveChange::class)->save([1, 1, 3], Carbon::now());
+
+        $change = ChangesModel::query()->latest('id')->first();
+        self::assertNotNull($change);
+
+        self::assertSame(1, ChangeUserModel::where('change_id', $change->id)->where('user_id', 1)->count());
+        self::assertSame(2, ChangeUserModel::where('change_id', $change->id)->count(), 'дубль схлопнут');
+
+        $ids = array_map('intval', (array) Json::decode($change->user_id));
+        self::assertEqualsCanonicalizing([1, 3], $ids, 'JSON тоже дедуплицирован');
+    }
+}


### PR DESCRIPTION
**Ф2 PR-2** — состав смены пишется в новую таблицу `change_user` (роль на участника) **параллельно** старому `changes.user_id` (JSON). Читающие экраны (getChangeId/getAllReport) остаются на JSON → вход/отчёты/счётчики НЕ меняются.

- Миграция `change_user(change_id, user_id, role, UNIQUE(change_id,user_id))`, без FK, `Schema::hasTable()` guard. Модель `ChangeUserModel` (role в fillable).
- `updateOrCreate` — в транзакции: JSON + пересбор change_user (delete→insert) с производной ролью (`ShiftRole::fromUser` по is_admin; явное назначение ролей/главного — PR-6 UI).
- `remove()` чистит change_user (нет FK/каскада).

Контракт `SaveChange` НЕ менялся → контроллер/форма/фабрика/сидеры не тронуты; инвариант главного отложен в PR-6 (с UI). **Полный Baza-сьют 43/43.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)