### PR TITLE
feat(baza): users.role + мягкий маппинг роли (Ф2 PR-3)

### DIFF
--- a/Baza/app/Console/Commands/CreateUserCommand.php
+++ b/Baza/app/Console/Commands/CreateUserCommand.php
@@ -42,7 +42,7 @@ class CreateUserCommand extends Command
             return Command::FAILURE;
         }
 
-        /** @var array<int, array{0:string, 1:string, 2:string, 3?:bool}> $rows */
+        /** @var array<int, array{0:string, 1:string, 2:string, 3?:bool, 4?:string}> $rows */
         $rows = require $path;
 
         $users = array_map(
@@ -51,6 +51,7 @@ class CreateUserCommand extends Command
                 'name'     => $row[1],
                 'password' => $row[2],
                 'is_admin' => (bool) ($row[3] ?? false),
+                'role'     => $row[4] ?? null, // опц. роль смены (ShiftRole); невалидную репозиторий игнорирует
             ],
             $rows
         );

--- a/Baza/app/Models/User.php
+++ b/Baza/app/Models/User.php
@@ -24,6 +24,7 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @property string $name
  * @property string $email
  * @property boolean $is_admin
+ * @property string|null $role
  * @property Carbon|null $email_verified_at
  * @property string $password
  * @property string|null $remember_token
@@ -61,12 +62,16 @@ use Laravel\Sanctum\PersonalAccessToken;
  * Роль определяется единственным булевым флагом is_admin (плоская модель прав):
  *   true  — администратор (отчёты по сменам + синхронизация данных, см. middleware 'admin');
  *   false — обычный сотрудник (сканер + поиск + впуск).
- * Заметь: is_admin сознательно НЕ в $fillable — его нельзя выставить через mass-assignment,
- * только напрямую/сидером. Вход — сессионный (web guard), JWT в Baza нет
- * (Sanctum подключён к модели, но боевого входа по API-токену в роутах нет).
+ * Заметь: is_admin (и добавленное в Ф2 поле role) сознательно НЕ в $fillable —
+ * их нельзя выставить через mass-assignment, только напрямую/сидером. Вход —
+ * сессионный (web guard), JWT в Baza нет (Sanctum подключён к модели, но боевого
+ * входа по API-токену в роутах нет).
  *
- * Грядущий апдейт заменит этот флаг на полноценные роли (Администратор / Начальник смены /
- * Билетёр / Ответственный за приём смены / Охранник) — см. .claude/docs/BAZA.md §8 и §11.
+ * Ф2 (в процессе): добавлено nullable-поле `role` — глобальная роль смены
+ * (коды ShiftRole: administrator / shift_chief / ticketer / kpp_commandant / guard).
+ * is_admin пока НЕ удаляем — мягкий маппинг ShiftRole::fromUser(is_admin, role):
+ * явная role перекрывает, иначе is_admin → administrator/ticketer. Полный перевод
+ * прав на роли+матрицу — см. .claude/specs/baza-f2-roles-rbac.md, BAZA.md §8 и §11.
  */
 class User extends Authenticatable
 {

--- a/Baza/database/migrations/2026_06_19_180000_add_role_to_users_table.php
+++ b/Baza/database/migrations/2026_06_19_180000_add_role_to_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Глобальная роль-дефолт пользователя (Ф2).
+ *
+ * Используется в мягком маппинге ShiftRole::fromUser (явная role перекрывает
+ * is_admin-маппинг) для производной роли участника смены. is_admin НЕ удаляем —
+ * вход не ломаем. nullable: пока роль не задана, маппинг идёт по is_admin.
+ *
+ * Schema::hasColumn() guard — на проде Baza колонку могли добавить руками
+ * (паттерн 2026_05_29_180000), иначе миграция упадёт Duplicate column.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'role')) {
+                $table->string('role', 40)->nullable()->after('is_admin');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'role')) {
+                $table->dropColumn('role');
+            }
+        });
+    }
+};

--- a/Baza/database/seeders/StaffUsersSeeder.php
+++ b/Baza/database/seeders/StaffUsersSeeder.php
@@ -35,7 +35,7 @@ class StaffUsersSeeder extends Seeder
             return;
         }
 
-        /** @var array<int, array{0:string, 1:string, 2:string, 3?:bool}> $rows */
+        /** @var array<int, array{0:string, 1:string, 2:string, 3?:bool, 4?:string}> $rows */
         $rows = require $path;
 
         $users = array_map(
@@ -44,6 +44,7 @@ class StaffUsersSeeder extends Seeder
                 'name'     => $row[1],
                 'password' => $row[2],
                 'is_admin' => (bool) ($row[3] ?? false),
+                'role'     => $row[4] ?? null, // опц. роль смены (ShiftRole); невалидную репозиторий игнорирует
             ],
             $rows
         );

