### PR TITLE
feat(baza): модуль Permission + матрица прав роль×действие в БД (Ф2 PR-4)

### DIFF
--- a/Baza/app/Models/BazaRolePermissionModel.php
+++ b/Baza/app/Models/BazaRolePermissionModel.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Строка матрицы прав «роль × действие» (Ф2).
+ *
+ * Наличие строки = право есть. role — код ShiftRole, action — код ShiftPermission.
+ *
+ * @property int $id
+ * @property string $role
+ * @property string $action
+ */
+class BazaRolePermissionModel extends Model
+{
+    protected $table = self::TABLE;
+
+    public const TABLE = 'baza_role_permissions';
+
+    protected $fillable = [
+        'role',
+        'action',
+    ];
+}

--- a/Baza/app/Providers/BazaServiceProvider.php
+++ b/Baza/app/Providers/BazaServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Providers;
 
 use Baza\Changes\Repositories\ChangesRepositoryInterface;
 use Baza\Changes\Repositories\InMemoryMySqlChangesRepository;
+use Baza\Permission\Repositories\InMemoryMySqlRolePermissionRepository;
+use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
 use Baza\Sync\Repositories\InMemoryMySqlSyncRepository;
 use Baza\Sync\Repositories\SyncRepositoryInterface;
 use Baza\Tickets\Repositories\AutoTicketRepositoryInterface;
@@ -37,5 +39,6 @@ class BazaServiceProvider extends ServiceProvider
         $this->app->bind(ParkingTicketRepositoryInterface::class, InMemoryMySqlParkingTicketRepository::class);
         $this->app->bind(UserRepositoryInterface::class, InMemoryMySqlUserRepository::class);
         $this->app->bind(SyncRepositoryInterface::class, InMemoryMySqlSyncRepository::class);
+        $this->app->bind(RolePermissionRepositoryInterface::class, InMemoryMySqlRolePermissionRepository::class);
     }
 }

--- a/Baza/database/migrations/2026_06_19_190000_create_baza_role_permissions_table.php
+++ b/Baza/database/migrations/2026_06_19_190000_create_baza_role_permissions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Матрица прав «роль × действие» (Ф2), редактируемая из UI.
+ *
+ * Наличие строки (role, action) = право есть; отсутствие = запрет. Роль
+ * administrator — суперроль (короткозамкнута в коде, в таблицу НЕ пишется).
+ * Готовит дизайн-контракт под незаконченную org-матрицу (.claude/specs/admin-rbac.md),
+ * но физически отдельная таблица в схеме baza (без cross-schema).
+ *
+ * Schema::hasTable() guard — паттерн Baza (на проде таблицу могли создать руками).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('baza_role_permissions')) {
+            return;
+        }
+
+        Schema::create('baza_role_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('role', 40);   // код ShiftRole
+            $table->string('action', 60);  // код ShiftPermission
+            $table->timestamps();
+
+            $table->unique(['role', 'action']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('baza_role_permissions');
+    }
+};

--- a/Baza/database/seeders/BazaRolePermissionsSeeder.php
+++ b/Baza/database/seeders/BazaRolePermissionsSeeder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\BazaRolePermissionModel;
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Illuminate\Database\Seeder;
+
+/**
+ * Дефолтная матрица прав «роль × действие» (Ф2).
+ *
+ * Идемпотентно (updateOrCreate) → безопасно гонять на каждом деплое. ПОДКЛЮЧЁН
+ * к DatabaseSeeder: матрица — это конфиг (без ПДн), а её наличие защищает от
+ * «заперли всех» (если появится не-админ, но матрица пуста). administrator —
+ * суперроль (короткозамкнута в коде), в таблицу НЕ пишется.
+ *
+ * Перевыпуск/правка прав — из UI (PR-6). Здесь только разумный дефолт.
+ */
+class BazaRolePermissionsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $matrix = [
+            ShiftRole::SHIFT_CHIEF => [
+                ShiftPermission::TICKET_SCAN,
+                ShiftPermission::TICKET_SEARCH,
+                ShiftPermission::TICKET_ENTER,
+                ShiftPermission::REPORT_VIEW,
+                ShiftPermission::SHIFT_COMPOSE,
+                ShiftPermission::SHIFT_CLOSE,
+                ShiftPermission::FINANCE_VIEW,
+            ],
+            ShiftRole::TICKETER => [
+                ShiftPermission::TICKET_SCAN,
+                ShiftPermission::TICKET_SEARCH,
+                ShiftPermission::TICKET_ENTER,
+            ],
+            ShiftRole::KPP_COMMANDANT => [
+                ShiftPermission::TICKET_SCAN,
+                ShiftPermission::TICKET_SEARCH,
+                ShiftPermission::TICKET_ENTER,
+                ShiftPermission::FINANCE_VIEW,
+            ],
+            ShiftRole::GUARD => [
+                ShiftPermission::TICKET_SCAN,
+                ShiftPermission::TICKET_SEARCH,
+                ShiftPermission::TICKET_ENTER,
+            ],
+        ];
+
+        foreach ($matrix as $role => $actions) {
+            foreach ($actions as $action) {
+                BazaRolePermissionModel::updateOrCreate(
+                    ['role' => $role, 'action' => $action],
+                    []
+                );
+            }
+        }
+    }
+}

