### PR TITLE
feat(baza): UI редактора матрицы прав роль×действие (Ф2 PR-6)

### DIFF
--- a/Baza/app/Http/Controllers/Permission/PermissionController.php
+++ b/Baza/app/Http/Controllers/Permission/PermissionController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Permission;
+
+use App\Http\Controllers\Controller;
+use Baza\Permission\Applications\CanAccess\CanAccess;
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Redirect;
+
+/**
+ * Редактор матрицы прав «роль × действие» через интерфейс (Ф2 PR-6).
+ *
+ * Доступ — только право rbac.manage (по дефолту лишь administrator). Сам
+ * administrator — суперроль: в матрице показан задизейбленным/всегда отмеченным
+ * и не редактируется (репозиторий игнорирует setMatrix для него). БД — в репозитории
+ * (через CanAccess → RolePermissionRepository), контроллер её не трогает.
+ */
+class PermissionController extends Controller
+{
+    public function __construct(
+        private CanAccess $canAccess,
+    )
+    {
+    }
+
+    public function index(): View
+    {
+        return view('permission.matrix', [
+            'roles'     => ShiftRole::catalog(),
+            'actions'   => ShiftPermission::catalog(),
+            'matrix'    => $this->canAccess->getMatrix(),
+            'adminRole' => ShiftRole::ADMINISTRATOR,
+        ]);
+    }
+
+    public function save(Request $request): RedirectResponse
+    {
+        /** @var array<string, string[]> $perm */
+        $perm = (array) $request->input('perm', []);
+
+        // Форма — источник правды: для каждой редактируемой роли пишем отмеченный
+        // набор (неотмеченное не приходит → право снимается). administrator пропускаем
+        // (суперроль, чекбоксы задизейблены и в POST не попадают).
+        foreach (ShiftRole::all() as $role) {
+            if ($role === ShiftRole::ADMINISTRATOR) {
+                continue;
+            }
+
+            $this->canAccess->setMatrix($role, (array) ($perm[$role] ?? []));
+        }
+
+        return Redirect::route('permission.index')->with('status', 'Права доступа обновлены');
+    }
+}

--- a/Baza/resources/views/layouts/navbars/sidebar.blade.php
+++ b/Baza/resources/views/layouts/navbars/sidebar.blade.php
@@ -26,6 +26,12 @@
                         <p>{{ __('Синхронизация') }}</p>
                     </a>
                 </li>
+                <li @if ($pageSlug == 'permission') class="active " @endif>
+                    <a href="{{ route('permission.index') }}">
+                        <i class="tim-icons icon-lock-circle"></i>
+                        <p>{{ __('Права доступа') }}</p>
+                    </a>
+                </li>
             @endif
         </ul>
     </div>

--- a/Baza/resources/views/permission/matrix.blade.php
+++ b/Baza/resources/views/permission/matrix.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.app', ['page' => __('Права доступа'), 'pageSlug' => 'permission'])
+
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            @include('alerts.success')
+
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title">Матрица прав «роль × действие»</h4>
+                    <p class="card-category">
+                        Отметь, какие действия доступны роли смены. <strong>Администратор</strong> —
+                        суперроль: имеет все права и не редактируется. Изменения применяются ко всем
+                        ролям сразу (снятая галочка = право убрано).
+                    </p>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ route('permission.save') }}">
+                        @csrf
+                        <div class="table-responsive">
+                            <table class="table">
+                                <thead class="text-primary">
+                                <tr>
+                                    <th>Действие</th>
+                                    @foreach($roles as $role)
+                                        <th class="text-center">{{ $role['label'] }}</th>
+                                    @endforeach
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($actions as $action)
+                                    <tr>
+                                        <td>
+                                            {{ $action['label'] }}<br>
+                                            <small class="text-muted">{{ $action['value'] }}</small>
+                                        </td>
+                                        @foreach($roles as $role)
+                                            @php
+                                                $isAdmin = $role['value'] === $adminRole;
+                                                $checked = $isAdmin
+                                                    || in_array($action['value'], $matrix[$role['value']] ?? [], true);
+                                            @endphp
+                                            <td class="text-center">
+                                                <input type="checkbox"
+                                                       name="perm[{{ $role['value'] }}][]"
+                                                       value="{{ $action['value'] }}"
+                                                       @checked($checked)
+                                                       @disabled($isAdmin)>
+                                            </td>
+                                        @endforeach
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                        <button type="submit" class="btn btn-fill btn-primary">
+                            Сохранить права
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('js')
+@endsection
+
+@section('css')
+@endsection

--- a/Baza/routes/web.php
+++ b/Baza/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Changes\ChangesController;
+use App\Http\Controllers\Permission\PermissionController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\Sync\SyncController;
 use App\Http\Controllers\Tickets\ScanController;
