### PR TITLE
feat(baza): понятные идемпотентные сидеры для стенда (TD-41)

### DIFF
--- a/Baza/database/seeders/DatabaseSeeder.php
+++ b/Baza/database/seeders/DatabaseSeeder.php
@@ -14,10 +14,14 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            // Фикстура персонала (id 1..36, дев-пароль 'secret'), идемпотентна.
             UsersTableSeeder::class,
             // Дефолтная матрица прав роль×действие (Ф2) — идемпотентна, без ПДн,
             // защищает от «заперли всех» при появлении не-админских ролей.
             BazaRolePermissionsSeeder::class,
+            // Демо стенда (TD-41): раздаёт разные роли смены + открывает демо-смену,
+            // чтобы Ф2 (роли/RBAC) было видно вживую. Идемпотентно.
+            StagingDemoSeeder::class,
         ]);
     }
 }

--- a/Baza/database/seeders/StagingDemoSeeder.php
+++ b/Baza/database/seeders/StagingDemoSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\ChangesModel;
+use App\Models\User;
+use Baza\Changes\Applications\SaveChange\SaveChange;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+/**
+ * Демо-данные стенда для Ф2 (TD-41) — чтобы роли смены и RBAC было видно вживую.
+ *
+ * Назначает РАЗНЫЕ роли смены нескольким фикстура-пользователям (UsersTableSeeder),
+ * открывает одну демо-смену из этого состава (роли попадут в change_user) и сеет
+ * дефолтную матрицу прав. Идемпотентно: роли — update по email; смена открывается
+ * только если открытой ещё нет; матрица — updateOrCreate.
+ *
+ * НЕ для прода: боевые роли назначает админ через UI «Права доступа» / форму смены.
+ */
+class StagingDemoSeeder extends Seeder
+{
+    /** email фикстуры => роль смены (ShiftRole). admin (id=1) остаётся суперролью по is_admin. */
+    private const DEMO_ROLES = [
+        'YulyaRahlina@spaceofjoy.ru' => ShiftRole::SHIFT_CHIEF,    // id=3
+        'KostyaIhti@spaceofjoy.ru'   => ShiftRole::TICKETER,       // id=4
+        'Infocentr1@spaceofjoy.ru'   => ShiftRole::KPP_COMMANDANT, // id=9
+        'Ohrana1@spaceofjoy.ru'      => ShiftRole::GUARD,          // id=33
+    ];
+
+    public function run(): void
+    {
+        // role вне $fillable → прямой query-builder update (идемпотентно)
+        foreach (self::DEMO_ROLES as $email => $role) {
+            User::where('email', $email)->update(['role' => $role]);
+        }
+
+        // дефолтная матрица прав (идемпотентно)
+        $this->call(BazaRolePermissionsSeeder::class);
+
+        // демо-смена из этого состава — только если открытой смены ещё нет
+        // (SaveChange всегда создаёт новую, поэтому защищаемся от дублей).
+        if (! ChangesModel::query()->whereNull('end')->exists()) {
+            app(SaveChange::class)->save([1, 3, 4, 9, 33], Carbon::now());
+        }
+    }
+}

--- a/Baza/database/seeders/UsersTableSeeder.php
+++ b/Baza/database/seeders/UsersTableSeeder.php
@@ -1,404 +1,86 @@
 <?php
+
 namespace Database\Seeders;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 