--- a/Baza/database/seeders/DatabaseSeeder.php
+++ b/Baza/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call([UsersTableSeeder::class]);
+        $this->call([
+            UsersTableSeeder::class,
+            // Дефолтная матрица прав роль×действие (Ф2) — идемпотентна, без ПДн,
+            // защищает от «заперли всех» при появлении не-админских ролей.
+            BazaRolePermissionsSeeder::class,
+        ]);
     }
 }

--- a/Baza/scr/Permission/Applications/CanAccess/CanAccess.php
+++ b/Baza/scr/Permission/Applications/CanAccess/CanAccess.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Applications\CanAccess;
+
+use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
+use Baza\Shared\Domain\Bus\Query\QueryBus;
+use Baza\Shared\Infrastructure\Bus\Query\InMemorySymfonyQueryBus;
+
+/**
+ * Проверка прав роли (Ф2) — точка enforcement для middleware/меню.
+ * Bus-паттерн как GetCurrentChanges. administrator — суперроль (всегда true).
+ */
+class CanAccess
+{
+    private QueryBus $bus;
+
+    public function __construct(
+        CanAccessQueryHandler $canAccessQueryHandler,
+        private RolePermissionRepositoryInterface $repository,
+    )
+    {
+        $this->bus = new InMemorySymfonyQueryBus([
+            CanAccessQuery::class => $canAccessQueryHandler,
+        ]);
+    }
+
+    public function check(string $role, string $action): bool
+    {
+        /** @var CanAccessResponse $result */
+        $result = $this->bus->ask(new CanAccessQuery($role, $action));
+
+        return $result->isAllowed();
+    }
+
+    /**
+     * Текущая матрица прав (для экрана редактора, PR-6).
+     *
+     * @return array<string, string[]>
+     */
+    public function getMatrix(): array
+    {
+        return $this->repository->getMatrix();
+    }
+
+    /**
+     * Перезаписать права роли (из экрана редактора, PR-6).
+     *
+     * @param string[] $actions
+     */
+    public function setMatrix(string $role, array $actions): void
+    {
+        $this->repository->setMatrix($role, $actions);
+    }
+}

