### PR TITLE
feat(baza): доставка билета в Baza через ingest-API с fallback (Ф3, PR-b)

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -92,6 +92,12 @@ AUTO_PAYMENT_TOKEN=
 # Сгенерировать: openssl rand -hex 32
 QR_INGEST_TOKENS=
 
+# Исходящий канал записи билета в Baza через ingest-API (Ф3, заголовок "X-Baza-Token").
+# Заданы И url, И token → доставка идёт через API с fallback на прямую запись в БД Baza.
+# Пусто → канал выключен, доставка только прямой записью (поведение без изменений).
+BAZA_INGEST_URL=
+BAZA_INGEST_TOKEN=
+
 SENTRY_ENABLE_LOGS=true
 LOG_CHANNEL=stack
 LOG_STACK=single,sentry_logs

--- a/Backend/config/services.php
+++ b/Backend/config/services.php
@@ -48,4 +48,13 @@ return [
         ))),
     ],
 
+    // Исходящий S2S-канал записи билета в Baza через ingest-API (Ф3).
+    // Заданы И url, И token → доставка идёт через API (POST {url}/api/baza/ingest/ticket,
+    // заголовок X-Baza-Token), при сбое — fallback на прямую запись в БД Baza.
+    // Пусто (по умолчанию) → канал выключен, поведение org не меняется (только прямая запись).
+    'baza_ingest' => [
+        'url' => env('BAZA_INGEST_URL'),
+        'token' => env('BAZA_INGEST_TOKEN'),
+    ],
+
 ];