+/**
+ * Базовый набор персонала-фикстуры (dev/staging + тесты).
+ *
+ * Это НЕ боевой список (боевой персонал заводится перед фестивалём из
+ * staff_users.php через tickets:crateUser, см. StaffUsersSeeder). Здесь —
+ * фиксированные id (тесты опираются на id=1 = admin, id=3 = обычный) с дев-паролем
+ * 'secret'.
+ *
+ * ИДЕМПОТЕНТЕН (TD-41): updateOrInsert по id → повторный прогон (force-seed на
+ * стенде) обновляет, а не падает с duplicate key. role здесь НЕ задаём — роли
+ * смены раздаёт демо-сидер стенда (StagingDemoSeeder), чтобы не ломать тесты,
+ * которые ждут id=3 без роли (= ticketer).
+ */
 class UsersTableSeeder extends Seeder
 {
     /**
-     * Run the database seeds.
-     *
-     * @return void
+     * @var array<int, array{0:int, 1:string, 2:string, 3:bool}>
      */
+    private const USERS = [
+        [1, 'Admin Admin', 'admin@admin.ru', true],
+        [2, 'Митрофан', 'Mitrofan@spaceofjoy.ru', true],
+        [3, 'Юля Рахлина', 'YulyaRahlina@spaceofjoy.ru', false],
+        [4, 'Костя Ихти', 'KostyaIhti@spaceofjoy.ru', false],
+        [5, 'Женя Филиппова', 'ZhenyaFilippova@spaceofjoy.ru', false],
+        [6, 'Денис Арчи', 'DenisArchi@spaceofjoy.ru', false],
+        [7, 'Костя', 'Kostya@spaceofjoy.ru', false],
+        [8, 'Лера', 'Lera@spaceofjoy.ru', false],
+        [9, 'Инфоцентр 1', 'Infocentr1@spaceofjoy.ru', false],
+        [10, 'Арчи', 'Archi@spaceofjoy.ru', false],
+        [11, 'Головин', 'Golovin@spaceofjoy.ru', false],
+        [12, 'Ядя', 'Yadya@spaceofjoy.ru', false],
+        [13, 'Свят', 'Svyat@spaceofjoy.ru', false],
+        [14, 'Саша Свят', 'SashaSvyat@spaceofjoy.ru', false],
+        [15, 'Антон Тульский', 'AntonTulskij@spaceofjoy.ru', false],
+        [16, 'Катя Бут', 'KatyaBut@spaceofjoy.ru', false],
+        [17, 'Фауст', 'Faust@spaceofjoy.ru', false],
+        [18, 'Фауст Алена', 'FaustAlena@spaceofjoy.ru', false],
+        [19, 'Тома КПП', 'TomaKPP@spaceofjoy.ru', false],
+        [20, 'Егор', 'Egor@spaceofjoy.ru', false],
+        [21, 'Алиса Егор', 'AlisaEgor@spaceofjoy.ru', false],
+        [22, 'Света Мутабор', 'SvetaMutabor@spaceofjoy.ru', false],
+        [23, 'Катя Жарова', 'KatyaZharova@spaceofjoy.ru', false],
+        [24, 'Лукич', 'Lukich@spaceofjoy.ru', false],
+        [25, 'Гвалди', 'Gvaldi@spaceofjoy.ru', false],
+        [26, 'Саша Фауст', 'SashaFaust@spaceofjoy.ru', false],
+        [27, 'Настя АЛИСА', 'NastyaALISA@spaceofjoy.ru', false],
+        [28, 'Оля Ваня', 'OlyaVanya@spaceofjoy.ru', false],
+        [29, 'Ваня Оля', 'VanyaOlya@spaceofjoy.ru', false],
+        [30, 'Инфоцентр 2', 'Infocentr2@spaceofjoy.ru', false],
+        [31, 'Инфоцентр 3', 'Infocentr3@spaceofjoy.ru', false],
+        [32, 'Инфоцентр 4', 'Infocentr4@spaceofjoy.ru', false],
+        [33, 'Охрана 1', 'Ohrana1@spaceofjoy.ru', false],
+        [34, 'Охрана 2', 'Ohrana2@spaceofjoy.ru', false],
+        [35, 'Охрана 3', 'Ohrana3@spaceofjoy.ru', false],
+        [36, 'Охрана 4', 'Ohrana4@spaceofjoy.ru', false],
+    ];
+
     public function run(): void
     {
-        DB::table('users')->insert([
-            'id' => 1,
-            'name' => 'Admin Admin',
-            'email' => 'admin@admin.ru',
-            'is_admin' => true,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
+        $now = now();
 
-        DB::table('users')->insert([
-            'id' => 2,
-            'name' => 'Митрофан',
-            'email' => 'Mitrofan@spaceofjoy.ru',
-            'is_admin' => true,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 3,
-            'name' => 'Юля Рахлина',
-            'email' => 'YulyaRahlina@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 4,
-            'name' => 'Костя Ихти',
-            'email' => 'KostyaIhti@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 5,
-            'name' => 'Женя Филиппова',
-            'email' => 'ZhenyaFilippova@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 6,
-            'name' => 'Денис Арчи',
-            'email' => 'DenisArchi@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 7,
-            'name' => 'Костя',
-            'email' => 'Kostya@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 8,
-            'name' => 'Лера',
-            'email' => 'Lera@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 9,
-            'name' => 'Инфоцентр 1',
-            'email' => 'Infocentr1@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 10,
-            'name' => 'Арчи',
-            'email' => 'Archi@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-
-        DB::table('users')->insert([
-            'id' => 11,
-            'name' => 'Головин',
-            'email' => 'Golovin@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 12,
-            'name' => 'Ядя',
-            'email' => 'Yadya@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 13,
-            'name' => 'Свят',
-            'email' => 'Svyat@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 14,
-            'name' => 'Саша Свят',
-            'email' => 'SashaSvyat@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 15,
-            'name' => 'Антон Тульский',
-            'email' => 'AntonTulskij@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 16,
-            'name' => 'Катя Бут',
-            'email' => 'KatyaBut@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 17,
-            'name' => 'Фауст',
-            'email' => 'Faust@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 18,
-            'name' => 'Фауст Алена',
-            'email' => 'FaustAlena@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 19,
-            'name' => 'Тома КПП',
-            'email' => 'TomaKPP@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 20,
-            'name' => 'Егор',
-            'email' => 'Egor@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-
-
-        DB::table('users')->insert([
-            'id' => 21,
-            'name' => 'Алиса Егор',
-            'email' => 'AlisaEgor@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 22,
-            'name' => 'Света Мутабор',
-            'email' => 'SvetaMutabor@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 23,
-            'name' => 'Катя Жарова',
-            'email' => 'KatyaZharova@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 24,
-            'name' => 'Лукич',
-            'email' => 'Lukich@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 25,
-            'name' => 'Гвалди',
-            'email' => 'Gvaldi@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 26,
-            'name' => 'Саша Фауст',
-            'email' => 'SashaFaust@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 27,
-            'name' => 'Настя АЛИСА',
-            'email' => 'NastyaALISA@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 28,
-            'name' => 'Оля Ваня',
-            'email' => 'OlyaVanya@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 29,
-            'name' => 'Ваня Оля',
-            'email' => 'VanyaOlya@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-
-        DB::table('users')->insert([
-            'id' => 30,
-            'name' => 'Инфоцентр 2',
-            'email' => 'Infocentr2@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-
-        DB::table('users')->insert([
-            'id' => 31,
-            'name' => 'Инфоцентр 3',
-            'email' => 'Infocentr3@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 32,
-            'name' => 'Инфоцентр 4',
-            'email' => 'Infocentr4@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 33,
-            'name' => 'Охрана 1',
-            'email' => 'Ohrana1@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 34,
-            'name' => 'Охрана 2',
-            'email' => 'Ohrana2@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 35,
-            'name' => 'Охрана 3',
-            'email' => 'Ohrana3@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
-        DB::table('users')->insert([
-            'id' => 36,
-            'name' => 'Охрана 4',
-            'email' => 'Ohrana4@spaceofjoy.ru',
-            'is_admin' => false,
-            'email_verified_at' => now(),
-            'password' => Hash::make('secret'),
-            'created_at' => now(),
-            'updated_at' => now()
-        ]);
+        foreach (self::USERS as [$id, $name, $email, $isAdmin]) {
+            // updateOrInsert по id → идемпотентно (повторный прогон не падает на дубле)
+            DB::table('users')->updateOrInsert(
+                ['id' => $id],
+                [
+                    'name'              => $name,
+                    'email'             => $email,
+                    'is_admin'          => $isAdmin,
+                    'email_verified_at' => $now,
+                    'password'          => Hash::make('secret'),
+                    'updated_at'        => $now,
+                    'created_at'        => $now,
+                ]
+            );
+        }
     }
 }

--- a/Baza/tests/Feature/StagingSeedersTest.php
+++ b/Baza/tests/Feature/StagingSeedersTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\BazaRolePermissionModel;
+use App\Models\ChangesModel;
+use App\Models\ChangeUserModel;
+use App\Models\User;
+use Baza\Shared\Domain\ValueObject\ShiftRole;
+use Database\Seeders\StagingDemoSeeder;
+use Database\Seeders\UsersTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Тесты понятных идемпотентных сидеров стенда (Baza, TD-41).
+ *
+ * UsersTableSeeder — идемпотентен (force-seed на стенде не падает duplicate key).
+ * StagingDemoSeeder — раздаёт разные роли смены + матрицу + открывает демо-смену,
+ * идемпотентно. БД baza_test.
+ */
+class StagingSeedersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_seeder_is_idempotent(): void
+    {
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(UsersTableSeeder::class); // повтор не должен падать duplicate key
+
+        self::assertSame(36, User::count());
+    }
+
+    public function test_demo_seeder_assigns_distinct_shift_roles(): void
+    {
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(StagingDemoSeeder::class);
+
+        self::assertSame(ShiftRole::SHIFT_CHIEF, User::where('email', 'YulyaRahlina@spaceofjoy.ru')->first()->role);
+        self::assertSame(ShiftRole::TICKETER, User::where('email', 'KostyaIhti@spaceofjoy.ru')->first()->role);
+        self::assertSame(ShiftRole::KPP_COMMANDANT, User::where('email', 'Infocentr1@spaceofjoy.ru')->first()->role);
+        self::assertSame(ShiftRole::GUARD, User::where('email', 'Ohrana1@spaceofjoy.ru')->first()->role);
+    }
+
+    public function test_demo_seeder_seeds_default_matrix(): void
+    {
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(StagingDemoSeeder::class);
+
+        self::assertGreaterThan(0, BazaRolePermissionModel::count());
+        // у ticketer есть впуск, но нет sync
+        self::assertTrue(BazaRolePermissionModel::where('role', ShiftRole::TICKETER)->where('action', 'ticket.enter')->exists());
+        self::assertFalse(BazaRolePermissionModel::where('role', ShiftRole::TICKETER)->where('action', 'sync.manage')->exists());
+    }
+
+    public function test_demo_seeder_is_idempotent_one_open_shift_with_roles(): void
+    {
+        $this->seed(UsersTableSeeder::class);
+        $this->seed(StagingDemoSeeder::class);
+        $this->seed(StagingDemoSeeder::class); // повтор не открывает вторую смену
+
+        self::assertSame(36, User::count());
+        self::assertSame(1, ChangesModel::query()->whereNull('end')->count(), 'ровно одна открытая демо-смена');
+
+        // роль начальника смены попала в состав change_user (из users.role)
+        $change = ChangesModel::query()->latest('id')->first();
+        $chief = User::where('email', 'YulyaRahlina@spaceofjoy.ru')->first();
+        self::assertSame(
+            ShiftRole::SHIFT_CHIEF,
+            ChangeUserModel::where('change_id', $change->id)->where('user_id', $chief->id)->first()->role
+        );
+    }
+}


### PR DESCRIPTION
**TD-41** (ask владельца) — стенд можно надёжно перезасеять (force-seed) + Ф2 видно вживую.

- `UsersTableSeeder` переписан: читаемый массив 36 фикстур + цикл `updateOrInsert` по id → **идемпотентен** (раньше `insert` с фикс-id падал duplicate key). Те же id/email/is_admin (тесты на id=1/id=3 целы).
- `StagingDemoSeeder` (новый): раздаёт разные роли смены (chief/ticketer/kpp_commandant/guard), дефолт-матрицу, открывает одну демо-смену (роли → change_user). Идемпотентно. НЕ для прода.
- `DatabaseSeeder`: + StagingDemoSeeder.

Тесты: StagingSeedersTest (идемпотентность, разные роли, матрица, одна смена с ролями). **Полный Baza-сьют 71/71.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)