--- a/Baza/scr/Permission/Applications/CanAccess/CanAccessQuery.php
+++ b/Baza/scr/Permission/Applications/CanAccess/CanAccessQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Applications\CanAccess;
+
+use Baza\Shared\Domain\Bus\Query\Query;
+
+class CanAccessQuery implements Query
+{
+    public function __construct(
+        private string $role,
+        private string $action,
+    )
+    {
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+}

--- a/Baza/scr/Permission/Applications/CanAccess/CanAccessQueryHandler.php
+++ b/Baza/scr/Permission/Applications/CanAccess/CanAccessQueryHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Applications\CanAccess;
+
+use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
+use Baza\Shared\Domain\Bus\Query\QueryHandler;
+
+class CanAccessQueryHandler implements QueryHandler
+{
+    public function __construct(
+        private RolePermissionRepositoryInterface $repository
+    )
+    {
+    }
+
+    public function __invoke(CanAccessQuery $query): CanAccessResponse
+    {
+        return new CanAccessResponse(
+            $this->repository->can($query->getRole(), $query->getAction())
+        );
+    }
+}

--- a/Baza/scr/Permission/Applications/CanAccess/CanAccessResponse.php
+++ b/Baza/scr/Permission/Applications/CanAccess/CanAccessResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Applications\CanAccess;
+
+use Baza\Shared\Domain\Bus\Query\Response;
+
+class CanAccessResponse implements Response
+{
+    public function __construct(
+        private bool $allowed,
+    )
+    {
+    }
+
+    public function isAllowed(): bool
+    {
+        return $this->allowed;
+    }
+}

--- a/Baza/scr/Permission/Repositories/InMemoryMySqlRolePermissionRepository.php
+++ b/Baza/scr/Permission/Repositories/InMemoryMySqlRolePermissionRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Repositories;
+
+use App\Models\BazaRolePermissionModel;
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use DB;
+
+class InMemoryMySqlRolePermissionRepository implements RolePermissionRepositoryInterface
+{
+    public function can(string $role, string $action): bool
+    {
+        // administrator — суперроль: всегда true, в таблице прав не держится
+        // (защита «нельзя закрыть себе доступ через матрицу»).
+        if ($role === ShiftRole::ADMINISTRATOR) {
+            return true;
+        }
+
+        return BazaRolePermissionModel::where('role', $role)
+            ->where('action', $action)
+            ->exists();
+    }
+
+    public function getMatrix(): array
+    {
+        $matrix = [];
+
+        foreach (BazaRolePermissionModel::all(['role', 'action']) as $row) {
+            $matrix[$row->role][] = $row->action;
+        }
+
+        return $matrix;
+    }
+
+    public function setMatrix(string $role, array $actions): void
+    {
+        // administrator не редактируется из UI (суперроль короткозамкнута в can()).
+        if ($role === ShiftRole::ADMINISTRATOR) {
+            return;
+        }
+
+        DB::transaction(function () use ($role, $actions) {
+            BazaRolePermissionModel::where('role', $role)->delete();
+
+            foreach (array_unique($actions) as $action) {
+                // только валидные коды действий (защита от мусора из формы)
+                if (ShiftPermission::isValid((string) $action)) {
+                    BazaRolePermissionModel::create([
+                        'role'   => $role,
+                        'action' => (string) $action,
+                    ]);
+                }
+            }
+        });
+    }
+}

--- a/Baza/scr/Permission/Repositories/RolePermissionRepositoryInterface.php
+++ b/Baza/scr/Permission/Repositories/RolePermissionRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Permission\Repositories;
+
+interface RolePermissionRepositoryInterface
+{
+    /**
+     * Есть ли у роли право на действие. administrator — суперроль (всегда true).
+     */
+    public function can(string $role, string $action): bool;
+
+    /**
+     * Вся матрица прав: [role => string[] actions]. administrator не включается
+     * (суперроль короткозамкнута в коде, прав в таблице не держит).
+     *
+     * @return array<string, string[]>
+     */
+    public function getMatrix(): array;
+
+    /**
+     * Перезаписать набор прав роли (delete старые → insert новые валидные).
+     * administrator игнорируется (его права не редактируются).
+     *
+     * @param string[] $actions
+     */
+    public function setMatrix(string $role, array $actions): void;
+}

--- a/Baza/tests/Feature/RolePermissionTest.php
+++ b/Baza/tests/Feature/RolePermissionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\BazaRolePermissionModel;
+use Baza\Permission\Applications\CanAccess\CanAccess;
+use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Database\Seeders\BazaRolePermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Тесты матрицы прав «роль × действие» (Baza, Ф2 PR-4).
+ *
+ * Дефолтная матрица из BazaRolePermissionsSeeder. administrator — суперроль
+ * (короткозамкнута в коде, в таблице нет). БД baza_test.
+ */
+class RolePermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function repo(): RolePermissionRepositoryInterface
+    {
+        return app(RolePermissionRepositoryInterface::class);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(BazaRolePermissionsSeeder::class);
+    }
+
+    public function test_default_matrix_grants_expected(): void
+    {
+        $repo = $this->repo();
+
+        // shift_chief: впуск + отчёт + состав + закрытие + финансы; НЕ sync/rbac/remove
+        self::assertTrue($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::REPORT_VIEW));
+        self::assertTrue($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::SHIFT_COMPOSE));
+        self::assertTrue($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::FINANCE_VIEW));
+        self::assertFalse($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::SYNC_MANAGE));
+        self::assertFalse($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::RBAC_MANAGE));
+        self::assertFalse($repo->can(ShiftRole::SHIFT_CHIEF, ShiftPermission::SHIFT_REMOVE));
+
+        // ticketer: только впуск
+        self::assertTrue($repo->can(ShiftRole::TICKETER, ShiftPermission::TICKET_ENTER));
+        self::assertFalse($repo->can(ShiftRole::TICKETER, ShiftPermission::REPORT_VIEW));
+
+        // kpp_commandant: впуск + финансы
+        self::assertTrue($repo->can(ShiftRole::KPP_COMMANDANT, ShiftPermission::FINANCE_VIEW));
+        self::assertFalse($repo->can(ShiftRole::KPP_COMMANDANT, ShiftPermission::REPORT_VIEW));
+
+        // guard: только впуск
+        self::assertTrue($repo->can(ShiftRole::GUARD, ShiftPermission::TICKET_ENTER));
+        self::assertFalse($repo->can(ShiftRole::GUARD, ShiftPermission::FINANCE_VIEW));
+    }
+
+    public function test_administrator_is_superrole(): void
+    {
+        $repo = $this->repo();
+
+        // суперроль: всё разрешено, даже sync/rbac, которых нет в таблице
+        self::assertTrue($repo->can(ShiftRole::ADMINISTRATOR, ShiftPermission::SYNC_MANAGE));
+        self::assertTrue($repo->can(ShiftRole::ADMINISTRATOR, ShiftPermission::RBAC_MANAGE));
+        self::assertSame(
+            0,
+            BazaRolePermissionModel::where('role', ShiftRole::ADMINISTRATOR)->count(),
+            'administrator не хранит прав в таблице'
+        );
+    }
+
+    public function test_can_access_service_check(): void
+    {
+        $svc = app(CanAccess::class);
+
+        self::assertTrue($svc->check(ShiftRole::TICKETER, ShiftPermission::TICKET_ENTER));
+        self::assertFalse($svc->check(ShiftRole::TICKETER, ShiftPermission::SYNC_MANAGE));
+        self::assertTrue($svc->check(ShiftRole::ADMINISTRATOR, ShiftPermission::RBAC_MANAGE));
+    }
+
+    public function test_set_matrix_replaces_role_permissions(): void
+    {
+        $repo = $this->repo();
+
+        $repo->setMatrix(ShiftRole::TICKETER, [ShiftPermission::REPORT_VIEW]);
+
+        self::assertTrue($repo->can(ShiftRole::TICKETER, ShiftPermission::REPORT_VIEW), 'новое право выдано');
+        self::assertFalse($repo->can(ShiftRole::TICKETER, ShiftPermission::TICKET_ENTER), 'старые права заменены');
+    }
+
+    public function test_set_matrix_ignores_administrator(): void
+    {
+        $repo = $this->repo();
+
+        $repo->setMatrix(ShiftRole::ADMINISTRATOR, []); // попытка отнять права у суперроли
+
+        self::assertTrue($repo->can(ShiftRole::ADMINISTRATOR, ShiftPermission::RBAC_MANAGE), 'суперроль не редактируется');
+        self::assertSame(0, BazaRolePermissionModel::where('role', ShiftRole::ADMINISTRATOR)->count());
+    }
+
+    public function test_set_matrix_filters_invalid_actions(): void
+    {
+        $repo = $this->repo();
+
+        $repo->setMatrix(ShiftRole::GUARD, ['bogus.action', ShiftPermission::TICKET_ENTER, 'drop.table']);
+
+        self::assertTrue($repo->can(ShiftRole::GUARD, ShiftPermission::TICKET_ENTER));
+        self::assertFalse($repo->can(ShiftRole::GUARD, 'bogus.action'));
+        self::assertSame(1, BazaRolePermissionModel::where('role', ShiftRole::GUARD)->count(), 'только валидное действие');
+    }
+
+    public function test_get_matrix_structure(): void
+    {
+        $matrix = $this->repo()->getMatrix();
+
+        self::assertArrayHasKey(ShiftRole::TICKETER, $matrix);
+        self::assertContains(ShiftPermission::TICKET_ENTER, $matrix[ShiftRole::TICKETER]);
+        self::assertArrayNotHasKey(ShiftRole::ADMINISTRATOR, $matrix, 'суперроль не в матрице');
+    }
+}


### PR DESCRIPTION
**Ф2 PR-4** — редактируемая из UI (PR-6) матрица прав, **2 оси** (роль × действие). Готовит дизайн-контракт под незаконченную org-матрицу (`.claude/specs/admin-rbac.md`), без cross-schema.

- Миграция `baza_role_permissions(role, action, UNIQUE)` (hasTable guard) + `BazaRolePermissionModel`.
- Модуль `Baza/scr/Permission/` (БД только в репозитории): `can/getMatrix/setMatrix`. **administrator — суперроль**, короткозамкнута в `can()` (всегда true, в таблицу не пишется → нельзя «закрыть себе доступ»). `setMatrix` фильтрует невалидные действия, игнорирует administrator.
- `CanAccess` (Bus-паттерн как GetCurrentChanges).
- `BazaRolePermissionsSeeder` (дефолт-матрица, idempotent) — **подключён к DatabaseSeeder** (конфиг без ПДн, защита от «заперли всех»).

Тесты: RolePermissionTest (дефолт/суперроль/CanAccess/setMatrix replace+ignore-admin+filter). **Полный Baza-сьют 55/55.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)