--- a/Backend/src/BazaDelivery/Application/Client/BazaIngestClient.php
+++ b/Backend/src/BazaDelivery/Application/Client/BazaIngestClient.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tickets\BazaDelivery\Application\Client;
+
+use Illuminate\Support\Facades\Http;
+use Throwable;
+use Tickets\BazaDelivery\Application\Support\BazaDeliveryLog;
+
+/**
+ * Исходящий S2S-клиент записи билета в Baza через ingest-API (Ф3).
+ *
+ * Шлёт POST {url}/api/baza/ingest/ticket с заголовком X-Baza-Token (зеркало приёма qr→org).
+ * Канал включается только если заданы и URL, и токен (env BAZA_INGEST_URL / BAZA_INGEST_TOKEN);
+ * иначе isEnabled()=false и доставка идёт прежним путём (прямая запись в БД Baza) — поведение
+ * org не меняется до явной настройки канала.
+ */
+final class BazaIngestClient
+{
+    private const PATH = '/api/baza/ingest/ticket';
+
+    /** Таймаут запроса к Baza (сек) — короткий, чтобы при недоступности быстро падать в fallback. */
+    private const TIMEOUT = 5;
+
+    public function isEnabled(): bool
+    {
+        return $this->baseUrl() !== '' && $this->token() !== '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $ticket
+     * @return bool|null true — Baza применила запись; false — Baza явно НЕ применила (200 success:false,
+     *                   напр. live-номера ещё нет); null — канал выключен / HTTP-ошибка / транспорт упал.
+     *                   В случае false/null вызывающий откатывается на прямую запись.
+     */
+    public function send(string $target, array $ticket): ?bool
+    {
+        if (! $this->isEnabled()) {
+            return null;
+        }
+
+        try {
+            $response = Http::withHeaders(['X-Baza-Token' => $this->token()])
+                ->acceptJson()
+                ->timeout(self::TIMEOUT)
+                ->post($this->baseUrl().self::PATH, [
+                    'target' => $target,
+                    'ticket' => $ticket,
+                ]);
+
+            if (! $response->successful()) {
+                BazaDeliveryLog::logger()->warning('baza.ingest.http_error', [
+                    'target' => $target,
+                    'status' => $response->status(),
+                ]);
+
+                return null;
+            }
+
+            return (bool) $response->json('success', false);
+        } catch (Throwable $e) {
+            BazaDeliveryLog::logger()->warning('baza.ingest.transport_error', [
+                'target' => $target,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function baseUrl(): string
+    {
+        return rtrim((string) config('services.baza_ingest.url', ''), '/');
+    }
+
+    private function token(): string
+    {
+        return (string) config('services.baza_ingest.token', '');
+    }
+}

--- a/Backend/src/BazaDelivery/Application/Job/DeliverTicketToBazaJob.php
+++ b/Backend/src/BazaDelivery/Application/Job/DeliverTicketToBazaJob.php
@@ -13,6 +13,7 @@ use RuntimeException;
 use Shared\Domain\ValueObject\Uuid;
 use Throwable;
 use Tickets\Auto\Repositories\AutoRepositoryInterface;
+use Tickets\BazaDelivery\Application\Client\BazaIngestClient;
 use Tickets\BazaDelivery\Application\Support\BazaDeliveryLog;
 use Tickets\BazaDelivery\Domain\BazaDeliveryLifecycleEvent;
 use Tickets\BazaDelivery\Domain\ValueObject\BazaDeliveryStatus;
@@ -48,9 +49,7 @@ final class DeliverTicketToBazaJob implements ShouldQueue
     /** @var int[] backoff между авто-ретраями (сек): 30с / 2м / 10м (далее — последнее значение). */
     public array $backoff = [30, 120, 600];
 
-    public function __construct(private readonly string $deliveryId)
-    {
-    }
+    public function __construct(private readonly string $deliveryId) {}
 
     public function handle(
         BazaDeliveryRepositoryInterface $repository,
@@ -74,7 +73,7 @@ final class DeliverTicketToBazaJob implements ShouldQueue
 
         // Кап: после MAX_ATTEMPTS попыток — терминальный failed, новых попыток нет.
         if ($delivery->getAttempts() >= self::MAX_ATTEMPTS) {
-            $repository->markFailed($id, 'Достигнут предел попыток доставки в Baza (' . self::MAX_ATTEMPTS . ')');
+            $repository->markFailed($id, 'Достигнут предел попыток доставки в Baza ('.self::MAX_ATTEMPTS.')');
             BazaDeliveryLog::logger()->error('baza.cap_reached', [
                 'id' => $this->deliveryId,
                 'attempts' => $delivery->getAttempts(),
@@ -91,7 +90,7 @@ final class DeliverTicketToBazaJob implements ShouldQueue
         ]);
 
         try {
-            if (! $this->deliver($delivery, $repository, $tickets, $autos)) {
+            if (! $this->deliver($delivery, $repository, $tickets, $autos, app(BazaIngestClient::class))) {
                 throw new RuntimeException('Запись билета в Baza вернула false');
             }
 
@@ -133,20 +132,61 @@ final class DeliverTicketToBazaJob implements ShouldQueue
         }
     }
 
-    /** Маршрутизация записи в Baza по цели доставки. */
+    /**
+     * Маршрутизация записи в Baza по цели доставки.
+     *
+     * Каждая цель сперва пробует ingest-API Baza (если канал настроен), при сбое/неприменении —
+     * текущая прямая запись в БД Baza (fallback). Канал выключен → сразу прямая запись (как раньше).
+     */
     private function deliver(
         BazaDeliveryDto $delivery,
         BazaDeliveryRepositoryInterface $repository,
         TicketsRepositoryInterface $tickets,
         AutoRepositoryInterface $autos,
+        BazaIngestClient $client,
     ): bool {
-        return match ($delivery->getTarget()) {
-            'el_tickets' => $tickets->setInBaza($this->resolveTicket($delivery, $repository, $tickets)),
-            'spisok_tickets' => $tickets->setInBazaList($this->resolveTicket($delivery, $repository, $tickets)),
-            'live_tickets' => $tickets->setInBazaLive((int) $delivery->getNumber(), $delivery->getTicketId()),
-            'auto' => $this->deliverAuto($delivery, $autos),
-            default => throw new RuntimeException('Неизвестная цель доставки в Baza: ' . $delivery->getTarget()),
-        };
+        switch ($delivery->getTarget()) {
+            case 'el_tickets':
+                $ticket = $this->resolveTicket($delivery, $repository, $tickets);
+
+                return $this->ingestOrDirect($client, 'el_tickets', $ticket->toArrayForBaza(), fn () => $tickets->setInBaza($ticket));
+            case 'spisok_tickets':
+                $ticket = $this->resolveTicket($delivery, $repository, $tickets);
+
+                return $this->ingestOrDirect($client, 'spisok_tickets', $ticket->toArrayForSpisok(), fn () => $tickets->setInBazaList($ticket));
+            case 'live_tickets':
+                $number = (int) $delivery->getNumber();
+                $ticketId = $delivery->getTicketId();
+
+                return $this->ingestOrDirect(
+                    $client,
+                    'live_tickets',
+                    ['kilter' => $number, 'el_ticket_id' => $ticketId?->value()],
+                    fn () => $tickets->setInBazaLive($number, $ticketId),
+                );
+            case 'auto':
+                return $this->deliverAuto($delivery, $autos, $client);
+            default:
+                throw new RuntimeException('Неизвестная цель доставки в Baza: '.$delivery->getTarget());
+        }
+    }
+
+    /**
+     * Ingest-API сначала, при сбое/неприменении — прямая запись (fallback).
+     *
+     * client->send: true → Baza применила (прямую запись пропускаем); false (явно не применила,
+     * напр. нет live-номера) / null (канал выключен или ошибка транспорта) → прямая запись.
+     *
+     * @param  array<string, mixed>  $payload
+     * @param  callable(): bool  $direct
+     */
+    private function ingestOrDirect(BazaIngestClient $client, string $target, array $payload, callable $direct): bool
+    {
+        if ($client->send($target, $payload) === true) {
+            return true;
+        }
+
+        return (bool) $direct();
     }
 
     /**
@@ -169,17 +209,29 @@ final class DeliverTicketToBazaJob implements ShouldQueue
         return $tickets->getTicket($delivery->getTicketId(), true);
     }
 
-    /** Запись авто заказа-списка в Baza: пересобираем AutoDto по id и пишем через setInBazaAuto. */
-    private function deliverAuto(BazaDeliveryDto $delivery, AutoRepositoryInterface $autos): bool
+    /** Запись авто заказа-списка в Baza: пересобираем AutoDto по id, ingest-API → fallback setInBazaAuto. */
+    private function deliverAuto(BazaDeliveryDto $delivery, AutoRepositoryInterface $autos, BazaIngestClient $client): bool
     {
         $auto = $autos->getById($delivery->getTicketId());
         if ($auto === null) {
-            throw new RuntimeException('Авто не найдено: ' . $delivery->getTicketId()->value());
+            throw new RuntimeException('Авто не найдено: '.$delivery->getTicketId()->value());
         }
 
-        $festivalId = $delivery->getFestivalId() !== null ? new Uuid($delivery->getFestivalId()) : null;
+        $festivalId = $delivery->getFestivalId();
+        $payload = [
+            'order_id' => $auto->orderTicketId->value(),
+            'auto' => $auto->number,
+            'curator' => (string) ($auto->curator ?? ''),
+            'project' => (string) ($auto->project ?? ''),
+            'festival_id' => $festivalId,
+        ];
 
-        return $autos->setInBazaAuto($auto, $festivalId);
+        return $this->ingestOrDirect(
+            $client,
+            'auto',
+            $payload,
+            fn () => $autos->setInBazaAuto($auto, $festivalId !== null ? new Uuid($festivalId) : null),
+        );
     }
 
     /** Окончательный сбой задачи (tries исчерпаны) — фиксируем failed. */
@@ -189,7 +241,7 @@ final class DeliverTicketToBazaJob implements ShouldQueue
     }
 
     /**
-     * @param array<string, mixed> $payload
+     * @param  array<string, mixed>  $payload
      */
     private function recordHistory(
         HistoryRepositoryInterface $history,

--- a/Backend/src/History/Domain/ActorType.php
+++ b/Backend/src/History/Domain/ActorType.php
@@ -6,11 +6,18 @@ namespace Tickets\History\Domain;
 
 final class ActorType
 {
-    public const USER         = 'user';
-    public const SYSTEM       = 'system';
-    public const ARTISAN      = 'artisan';
+    public const USER = 'user';
+
+    public const SYSTEM = 'system';
+
+    public const ARTISAN = 'artisan';
+
     // Автоматическое одобрение заказа по заголовку AutoPayment на /api/v1/order/create
     public const AUTO_PAYMENT = 'auto_payment';
+
     // Действия по заказам, пришедшим от витрины qr (S2S-канал, не человек)
-    public const QR           = 'qr';
+    public const QR = 'qr';
+
+    // События от Baza (системы входа): S2S-канал, не человек (вебхук «билет прошёл» Ф4 и пр.)
+    public const BAZA = 'baza';
 }

--- a/Backend/tests/Feature/BazaDelivery/BazaIngestRoutingTest.php
+++ b/Backend/tests/Feature/BazaDelivery/BazaIngestRoutingTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\BazaDelivery;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Shared\Domain\ValueObject\Uuid;
+use Tests\TestCase;
+use Tickets\Auto\Repositories\AutoRepositoryInterface;
+use Tickets\BazaDelivery\Application\BazaDeliveryContext;
+use Tickets\BazaDelivery\Application\BazaDeliveryDispatcher;
+use Tickets\BazaDelivery\Application\Job\DeliverTicketToBazaJob;
+use Tickets\BazaDelivery\Domain\ValueObject\BazaDeliveryStatus;
+use Tickets\BazaDelivery\Dto\BazaDeliveryDto;
+use Tickets\BazaDelivery\Repositories\BazaDeliveryRepositoryInterface;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Ф3 (PR-b): доставка билета в Baza маршрутизируется через ingest-API с fallback на прямую запись.
+ *
+ * Канал включается конфигом services.baza_ingest (url+token). Успех API → прямую запись пропускаем;
+ * HTTP-ошибка / success:false / выключенный канал → откат на текущую прямую запись (поведение цело).
+ */
+class BazaIngestRoutingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const BASE = 'https://baza.test';
+
+    private function enableChannel(): void
+    {
+        config([
+            'services.baza_ingest.url' => self::BASE,
+            'services.baza_ingest.token' => 'ingest-token',
+        ]);
+    }
+
+    private function ticketResponse(): TicketResponse
+    {
+        return new TicketResponse(
+            name: 'Тест Гость',
+            kilter: 12345,
+            uuid: Uuid::random(),
+            status: 'paid',
+            email: 'guest@example.com',
+            phone: '+70000000000',
+            city: 'Москва',
+            comment: null,
+            date_order: Carbon::now(),
+            festival_id: Uuid::random(),
+            type_ticket_id: Uuid::random(),
+        );
+    }
+
+    private function queuedDelivery(string $target = BazaDeliveryDispatcher::TARGET_EL, ?int $number = null): Uuid
+    {
+        $id = Uuid::random();
+        app(BazaDeliveryRepositoryInterface::class)->create(BazaDeliveryDto::queued(
+            $id,
+            Uuid::random(),
+            $target,
+            new BazaDeliveryContext(source: 'org_event', number: $number),
+        ));
+
+        return $id;
+    }
+
+    private function runJob(Uuid $id, TicketsRepositoryInterface $tickets, ?AutoRepositoryInterface $autos = null): void
+    {
+        (new DeliverTicketToBazaJob($id->value()))->handle(
+            app(BazaDeliveryRepositoryInterface::class),
+            $tickets,
+            app(HistoryRepositoryInterface::class),
+            $autos ?? app(AutoRepositoryInterface::class),
+        );
+    }
+
+    public function test_ingest_success_skips_direct_write(): void
+    {
+        $this->enableChannel();
+        Http::fake([self::BASE.'/*' => Http::response(['success' => true], 200)]);
+
+        $id = $this->queuedDelivery();
+
+        $tickets = $this->createMock(TicketsRepositoryInterface::class);
+        $tickets->method('getTicket')->willReturn($this->ticketResponse());
+        $tickets->expects($this->never())->method('setInBaza'); // ingest применил → прямую запись не зовём
+
+        $this->runJob($id, $tickets);
+
+        $this->assertSame(BazaDeliveryStatus::DELIVERED, app(BazaDeliveryRepositoryInterface::class)->findById($id)->getStatus());
+        Http::assertSent(fn ($req) => $req->url() === self::BASE.'/api/baza/ingest/ticket'
+            && $req['target'] === 'el_tickets'
+            && $req->hasHeader('X-Baza-Token', 'ingest-token'));
+    }
+
+    public function test_http_error_falls_back_to_direct_write(): void
+    {
+        $this->enableChannel();
+        Http::fake([self::BASE.'/*' => Http::response('boom', 500)]);
+
+        $id = $this->queuedDelivery();
+
+        $tickets = $this->createMock(TicketsRepositoryInterface::class);
+        $tickets->method('getTicket')->willReturn($this->ticketResponse());
+        $tickets->expects($this->once())->method('setInBaza')->willReturn(true); // fallback
+
+        $this->runJob($id, $tickets);
+
+        $this->assertSame(BazaDeliveryStatus::DELIVERED, app(BazaDeliveryRepositoryInterface::class)->findById($id)->getStatus());
+    }
+
+    public function test_success_false_falls_back_to_direct_for_live(): void
+    {
+        $this->enableChannel();
+        // Baza явно не применила (нет live-номера) → откат на прямую запись.
+        Http::fake([self::BASE.'/*' => Http::response(['success' => false], 200)]);
+
+        $id = $this->queuedDelivery(BazaDeliveryDispatcher::TARGET_LIVE, number: 555);
+
+        $tickets = $this->createMock(TicketsRepositoryInterface::class);
+        $tickets->expects($this->once())->method('setInBazaLive')->with(555)->willReturn(true);
+
+        $this->runJob($id, $tickets);
+
+        $this->assertSame(BazaDeliveryStatus::DELIVERED, app(BazaDeliveryRepositoryInterface::class)->findById($id)->getStatus());
+    }
+
+    public function test_channel_disabled_uses_direct_write_only(): void
+    {
+        // Канал не настроен (дефолт) → ingest не дёргаем, только прямая запись.
+        config(['services.baza_ingest.url' => null, 'services.baza_ingest.token' => null]);
+        Http::fake();
+
+        $id = $this->queuedDelivery();
+
+        $tickets = $this->createMock(TicketsRepositoryInterface::class);
+        $tickets->method('getTicket')->willReturn($this->ticketResponse());
+        $tickets->expects($this->once())->method('setInBaza')->willReturn(true);
+
+        $this->runJob($id, $tickets);
+
+        $this->assertSame(BazaDeliveryStatus::DELIVERED, app(BazaDeliveryRepositoryInterface::class)->findById($id)->getStatus());
+        Http::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## Что (Ф3 — контракт интеграции org→Baza, часть 2/2)

org теперь шлёт билет в Baza **по HTTP** (новый ingest-API из PR #108) вместо прямой записи в чужую БД — с **fallback** на текущую прямую запись, чтобы доставка не прерывалась во время перехода.

## Как

- **`BazaIngestClient`** — POST `{url}/api/baza/ingest/ticket`, заголовок `X-Baza-Token`, timeout 5с. `true` → Baza применила; `false` (явно не применила, напр. live-номера ещё нет) / `null` (канал выключен или транспорт упал) → откат.
- **`DeliverTicketToBazaJob::deliver()`** для каждой цели (el/spisok/live/auto): `ingestOrDirect()` — сперва `client->send()`, при не-`true` — текущая прямая запись (`setInBaza`/`setInBazaList`/`setInBazaLive`/`setInBazaAuto`). Машина статусов/ретрай/кап 10 — без изменений.
- **Конфиг** `services.baza_ingest` (`url`+`token`, env `BAZA_INGEST_URL`/`BAZA_INGEST_TOKEN`). **Пусто (дефолт) → канал выключен**, поведение org не меняется (только прямая запись). Включается заданием обоих значений.
- **`ActorType::BAZA`** — для будущего вебхука «билет прошёл» (Ф4).

## Безопасность перехода

- Default OFF: без `BAZA_INGEST_URL` доставка идёт прежним путём → можно мержить и катить, ничего не ломая.
- Любой сбой API (5xx/таймаут/connection) → fallback на прямую запись → доставка доезжает (или ретрай по текущей машине).
- ingest-API идемпотентен по UUID (PR #108) → ретраи безопасны.

## Проверка

- `BazaIngestRoutingTest` — **4 кейса**: успех API пропускает прямую запись (+ проверка URL/заголовка/target); HTTP 500 → fallback; `success:false` (live без номера) → fallback; выключенный канал → только прямая запись (`Http::assertNothingSent`).
- Существующие `DeliverTicketToBazaJobTest` (8) — зелёные (поведение по умолчанию цело).
- **Полный сьют Backend — 478 зелёный.**

## Зависимость

Принимающий эндпоинт — PR #108 (`feat(baza): ingest-API приёма билета`, уже смержен). Канал включается на стейдже заданием `BAZA_INGEST_URL`/`BAZA_INGEST_TOKEN` после деплоя обоих.

🤖 Generated with [Claude Code](https://claude.com/claude-code)