--- a/Baza/database/seeders/data/staff_users.example.php
+++ b/Baza/database/seeders/data/staff_users.example.php
@@ -16,7 +16,10 @@ declare(strict_types=1);
 | Идемпотентно: повторный запуск ОБНОВИТ пароли существующих email (по email),
 | не создаст дублей. Пароли здесь — открытым текстом, при заведении хешируются.
 |
-| Формат строки:  [email, имя, пароль, is_admin(bool)]
+| Формат строки:  [email, имя, пароль, is_admin(bool), role(опц.)]
+|   role — код роли смены (ShiftRole): administrator | shift_chief | ticketer |
+|   kpp_commandant | guard. Можно НЕ указывать — тогда роль выведется по is_admin
+|   (true → administrator, false → ticketer). Невалидная роль игнорируется.
 |
 | ВАЖНО (безопасность): staff_users.php НЕ коммитить. Пароли, попавшие в git,
 | считаются скомпрометированными — перед фестивалем выдавай НОВЫЕ.
@@ -24,8 +27,9 @@ declare(strict_types=1);
 */
 
 return [
-    // [email,                     имя,        пароль,        is_admin]
-    ['admin@example.test',         'Админ',     'CHANGE_ME',   true],
-    ['security1@example.test',     'Охрана 1',  'CHANGE_ME',   false],
-    ['ticketer1@example.test',     'Билетёр 1', 'CHANGE_ME',   false],
+    // [email,                     имя,        пароль,        is_admin, role(опц.)]
+    ['admin@example.test',         'Админ',     'CHANGE_ME',   true,     'administrator'],
+    ['chief@example.test',         'Начсмены',  'CHANGE_ME',   false,    'shift_chief'],
+    ['security1@example.test',     'Охрана 1',  'CHANGE_ME',   false,    'guard'],
+    ['ticketer1@example.test',     'Билетёр 1', 'CHANGE_ME',   false], // role опущена → ticketer
 ];

--- a/Baza/scr/Changes/Repositories/InMemoryMySqlChangesRepository.php
+++ b/Baza/scr/Changes/Repositories/InMemoryMySqlChangesRepository.php
@@ -112,8 +112,9 @@ group by `changes`.`id`", [
 
     /**
      * Пересобирает состав change_user для смены (delete старые → insert текущие).
-     * Роль участника — производная (ShiftRole::fromUser по is_admin); явное
-     * назначение ролей и главного смены делается из UI в PR-6.
+     * Роль участника — мягкий маппинг ShiftRole::fromUser: явная глобальная
+     * users.role перекрывает производную по is_admin. Явное назначение ролей
+     * именно в этой смене и выбор главного делается из UI в PR-6.
      *
      * @param int[] $userList
      */
@@ -126,7 +127,7 @@ group by `changes`.`id`", [
         }
 
         $users = User::whereIn('id', array_map('intval', $userList))
-            ->get(['id', 'is_admin'])
+            ->get(['id', 'is_admin', 'role'])
             ->keyBy('id');
 
         foreach ($userList as $userId) {
@@ -136,7 +137,7 @@ group by `changes`.`id`", [
             ChangeUserModel::create([
                 'change_id' => $changeId,
                 'user_id'   => $userId,
-                'role'      => ShiftRole::fromUser((bool) ($user?->is_admin ?? false)),
+                'role'      => ShiftRole::fromUser((bool) ($user?->is_admin ?? false), $user?->role),
             ]);
         }
     }

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlUserRepository.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlUserRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Baza\Tickets\Repositories;
 
 use App\Models\User;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
 
 class InMemoryMySqlUserRepository implements UserRepositoryInterface
 {
@@ -21,7 +22,7 @@ class InMemoryMySqlUserRepository implements UserRepositoryInterface
      * перевыпускать пароли. Теперь updateOrCreate по email: повторный прогон
      * обновляет имя/пароль существующего сотрудника, не создавая дублей.
      *
-     * @param array<int, array{email:string, name:string, password:string, is_admin?:bool}> $dataUsers
+     * @param array<int, array{email:string, name:string, password:string, is_admin?:bool, role?:string}> $dataUsers
      */
     public function createList(array $dataUsers): bool
     {
@@ -34,9 +35,16 @@ class InMemoryMySqlUserRepository implements UserRepositoryInterface
                     'password' => bcrypt($user['password']),
                 ]
             );
