### PR TITLE
feat(baza): ingest-API приёма билета от org (Ф3, PR-a)

### DIFF
--- a/Baza/.env.example
+++ b/Baza/.env.example
@@ -22,6 +22,10 @@ QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
+# S2S-приём билетов от org (Ф3). Заголовок X-Baza-Token, список ключей через запятую
+# (ротация без простоя). Пусто → канал ingest закрыт. Зеркало org QR_INGEST_TOKENS.
+BAZA_INGEST_TOKENS=
+
 MEMCACHED_HOST=127.0.0.1
 
 REDIS_HOST=127.0.0.1

--- a/Baza/app/Http/Controllers/Api/IngestTicketController.php
+++ b/Baza/app/Http/Controllers/Api/IngestTicketController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Baza\Ingest\Applications\IngestTicket\IngestTicketApplication;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Приём билета от org через ingest-API (Ф3): POST /api/baza/ingest/ticket.
+ *
+ * S2S-канал (middleware baza.ingest, заголовок X-Baza-Token). Контракт:
+ *   { "target": "el_tickets|spisok_tickets|live_tickets|auto", "ticket": { ...поля цели... } }
+ *
+ * Идемпотентно по естественному ключу цели (org может ретраить). Ответ:
+ *   200 { success: true }  — билет записан;
+ *   200 { success: false } — не применено (напр. live-номера ещё нет) → org откатится на прямую запись;
+ *   422 — битый контракт (неизвестная цель / нет ключа билета);
+ *   401 — нет/неверный X-Baza-Token (middleware).
+ */
+class IngestTicketController extends Controller
+{
+    public function __construct(
+        private readonly IngestTicketApplication $application,
+    ) {}
+
+    public function ticket(Request $request): JsonResponse
+    {
+        $target = (string) $request->input('target', '');
+        $ticket = $request->input('ticket', []);
+        if (! is_array($ticket)) {
+            $ticket = [];
+        }
+
+        try {
+            $applied = $this->application->ingest($target, $ticket);
+
+            return response()->json([
+                'success' => $applied,
+                'target' => $target,
+            ]);
+        } catch (InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 422);
+        } catch (Throwable $e) {
+            // Реальная ошибка записи — 500, чтобы org откатился на прямую запись и/или ретрай.
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/Baza/app/Http/Kernel.php
+++ b/Baza/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\BazaIngestAuth;
 use App\Http\Middleware\CheckPermission;
 use App\Http\Middleware\IsAdmin;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
@@ -67,5 +68,6 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => IsAdmin::class,
         'permission' => CheckPermission::class,
+        'baza.ingest' => BazaIngestAuth::class,
     ];
 }

--- a/Baza/app/Http/Middleware/BazaIngestAuth.php
+++ b/Baza/app/Http/Middleware/BazaIngestAuth.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Аутентификация S2S-канала приёма билетов от org (Ф3).
+ *
+ * org предъявляет сервисный ключ в заголовке "X-Baza-Token"; Baza сверяет его со списком
+ * валидных ключей из конфига (services.baza_ingest.tokens, источник — env BAZA_INGEST_TOKENS).
+ * Зеркало org-овского QrIngestAuth (X-QR-Token).
+ *
+ * Список ключей (через запятую) даёт ротацию без простоя. Безопасный дефолт: пустой список
+ * (канал не сконфигурирован) → доступ закрыт. Сравнение через hash_equals — защита от timing-атаки.
+ */
+class BazaIngestAuth
+{
+    /** Заголовок, в котором org передаёт сервисный ключ. */
+    public const HEADER = 'X-Baza-Token';
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $provided = (string) $request->headers->get(self::HEADER, '');
+
+        if ($provided !== '' && $this->matchesKnownToken($provided)) {
+            return $next($request);
+        }
+
+        Log::channel(config('logging.default'))->warning('baza.ingest.rejected', [
+            'reason' => $provided === '' ? 'no_token' : 'bad_token',
+            'ip' => $request->ip(),
+            'path' => $request->path(),
+        ]);
+
+        return response()->json([
+            'success' => false,
+            'message' => 'Доступ запрещён: неверный или отсутствующий ключ канала baza-ingest',
+        ], Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * Совпадает ли предъявленный ключ хотя бы с одним из настроенных (constant-time сравнение).
+     */
+    private function matchesKnownToken(string $provided): bool
+    {
+        /** @var list<string> $tokens */
+        $tokens = config('services.baza_ingest.tokens', []);
+
+        foreach ($tokens as $token) {
+            if ($token !== '' && hash_equals((string) $token, $provided)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Baza/app/Providers/BazaServiceProvider.php
+++ b/Baza/app/Providers/BazaServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Providers;
 
 use Baza\Changes\Repositories\ChangesRepositoryInterface;
 use Baza\Changes\Repositories\InMemoryMySqlChangesRepository;
+use Baza\Ingest\Repositories\IngestRepositoryInterface;
+use Baza\Ingest\Repositories\InMemoryMySqlIngestRepository;
 use Baza\Permission\Repositories\InMemoryMySqlRolePermissionRepository;
 use Baza\Permission\Repositories\RolePermissionRepositoryInterface;
 use Baza\Sync\Repositories\InMemoryMySqlSyncRepository;
@@ -40,5 +42,6 @@ class BazaServiceProvider extends ServiceProvider
         $this->app->bind(UserRepositoryInterface::class, InMemoryMySqlUserRepository::class);
         $this->app->bind(SyncRepositoryInterface::class, InMemoryMySqlSyncRepository::class);
         $this->app->bind(RolePermissionRepositoryInterface::class, InMemoryMySqlRolePermissionRepository::class);
+        $this->app->bind(IngestRepositoryInterface::class, InMemoryMySqlIngestRepository::class);
     }
 }

--- a/Baza/config/services.php
+++ b/Baza/config/services.php
@@ -31,4 +31,18 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Baza Ingest (S2S-приём билетов от org, Ф3)
+    |--------------------------------------------------------------------------
+    | Список валидных ключей (через запятую) для заголовка X-Baza-Token.
+    | Зеркало org services.qr_ingest. Пустой список → канал закрыт (безопасный дефолт).
+    */
+    'baza_ingest' => [
+        'tokens' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('BAZA_INGEST_TOKENS', '')),
+        ))),
+    ],
+
 ];

