### PR TITLE
feat(baza): permission-middleware + перевод admin-роутов на RBAC (Ф2 PR-5)

### DIFF
--- a/Baza/app/Http/Kernel.php
+++ b/Baza/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\CheckPermission;
 use App\Http\Middleware\IsAdmin;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
@@ -65,5 +66,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => IsAdmin::class,
+        'permission' => CheckPermission::class,
     ];
 }

--- a/Baza/app/Http/Middleware/CheckPermission.php
+++ b/Baza/app/Http/Middleware/CheckPermission.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Auth;
+use Baza\Permission\Applications\CanAccess\CanAccess;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * RBAC по матрице прав «роль × действие» (Ф2) — приходит на смену бинарному IsAdmin.
+ *
+ * Роль берётся мягким маппингом ShiftRole::fromUser(is_admin, users.role):
+ * is_admin=true → administrator (суперроль, проходит везде) — поэтому текущий
+ * вход админов НЕ ломается, пока не появятся не-админские роли.
+ *
+ * Использование: `->middleware('permission:report.view')`. Перед ним обычно
+ * стоит `auth` (гость → редирект на login); здесь — только проверка права.
+ * При отказе: API (expectsJson) → JSON 403; web → HTML 403 (фикс UX-бага IsAdmin,
+ * который всегда отдавал JSON даже на страницах).
+ */
+class CheckPermission
+{
+    public function __construct(
+        private CanAccess $canAccess,
+    )
+    {
+    }
+
+    public function handle(Request $request, Closure $next, string $action): Response
+    {
+        $user = Auth::user();
+
+        if ($user !== null) {
+            $role = ShiftRole::fromUser((bool) $user->is_admin, $user->role);
+
+            if ($this->canAccess->check($role, $action)) {
+                return $next($request);
+            }
+        }
+
+        if ($request->expectsJson()) {
+            return response()->json(['errors' => ['error' => 'Forbidden']], 403);
+        }
+
+        abort(403);
+    }
+}

--- a/Baza/routes/web.php
+++ b/Baza/routes/web.php
@@ -59,14 +59,15 @@ Route::middleware('auth')->group(function () {
     Route::post('/api/enter', [\App\Http\Controllers\Api\ScanController::class, 'enter'])->name('tickets.scan.enter');
 });
 
-// changes
-Route::get('/report', [ChangesController::class, 'report'])->name('changes.report')->middleware('admin');
-Route::get('/change/edit/{id?}', [ChangesController::class, 'viewAddChange'])->name('changes.edit')->middleware('admin');
-Route::post('/change/close', [ChangesController::class, 'close'])->name('changes.close')->middleware('admin');
-Route::post('/change/save', [ChangesController::class, 'save'])->name('changes.save')->middleware('admin');
-Route::post('/change/remove', [ChangesController::class, 'remove'])->name('changes.remove')->middleware('admin');
+// changes — RBAC по матрице прав (Ф2): 'auth' (гость → login) + 'permission:<действие>'.
+// administrator проходит везде (суперроль), is_admin-юзеры не теряют доступ.
+Route::get('/report', [ChangesController::class, 'report'])->name('changes.report')->middleware(['auth', 'permission:report.view']);
+Route::get('/change/edit/{id?}', [ChangesController::class, 'viewAddChange'])->name('changes.edit')->middleware(['auth', 'permission:shift.compose']);
+Route::post('/change/close', [ChangesController::class, 'close'])->name('changes.close')->middleware(['auth', 'permission:shift.close']);
+Route::post('/change/save', [ChangesController::class, 'save'])->name('changes.save')->middleware(['auth', 'permission:shift.compose']);
+Route::post('/change/remove', [ChangesController::class, 'remove'])->name('changes.remove')->middleware(['auth', 'permission:shift.remove']);
 