-            // is_admin сознательно вне $fillable (защита от mass-assignment) —
+            // is_admin и role сознательно вне $fillable (защита от mass-assignment) —
             // выставляем напрямую, не ослабляя модель.
             $model->is_admin = (bool) ($user['is_admin'] ?? false);
+
+            // Явная глобальная роль смены (опционально). Невалидную игнорируем —
+            // тогда роль выведется по is_admin (ShiftRole::fromUser).
+            if (isset($user['role']) && ShiftRole::isValid((string) $user['role'])) {
+                $model->role = (string) $user['role'];
+            }
+
             $model->save();
         }
 

--- a/Baza/tests/Feature/UserRoleTest.php
+++ b/Baza/tests/Feature/UserRoleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\ChangesModel;
+use App\Models\ChangeUserModel;
+use App\Models\User;
+use Baza\Changes\Applications\SaveChange\SaveChange;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Baza\Tickets\Repositories\UserRepositoryInterface;
+use Carbon\Carbon;
+use Database\Seeders\UsersTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Тесты глобальной роли пользователя users.role + мягкого маппинга (Baza, Ф2 PR-3).
+ *
+ * users.role (nullable) — явная роль смены, перекрывает производную по is_admin
+ * (ShiftRole::fromUser). Заводится сидером/командой (опц. 5-я колонка списка),
+ * читается при пересборке состава смены в change_user. БД baza_test.
+ */
+class UserRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function repo(): UserRepositoryInterface
+    {
+        return app(UserRepositoryInterface::class);
+    }
+
+    public function test_create_list_sets_explicit_valid_role(): void
+    {
+        $this->repo()->createList([
+            ['email' => 'guard@test.local', 'name' => 'Охрана', 'password' => 'p', 'is_admin' => false, 'role' => ShiftRole::GUARD],
+        ]);
+
+        self::assertSame(ShiftRole::GUARD, User::where('email', 'guard@test.local')->first()->role);
+    }
+
+    public function test_create_list_ignores_invalid_role(): void
+    {
+        $this->repo()->createList([
+            ['email' => 'bad@test.local', 'name' => 'Кривой', 'password' => 'p', 'is_admin' => false, 'role' => 'superuser'],
+        ]);
+
+        self::assertNull(User::where('email', 'bad@test.local')->first()->role, 'невалидная роль не записывается');
+    }
+
+    public function test_create_list_without_role_leaves_null(): void
+    {
+        $this->repo()->createList([
+            ['email' => 'norole@test.local', 'name' => 'Без роли', 'password' => 'p', 'is_admin' => true],
+        ]);
+
+        // role не задан → null; роль выведется по is_admin при использовании
+        self::assertNull(User::where('email', 'norole@test.local')->first()->role);
+    }
+
+    public function test_shift_uses_explicit_user_role_over_is_admin_mapping(): void
+    {
+        $this->seed(UsersTableSeeder::class); // user 1: is_admin=true; user 3: is_admin=false
+
+        // user 3 — обычный (is_admin=false), но с явной глобальной ролью guard
+        $u3 = User::find(3);
+        $u3->role = ShiftRole::GUARD;
+        $u3->save();
+
+        app(SaveChange::class)->save([1, 3], Carbon::now());
+        $change = ChangesModel::query()->latest('id')->first();
+
+        $rows = ChangeUserModel::where('change_id', $change->id)->get()->keyBy('user_id');
+        // явная role перекрывает is_admin-маппинг
+        self::assertSame(ShiftRole::GUARD, $rows[3]->role, 'явная users.role используется в составе смены');
+        // user 1 без role → производная administrator (is_admin=true)
+        self::assertSame(ShiftRole::ADMINISTRATOR, $rows[1]->role);
+    }
+}


### PR DESCRIPTION
**Ф2 PR-3** — глобальная роль-дефолт пользователя (`users.role`, nullable) + её учёт в составе смены.

- Миграция `add_role_to_users` (`Schema::hasColumn` guard, nullable after is_admin). is_admin НЕ удаляем — вход цел.
- `createList` пишет role напрямую (вне $fillable, как is_admin); невалидную (не ShiftRole) игнорирует.
- Команда/сидер читают опц. 5-ю колонку списка (role); `staff_users.example.php` документирует `[email,имя,пароль,is_admin,role?]`.
- `syncChangeUsers` мягко маппит `ShiftRole::fromUser(is_admin, users.role)` — явная роль перекрывает производную.

Тесты: UserRoleTest (ставит/игнорирует/null; смена использует явную role). **Полный Baza-сьют 48/48.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)