@@ -71,3 +72,8 @@ Route::post('/change/remove', [ChangesController::class, 'remove'])->name('chang
 Route::get('/sync', [SyncController::class, 'index'])->name('sync.index')->middleware(['auth', 'permission:sync.manage']);
 Route::post('/sync/export', [SyncController::class, 'export'])->name('sync.export')->middleware(['auth', 'permission:sync.manage']);
 Route::post('/sync/import', [SyncController::class, 'import'])->name('sync.import')->middleware(['auth', 'permission:sync.manage']);
+
+// Права доступа — редактор матрицы роль×действие (Ф2). Только право rbac.manage
+// (по дефолту лишь administrator). administrator не редактируется (суперроль).
+Route::get('/permissions', [PermissionController::class, 'index'])->name('permission.index')->middleware(['auth', 'permission:rbac.manage']);
+Route::post('/permissions', [PermissionController::class, 'save'])->name('permission.save')->middleware(['auth', 'permission:rbac.manage']);

--- a/Baza/tests/Feature/PermissionMatrixUiTest.php
+++ b/Baza/tests/Feature/PermissionMatrixUiTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\User;
+use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
+use Baza\Shared\Domain\ValueObject\ShiftPermission;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Database\Seeders\BazaRolePermissionsSeeder;
+use Database\Seeders\UsersTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Тесты экрана-редактора матрицы прав (Baza, Ф2 PR-6).
+ *
+ * /permissions (GET форма + POST сохранение) под правом rbac.manage (дефолт — admin).
+ * Форма — источник правды: снятая галочка убирает право; administrator не редактируется.
+ * БД baza_test. UsersTableSeeder: id=1 admin, id=3 обычный.
+ */
+class PermissionMatrixUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function repo(): RolePermissionRepositoryInterface
+    {
+        return app(RolePermissionRepositoryInterface::class);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(BazaRolePermissionsSeeder::class);
+    }
+
+    public function test_admin_can_open_matrix(): void
+    {
+        $this->actingAs(User::find(1))->get('/permissions')->assertOk();
+    }
+
+    public function test_guest_redirected_to_login(): void
+    {
+        $this->get('/permissions')->assertRedirect('/login');
+    }
+
+    public function test_ticketer_forbidden(): void
+    {
+        // user 3: is_admin=false → ticketer; rbac.manage нет
+        $this->actingAs(User::find(3))->get('/permissions')->assertForbidden();
+    }
+
+    public function test_save_updates_matrix(): void
+    {
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        $this->actingAs(User::find(1))
+            ->post('/permissions', [
+                'perm' => [
+                    ShiftRole::TICKETER => [ShiftPermission::REPORT_VIEW, ShiftPermission::TICKET_ENTER],
+                ],
+            ])
+            ->assertRedirect(route('permission.index'));
+
+        // ticketer получил отмеченное
+        self::assertTrue($this->repo()->can(ShiftRole::TICKETER, ShiftPermission::REPORT_VIEW));
+        self::assertTrue($this->repo()->can(ShiftRole::TICKETER, ShiftPermission::TICKET_ENTER));
+        self::assertFalse($this->repo()->can(ShiftRole::TICKETER, ShiftPermission::SYNC_MANAGE));
+
+        // guard НЕ был в payload → его права сняты (форма = источник правды)
+        self::assertFalse($this->repo()->can(ShiftRole::GUARD, ShiftPermission::TICKET_ENTER));
+    }
+
+    public function test_save_cannot_grant_to_administrator(): void
+    {
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        // попытка прописать administrator в матрицу через форму — игнорируется
+        $this->actingAs(User::find(1))
+            ->post('/permissions', [
+                'perm' => [
+                    ShiftRole::ADMINISTRATOR => [ShiftPermission::SYNC_MANAGE],
+                ],
+            ])
+            ->assertRedirect();
+
+        // суперроль и так всё может, но строк в таблице у неё нет
+        self::assertTrue($this->repo()->can(ShiftRole::ADMINISTRATOR, ShiftPermission::SYNC_MANAGE));
+        self::assertSame([], $this->repo()->getMatrix()[ShiftRole::ADMINISTRATOR] ?? []);
+    }
+}


### PR DESCRIPTION
**Ф2 PR-6** — матрица прав редактируется **через интерфейс** (ask владельца).

- `PermissionController` + экран `permission/matrix.blade` (таблица чекбоксов роль×действие). **administrator** задизейблен/всегда отмечен (суперроль, не редактируется).
- Роуты `/permissions` GET/POST под `['auth','permission:rbac.manage']`. Форма — источник правды (снятая галочка = право убрано).
- Пункт меню «Права доступа» в sidebar.

Тесты: PermissionMatrixUiTest (admin→200, гость→login, ticketer→403, save меняет матрицу, administrator не прописывается). **Полный Baza-сьют 67/67.**

Остаётся PR-7 (refinement): явные роли участникам смены в форме + инвариант «есть начальник» (контракт SaveChange, отложено из PR-2). Сейчас роли выводятся из users.role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)