-// sync (только для админов)
-Route::get('/sync', [SyncController::class, 'index'])->name('sync.index')->middleware('admin');
-Route::post('/sync/export', [SyncController::class, 'export'])->name('sync.export')->middleware('admin');
-Route::post('/sync/import', [SyncController::class, 'import'])->name('sync.import')->middleware('admin');
+// sync — только право sync.manage (в дефолте — лишь administrator)
+Route::get('/sync', [SyncController::class, 'index'])->name('sync.index')->middleware(['auth', 'permission:sync.manage']);
+Route::post('/sync/export', [SyncController::class, 'export'])->name('sync.export')->middleware(['auth', 'permission:sync.manage']);
+Route::post('/sync/import', [SyncController::class, 'import'])->name('sync.import')->middleware(['auth', 'permission:sync.manage']);

--- a/Baza/tests/Feature/PermissionMiddlewareTest.php
+++ b/Baza/tests/Feature/PermissionMiddlewareTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\User;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Database\Seeders\BazaRolePermissionsSeeder;
+use Database\Seeders\UsersTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Тесты permission-middleware на admin-роутах смен/синхронизации (Baza, Ф2 PR-5).
+ *
+ * /report,/change/*,/sync/* переведены с бинарного 'admin' на ['auth','permission:<действие>'].
+ * administrator (is_admin=true → суперроль) проходит везде — вход админов цел.
+ * БД baza_test. UsersTableSeeder: id=1 admin, id=3 обычный. BazaRolePermissionsSeeder — матрица.
+ */
+class PermissionMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(BazaRolePermissionsSeeder::class);
+    }
+
+    public function test_guest_redirected_to_login_on_report(): void
+    {
+        $this->get('/report')->assertRedirect('/login');
+    }
+
+    public function test_admin_can_open_report(): void
+    {
+        // is_admin=true → administrator (суперроль) → доступ цел
+        $this->actingAs(User::find(1))->get('/report')->assertOk();
+    }
+
+    public function test_admin_can_open_sync(): void
+    {
+        $this->actingAs(User::find(1))->get('/sync')->assertOk();
+    }
+
+    public function test_ticketer_forbidden_on_sync(): void
+    {
+        // user 3: is_admin=false, role=null → ticketer; sync.manage нет в дефолт-матрице
+        $this->actingAs(User::find(3))->get('/sync')->assertForbidden();
+    }
+
+    public function test_ticketer_forbidden_on_change_save(): void
+    {
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        $this->actingAs(User::find(3))
+            ->post('/change/save', ['compound' => [3], 'start' => now()->toDateTimeString()])
+            ->assertForbidden();
+    }
+
+    public function test_shift_chief_can_open_report(): void
+    {
+        // обычному сотруднику явно дали роль начальника смены → есть report.view
+        $user = User::find(3);
+        $user->role = ShiftRole::SHIFT_CHIEF;
+        $user->save();
+
+        $this->actingAs($user)->get('/report')->assertOk();
+    }
+
+    public function test_shift_chief_forbidden_on_sync(): void
+    {
+        // у начальника смены нет sync.manage (только у administrator)
+        $user = User::find(3);
+        $user->role = ShiftRole::SHIFT_CHIEF;
+        $user->save();
+
+        $this->actingAs($user)->get('/sync')->assertForbidden();
+    }
+}


### PR DESCRIPTION
**Ф2 PR-5** — security-гейт: бинарный `admin` на `/report,/change/*,/sync/*` заменён на `['auth','permission:<действие>']`.

- `CheckPermission` (alias `permission`): роль = `ShiftRole::fromUser(is_admin, users.role)`, проверка `CanAccess::check`. **administrator — суперроль, проходит везде** → вход админов не ломается. Отказ: API → JSON 403, web → HTML 403 (фикс UX IsAdmin).
- Роуты: report.view / shift.compose / shift.close / shift.remove / sync.manage; +`auth` (гость → login).
- Защита от lock-out: дефолт-матрица (PR-4) + administrator не зависит от матрицы.

Тесты: PermissionMiddlewareTest (гость→login; admin→200; ticketer→403 sync/save; chief→report ok, sync 403). **Полный Baza-сьют 62/62.** Adversarial-ревью в процессе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)