--- a/Baza/routes/api.php
+++ b/Baza/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\IngestTicketController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -22,3 +23,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 // под middleware('auth'): группа `api` не стартует сессию, поэтому раньше эндпоинты были
 // фактически без авторизации, а id сотрудника брался из тела запроса. Теперь они под
 // web-группой (сессия + CSRF) и auth — см. routes/web.php.
+
+// S2S-приём билетов от org (Ф3). Заголовок X-Baza-Token (middleware baza.ingest).
+// Группа `api` сессию не стартует — это и нужно для машина-машина канала.
+Route::post('/baza/ingest/ticket', [IngestTicketController::class, 'ticket'])
+    ->middleware('baza.ingest');

--- a/Baza/scr/Ingest/Applications/IngestTicket/IngestTicketApplication.php
+++ b/Baza/scr/Ingest/Applications/IngestTicket/IngestTicketApplication.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Ingest\Applications\IngestTicket;
+
+use Baza\Ingest\Repositories\IngestRepositoryInterface;
+use InvalidArgumentException;
+
+/**
+ * Приём билета от org (Ф3, API №ingest). Тонкий слой: валидирует цель (target) и
+ * раскладывает поля по нужному upsert репозитория. БД — только в репозитории.
+ *
+ * Возвращает bool «применено ли»: для el/spisok/auto всегда true при успехе,
+ * для live — false, если строки с номером ещё нет (org откатится на прямую запись).
+ * Неизвестный target / битый контракт → InvalidArgumentException (контроллер отдаст 422).
+ */
+final class IngestTicketApplication
+{
+    public const TARGET_EL = 'el_tickets';
+
+    public const TARGET_SPISOK = 'spisok_tickets';
+
+    public const TARGET_LIVE = 'live_tickets';
+
+    public const TARGET_AUTO = 'auto';
+
+    public const TARGETS = [
+        self::TARGET_EL,
+        self::TARGET_SPISOK,
+        self::TARGET_LIVE,
+        self::TARGET_AUTO,
+    ];
+
+    public function __construct(
+        private readonly IngestRepositoryInterface $repository,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     */
+    public function ingest(string $target, array $ticket): bool
+    {
+        if (! in_array($target, self::TARGETS, true)) {
+            throw new InvalidArgumentException("Неизвестная цель доставки: '{$target}'");
+        }
+
+        return match ($target) {
+            self::TARGET_EL => $this->upsertEl($ticket),
+            self::TARGET_SPISOK => $this->upsertSpisok($ticket),
+            self::TARGET_LIVE => $this->linkLive($ticket),
+            self::TARGET_AUTO => $this->upsertAuto($ticket),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     */
+    private function upsertEl(array $ticket): bool
+    {
+        if (empty($ticket['uuid'])) {
+            throw new InvalidArgumentException('el_tickets: не передан uuid билета');
+        }
+
+        return $this->repository->upsertElTicket($ticket);
+    }
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     */
+    private function upsertSpisok(array $ticket): bool
+    {
+        if (empty($ticket['ticket_uuid'])) {
+            throw new InvalidArgumentException('spisok_tickets: не передан ticket_uuid');
+        }
+
+        return $this->repository->upsertSpisokTicket($ticket);
+    }
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     */
+    private function linkLive(array $ticket): bool
+    {
+        $kilter = isset($ticket['kilter']) ? (int) $ticket['kilter'] : (int) ($ticket['number'] ?? 0);
+        if ($kilter <= 0) {
+            throw new InvalidArgumentException('live_tickets: не передан номер (kilter)');
+        }
+
+        $elTicketId = isset($ticket['el_ticket_id']) ? (string) $ticket['el_ticket_id'] : null;
+
+        return $this->repository->linkLiveTicket($kilter, $elTicketId !== '' ? $elTicketId : null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     */
+    private function upsertAuto(array $ticket): bool
+    {
+        if (empty($ticket['order_id']) || empty($ticket['auto'])) {
+            throw new InvalidArgumentException('auto: нужны order_id и auto (номер)');
+        }
+
+        return $this->repository->upsertAuto($ticket);
+    }
+}

--- a/Baza/scr/Ingest/Repositories/InMemoryMySqlIngestRepository.php
+++ b/Baza/scr/Ingest/Repositories/InMemoryMySqlIngestRepository.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Ingest\Repositories;
+
+use App\Models\AutoModel;
+use App\Models\ElTicketsModel;
+use App\Models\LiveTicketModel;
+use App\Models\SpisokTicketModel;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Запись принятых от org билетов в собственные таблицы Baza.
+ *
+ * Через query-builder (а не Eloquent-fill) — чтобы писать и поля вне $fillable модели
+ * (festival_id/city/number), по образцу InMemoryMySqlSyncRepository. Набор полей и
+ * семантика upsert — зеркало org-методов setInBaza / setInBazaList / setInBazaLive / setInBazaAuto.
+ */
+class InMemoryMySqlIngestRepository implements IngestRepositoryInterface
+{
+    public function upsertElTicket(array $fields): bool
+    {
+        $uuid = (string) ($fields['uuid'] ?? '');
+        if ($uuid === '') {
+            return false;
+        }
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+        $exists = DB::table(ElTicketsModel::TABLE)->where('uuid', $uuid)->exists();
+
+        // type_ticket_id/type_ticket в схеме Baza фактически NOT NULL (->default(null) без
+        // ->nullable()): на проде non-strict MySQL молча пишет '', strict-режим даёт ошибку.
+        // Коалесцируем null → '' для устойчивости (гость без типа билета не должен ронять выдачу).
+        $typeTicketId = (string) ($fields['type_ticket_id'] ?? '');
+        $typeTicket = (string) ($fields['type_ticket'] ?? '');
+
+        if ($exists) {
+            // Обновляем только изменяемые поля (как org: статус/тип/имя/festival).
+            return DB::table(ElTicketsModel::TABLE)->where('uuid', $uuid)->update([
+                'status' => (string) ($fields['status'] ?? 'paid'),
+                'is_need_seedling' => (bool) ($fields['is_need_seedling'] ?? false),
+                'type_ticket_id' => $typeTicketId,
+                'type_ticket' => $typeTicket,
+                'name' => (string) ($fields['name'] ?? ''),
+                'festival_id' => $fields['festival_id'] ?? null,
+                'updated_at' => $now,
+            ]) >= 0;
+        }
+
+        return DB::table(ElTicketsModel::TABLE)->insert([
+            'kilter' => (int) ($fields['kilter'] ?? 0),
+            'uuid' => $uuid,
+            'city' => (string) ($fields['city'] ?? ''),
+            'name' => (string) ($fields['name'] ?? ''),
+            'email' => (string) ($fields['email'] ?? ''),
+            'phone' => (string) ($fields['phone'] ?? ''),
+            'date_order' => $this->normalizeDate($fields['date_order'] ?? null) ?? $now,
+            'status' => (string) ($fields['status'] ?? 'paid'),
+            'comment' => $fields['comment'] ?? null,
+            'is_need_seedling' => (bool) ($fields['is_need_seedling'] ?? false),
+            'type_ticket_id' => $typeTicketId,
+            'type_ticket' => $typeTicket,
+            'festival_id' => $fields['festival_id'] ?? null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    public function upsertSpisokTicket(array $fields): bool
+    {
+        $ticketUuid = (string) ($fields['ticket_uuid'] ?? '');
+        if ($ticketUuid === '') {
+            return false;
+        }
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+        $exists = DB::table(SpisokTicketModel::TABLE)->where('ticket_uuid', $ticketUuid)->exists();
+
+        if ($exists) {
+            return DB::table(SpisokTicketModel::TABLE)->where('ticket_uuid', $ticketUuid)->update([
+                'project' => (string) ($fields['project'] ?? ''),
+                'curator' => (string) ($fields['curator'] ?? ''),
+                'email' => (string) ($fields['email'] ?? ''),
+                'name' => (string) ($fields['name'] ?? ''),
+                'comment' => (string) ($fields['comment'] ?? ''),
+                'status' => (string) ($fields['status'] ?? 'paid'),
+                'festival_id' => $fields['festival_id'] ?? null,
+                'updated_at' => $now,
+            ]) >= 0;
+        }
+
+        return DB::table(SpisokTicketModel::TABLE)->insert([
+            'kilter' => (int) ($fields['kilter'] ?? 0),
+            'project' => (string) ($fields['project'] ?? ''),
+            'curator' => (string) ($fields['curator'] ?? ''),
+            'email' => (string) ($fields['email'] ?? ''),
+            'name' => (string) ($fields['name'] ?? ''),
+            'date_order' => $this->normalizeDate($fields['date_order'] ?? null) ?? $now,
+            'comment' => (string) ($fields['comment'] ?? ''),
+            'status' => (string) ($fields['status'] ?? 'paid'),
+            'ticket_uuid' => $ticketUuid,
+            'festival_id' => $fields['festival_id'] ?? null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    public function linkLiveTicket(int $kilter, ?string $elTicketId): bool
+    {
+        $exists = DB::table(LiveTicketModel::TABLE)->where('kilter', $kilter)->exists();
+        if (! $exists) {
+            // Строки live-билета с таким номером ещё нет — нечего связывать.
+            return false;
+        }
+
+        DB::table(LiveTicketModel::TABLE)->where('kilter', $kilter)->update([
+            'el_ticket_id' => $elTicketId,
+            'updated_at' => Carbon::now()->format('Y-m-d H:i:s'),
+        ]);
+
+        return true;
+    }
+
+    public function upsertAuto(array $fields): bool
+    {
+        $orderId = (string) ($fields['order_id'] ?? '');
+        $auto = (string) ($fields['auto'] ?? '');
+        if ($orderId === '' || $auto === '') {
+            return false;
+        }
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        DB::table(AutoModel::TABLE)->updateOrInsert(
+            ['order_id' => $orderId, 'auto' => $auto],
+            [
+                'curator' => (string) ($fields['curator'] ?? ''),
+                'project' => (string) ($fields['project'] ?? ''),
+                'festival_id' => $fields['festival_id'] ?? null,
+                'updated_at' => $now,
+                'created_at' => $now,
+            ],
+        );
+
+        return true;
+    }
+
+    /**
+     * Нормализует дату из ISO-8601 (org шлёт Carbon→ISO в JSON) к MySQL 'Y-m-d H:i:s'.
+     * null/пустую/нечитаемую → null (вызывающий подставит now).
+     */
+    private function normalizeDate(mixed $value): ?string
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->format('Y-m-d H:i:s');
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/Baza/scr/Ingest/Repositories/IngestRepositoryInterface.php
+++ b/Baza/scr/Ingest/Repositories/IngestRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Ingest\Repositories;
+
+/**
+ * Приём билетов от org через ingest-API (Ф3).
+ *
+ * Зеркало того, что org раньше делал прямой записью в БД Baza (соединение mysqlBaza,
+ * методы setInBaza*). Теперь org шлёт билет HTTP-запросом, а запись в свои таблицы делает
+ * сама Baza — через этот репозиторий (БД только здесь). Идемпотентность по естественному
+ * ключу каждой цели: el → uuid, spisok → ticket_uuid, live → kilter, auto → (order_id, auto).
+ */
+interface IngestRepositoryInterface
+{
+    /** el_tickets: INSERT по uuid, если нет; иначе UPDATE. Всегда true при успехе. */
+    public function upsertElTicket(array $fields): bool;
+
+    /** spisok_tickets: INSERT по ticket_uuid, если нет; иначе UPDATE. Всегда true при успехе. */
+    public function upsertSpisokTicket(array $fields): bool;
+
+    /**
+     * live_tickets: только UPDATE el_ticket_id по kilter (строка создаётся диапазоном в Baza заранее).
+     * false, если строки с таким kilter нет — org откатится на прямую запись/ретрай.
+     */
+    public function linkLiveTicket(int $kilter, ?string $elTicketId): bool;
+
+    /** auto: updateOrInsert по (order_id, auto) — идемпотентно. */
+    public function upsertAuto(array $fields): bool;
+}

--- a/Baza/tests/Feature/Ingest/IngestTicketApiTest.php
+++ b/Baza/tests/Feature/Ingest/IngestTicketApiTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ingest;
+
+use App\Models\AutoModel;
+use App\Models\ElTicketsModel;
+use App\Models\LiveTicketModel;
+use App\Models\SpisokTicketModel;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * S2S-приём билетов от org через ingest-API (Ф3): POST /api/baza/ingest/ticket.
+ *
+ * Канал закрыт middleware baza.ingest (заголовок X-Baza-Token). Идемпотентно по
+ * естественному ключу цели: el → uuid, spisok → ticket_uuid, live → kilter, auto → (order_id,auto).
+ * БД baza_test (phpunit.xml).
+ */
+class IngestTicketApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TOKEN = 'test-baza-ingest-token';
+
+    private const URL = '/api/baza/ingest/ticket';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['services.baza_ingest.tokens' => [self::TOKEN]]);
+    }
+
+    /** @return array<string,string> */
+    private function authHeader(): array
+    {
+        return ['X-Baza-Token' => self::TOKEN];
+    }
+
+    public function test_rejects_without_token(): void
+    {
+        $this->postJson(self::URL, ['target' => 'el_tickets', 'ticket' => ['uuid' => 'x']])
+            ->assertStatus(401)
+            ->assertJson(['success' => false]);
+    }
+
+    public function test_rejects_with_bad_token(): void
+    {
+        $this->postJson(self::URL, ['target' => 'el_tickets', 'ticket' => ['uuid' => 'x']], ['X-Baza-Token' => 'wrong'])
+            ->assertStatus(401);
+    }
+
+    public function test_el_ticket_insert_then_idempotent_update(): void
+    {
+        $uuid = '11111111-1111-4111-8111-111111111111';
+        $ticket = [
+            'kilter' => 101,
+            'uuid' => $uuid,
+            'city' => 'Москва',
+            'name' => 'Иван Иванов',
+            'email' => 'ivan@example.com',
+            'phone' => '+70000000000',
+            'date_order' => Carbon::parse('2026-06-20T10:00:00+03:00')->toIso8601String(),
+            'status' => 'paid',
+            'festival_id' => '9d679bcf-b438-4ddb-ac04-023fa9bff4b8',
+        ];
+
+        $this->postJson(self::URL, ['target' => 'el_tickets', 'ticket' => $ticket], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => true, 'target' => 'el_tickets']);
+
+        self::assertSame(1, ElTicketsModel::where('uuid', $uuid)->count());
+        self::assertSame('Иван Иванов', ElTicketsModel::where('uuid', $uuid)->value('name'));
+
+        // Повтор с новым именем — без дубля, имя обновилось (идемпотентность по uuid).
+        $ticket['name'] = 'Иван Петров';
+        $this->postJson(self::URL, ['target' => 'el_tickets', 'ticket' => $ticket], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        self::assertSame(1, ElTicketsModel::where('uuid', $uuid)->count());
+        self::assertSame('Иван Петров', ElTicketsModel::where('uuid', $uuid)->value('name'));
+    }
+
+    public function test_spisok_ticket_insert_by_ticket_uuid(): void
+    {
+        $ticketUuid = '22222222-2222-4222-8222-222222222222';
+        $ticket = [
+            'kilter' => 202,
+            'project' => 'Сцена А',
+            'curator' => 'curator@example.com',
+            'email' => 'guest@example.com',
+            'name' => 'Гость Списка',
+            'date_order' => Carbon::now()->toIso8601String(),
+            'status' => 'paid',
+            'ticket_uuid' => $ticketUuid,
+            'festival_id' => '9d679bcf-b438-4ddb-ac04-023fa9bff4b2',
+        ];
+
+        $this->postJson(self::URL, ['target' => 'spisok_tickets', 'ticket' => $ticket], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        self::assertSame(1, SpisokTicketModel::where('ticket_uuid', $ticketUuid)->count());
+    }
+
+    public function test_live_ticket_links_existing_row(): void
+    {
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+        DB::table(LiveTicketModel::TABLE)->insert([
+            'kilter' => 777,
+            'status' => 'paid',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $elId = '33333333-3333-4333-8333-333333333333';
+        $this->postJson(self::URL, [
+            'target' => 'live_tickets',
+            'ticket' => ['kilter' => 777, 'el_ticket_id' => $elId],
+        ], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        self::assertSame($elId, DB::table(LiveTicketModel::TABLE)->where('kilter', 777)->value('el_ticket_id'));
+    }
+
+    public function test_live_ticket_absent_row_returns_success_false(): void
+    {
+        // Нет строки live-билета с таким номером → не применено (org откатится на прямую запись).
+        $this->postJson(self::URL, [
+            'target' => 'live_tickets',
+            'ticket' => ['kilter' => 999999, 'el_ticket_id' => '44444444-4444-4444-8444-444444444444'],
+        ], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => false]);
+    }
+
+    public function test_auto_insert_by_order_and_number(): void
+    {
+        $orderId = '55555555-5555-4555-8555-555555555555';
+        $this->postJson(self::URL, [
+            'target' => 'auto',
+            'ticket' => [
+                'order_id' => $orderId,
+                'auto' => 'А123АА777',
+                'curator' => 'cur@example.com',
+                'project' => 'Парковка',
+                'festival_id' => '9d679bcf-b438-4ddb-ac04-023fa9bff4b4',
+            ],
+        ], $this->authHeader())
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        self::assertSame(1, AutoModel::where('order_id', $orderId)->where('auto', 'А123АА777')->count());
+    }
+
+    public function test_unknown_target_returns_422(): void
+    {
+        $this->postJson(self::URL, ['target' => 'nope', 'ticket' => []], $this->authHeader())
+            ->assertStatus(422)
+            ->assertJson(['success' => false]);
+    }
+
+    public function test_el_without_uuid_returns_422(): void
+    {
+        $this->postJson(self::URL, ['target' => 'el_tickets', 'ticket' => ['name' => 'No UUID']], $this->authHeader())
+            ->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Что (Ф3 — контракт интеграции org→Baza, часть 1/2)

Новый **S2S-эндпоинт Baza** для приёма билета от org по HTTP вместо текущей прямой записи в чужую БД. Зеркало org-овского `qr.ingest`.

```
POST /api/baza/ingest/ticket
X-Baza-Token: <ключ>
{ "target": "el_tickets|spisok_tickets|live_tickets|auto", "ticket": { ...поля цели... } }
```

## Как

- **Middleware** `baza.ingest` (`BazaIngestAuth`) — `X-Baza-Token`, `hash_equals`, список ключей из `config services.baza_ingest.tokens` (env `BAZA_INGEST_TOKENS`, ротация без простоя, пустой список → закрыто). Точное зеркало org `QrIngestAuth`.
- **Модуль** `scr/Ingest/` — тонкий `IngestTicketApplication` (валидация цели) + `IngestRepositoryInterface`/`InMemoryMySqlIngestRepository` (**БД только здесь**). Upsert идемпотентен по естественному ключу: el→`uuid`, spisok→`ticket_uuid`, live→`kilter`, auto→`(order_id,auto)`. Набор полей и семантика — зеркало org `setInBaza/setInBazaList/setInBazaLive/setInBazaAuto`.
- **live**: только UPDATE `el_ticket_id` по номеру (строка создаётся диапазоном в Baza заранее). Нет строки → `success:false` → org откатится на прямую запись/ретрай.
- **Контроллер**: `200 {success:true}` записан / `200 {success:false}` не применено / `422` битый контракт / `401` без токена.
- **type_ticket_id/type_ticket** в схеме Baza фактически NOT NULL (`->default(null)` без `->nullable()`); коалесцируем `null → ''` для устойчивости (в strict-MySQL иначе 500).

## Проверка

- Тест `IngestTicketApiTest` — **9 кейсов** (auth 401 без/с битым токеном, idempotent el/spisok/auto, link live + live-нет-строки→false, 422 unknown target / el без uuid). Зелёные.
- Полный сьют Baza — **80/80**. Pint — чисто.

## Дальше

PR-b (org): `DeliverTicketToBazaJob` сначала пробует ingest-API, при сбое — текущая прямая запись (fallback). Default OFF (нет `BAZA_INGEST_URL`) → поведение org не меняется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)