### PR TITLE
feat(baza): поисковый индекс ticket_search — поиск по всем полям без QR (1/2)

### DIFF
--- a/Baza/app/Http/Controllers/Api/IngestTicketController.php
+++ b/Baza/app/Http/Controllers/Api/IngestTicketController.php
@@ -36,9 +36,14 @@ class IngestTicketController extends Controller
         if (! is_array($ticket)) {
             $ticket = [];
         }
+        // Опциональный богатый блок для поискового индекса (Ф-rich). Нет → fallback на ticket.
+        $search = $request->input('search', []);
+        if (! is_array($search)) {
+            $search = [];
+        }
 
         try {
-            $applied = $this->application->ingest($target, $ticket);
+            $applied = $this->application->ingest($target, $ticket, $search);
 
             return response()->json([
                 'success' => $applied,

--- a/Baza/app/Models/TicketSearchModel.php
+++ b/Baza/app/Models/TicketSearchModel.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Поисковый индекс билетов (ручной поиск на КПП без QR). См. миграцию ticket_search.
+ *
+ * @property int $id
+ * @property string $ticket_uuid
+ * @property string|null $festival_id
+ * @property string $type
+ * @property int|null $kilter
+ * @property array|null $payload
+ */
+class TicketSearchModel extends Model
+{
+    protected $table = self::TABLE;
+
+    public const TABLE = 'ticket_search';
+
+    protected $fillable = [
+        'ticket_uuid',
+        'festival_id',
+        'type',
+        'kilter',
+        'fio',
+        'phone',
+        'telegram',
+        'email',
+        'city',
+        'car_number',
+        'child_name',
+        'parent_phone',
+        'external_order_no',
+        'type_ticket',
+        'payload',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+}

--- a/Baza/app/Providers/BazaServiceProvider.php
+++ b/Baza/app/Providers/BazaServiceProvider.php
@@ -23,10 +23,12 @@ use Baza\Tickets\Repositories\InMemoryMySqlFriendlyTicket;
 use Baza\Tickets\Repositories\InMemoryMySqlLiveTicket;
 use Baza\Tickets\Repositories\InMemoryMySqlParkingTicketRepository;
 use Baza\Tickets\Repositories\InMemoryMySqlSpisokTicket;
+use Baza\Tickets\Repositories\InMemoryMySqlTicketSearch;
 use Baza\Tickets\Repositories\InMemoryMySqlUserRepository;
 use Baza\Tickets\Repositories\LiveTicketRepositoryInterface;
 use Baza\Tickets\Repositories\ParkingTicketRepositoryInterface;
 use Baza\Tickets\Repositories\SpisokTicketsRepositoryInterface;
+use Baza\Tickets\Repositories\TicketSearchRepositoryInterface;
 use Baza\Tickets\Repositories\UserRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
@@ -46,5 +48,6 @@ class BazaServiceProvider extends ServiceProvider
         $this->app->bind(RolePermissionRepositoryInterface::class, InMemoryMySqlRolePermissionRepository::class);
         $this->app->bind(IngestRepositoryInterface::class, InMemoryMySqlIngestRepository::class);
         $this->app->bind(EntryOutboxRepositoryInterface::class, InMemoryMySqlEntryOutboxRepository::class);
+        $this->app->bind(TicketSearchRepositoryInterface::class, InMemoryMySqlTicketSearch::class);
     }
 }

--- a/Baza/database/migrations/2026_06_20_150000_create_ticket_search_table.php
+++ b/Baza/database/migrations/2026_06_20_150000_create_ticket_search_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Единый поисковый индекс билетов для ручного поиска на КПП (когда у гостя НЕТ QR).
+ *
+ * Наполняется из org→Baza ingest (Ф3) богатыми данными гостя (rich-контракт qr) + узким
+ * fallback. Поиск Baza (`/search`) ищет по проиндексированным полям — ФИО/телефон/телега/
+ * госномер/имя ребёнка и т.д. Локальная таблица → поиск работает ОФЛАЙН. Попадает на ноутбук
+ * КПП через существующий синк (export/import), поэтому PK — автоинкрементный `id` (как у
+ * остальных синкаемых таблиц), а uuid билета — отдельной колонкой.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('ticket_search')) {
+            return;
+        }
+
+        Schema::create('ticket_search', function (Blueprint $table) {
+            $table->id();                                  // автоинкремент — для синка
+            $table->char('ticket_uuid', 36)->unique();     // id билета в org (естественный ключ)
+            $table->char('festival_id', 36)->nullable()->index();
+            $table->string('type', 20);                    // electron|spisok|live|auto (DefineService)
+            $table->integer('kilter')->nullable();         // номер билета — мост к впуску
+            // Проекция искомых полей (лёгкие, индексируются — поиск НЕ по JSON):
+            $table->string('fio')->nullable()->index();
+            $table->string('phone', 64)->nullable()->index();
+            $table->string('telegram', 64)->nullable()->index();
+            $table->string('email')->nullable()->index();
+            $table->string('city')->nullable();
+            $table->string('car_number', 64)->nullable()->index();
+            $table->string('child_name')->nullable()->index();
+            $table->string('parent_phone', 64)->nullable()->index();
+            $table->string('external_order_no', 64)->nullable()->index();
+            $table->string('type_ticket')->nullable();     // читаемый тип билета
+            $table->json('payload')->nullable();           // весь полученный search/ticket as-is
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_search');
+    }
+};

--- a/Baza/database/seeders/TicketSearchTestDataSeeder.php
+++ b/Baza/database/seeders/TicketSearchTestDataSeeder.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\TicketSearchModel;
+use Illuminate\Database\Seeder;
+
+/**
+ * Демо-данные поискового индекса ticket_search (для стенда) — чтобы ручной поиск на КПП
+ * «без QR» было видно вживую: по ФИО, телефону, telegram, госномеру, имени ребёнка.
+ *
+ * Идемпотентно: updateOrCreate по ticket_uuid (повторный прогон не плодит дубли).
+ * НЕ для прода — боевые строки наполняются из org→Baza ingest. festival_id совпадает
+ * с фестивалём поиска (ChangesTestDataSeeder::FESTIVAL_ID), иначе строки не найдутся.
+ */
+class TicketSearchTestDataSeeder extends Seeder
+{
+    private const FESTIVAL_ID = ChangesTestDataSeeder::FESTIVAL_ID;
+
+    public function run(): void
+    {
+        foreach ($this->rows() as $row) {
+            TicketSearchModel::query()->updateOrCreate(
+                ['ticket_uuid' => $row['ticket_uuid']],
+                $row + ['festival_id' => self::FESTIVAL_ID],
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function rows(): array
+    {
+        return [
+            [
+                'ticket_uuid' => 'aaa10001-0000-4000-8000-000000000001',
+                'type' => 'electron', 'kilter' => 900001,
+                'fio' => 'Иван Петров', 'phone' => '+79991234567', 'telegram' => 'ivan',
+                'email' => 'ivan@example.com', 'city' => 'Казань',
+                'type_ticket' => 'Оргвзнос', 'external_order_no' => '123',
+                'payload' => ['role' => 'org_fee', 'is_buyer' => true],
+            ],
+            [
+                'ticket_uuid' => 'aaa10002-0000-4000-8000-000000000002',
+                'type' => 'electron', 'kilter' => 900002,
+                'fio' => 'Пётр Смирнов', 'phone' => '+79990001122', 'telegram' => null,
+                'email' => 'petr@example.com', 'city' => 'Москва',
+                'type_ticket' => 'Оргвзнос', 'external_order_no' => '123',
+                'payload' => ['role' => 'org_fee', 'is_buyer' => false],
+            ],
+            [
+                'ticket_uuid' => 'aaa10003-0000-4000-8000-000000000003',
+                'type' => 'electron', 'kilter' => 900003,
+                'fio' => 'Маша Петрова (7 лет)', 'child_name' => 'Маша Петрова',
+                'parent_phone' => '+79991234567', 'email' => 'ivan@example.com',
+                'type_ticket' => 'Детский билет', 'external_order_no' => '123',
+                'payload' => ['role' => 'kid', 'child' => ['age' => 7, 'allergies' => 'пыльца']],
+            ],
+            [
+                'ticket_uuid' => 'aaa10004-0000-4000-8000-000000000004',
+                'type' => 'auto', 'kilter' => null,
+                'fio' => 'Иван Петров', 'car_number' => 'А123БВ77',
+                'type_ticket' => 'Парковка', 'external_order_no' => '123',
+                'payload' => ['role' => 'eco_car', 'car' => ['number' => 'А123БВ77']],
+            ],
+            [
+                'ticket_uuid' => 'aaa10005-0000-4000-8000-000000000005',
+                'type' => 'spisok', 'kilter' => 900005,
+                'fio' => 'Гость Списка', 'phone' => '+79993334455',
+                'email' => 'guest@example.com', 'city' => 'Самара',
+                'type_ticket' => 'Список', 'external_order_no' => '777',
+                'payload' => ['role' => 'list'],
+            ],
+        ];
+    }
+}

--- a/Baza/resources/views/tickets/search.blade.php
+++ b/Baza/resources/views/tickets/search.blade.php
@@ -32,6 +32,59 @@
                 </form>
             </div>
 
+            {{-- Богатый поиск по всем полям (ticket_search) — для гостей БЕЗ QR. --}}
+            @if (!empty($result[\Baza\Tickets\Responses\SearchResponse::TICKET_SEARCH]))
+                <div class="card">
+                    <div class="card-header card-header-success">
+                        <h5 class="title">{{ __('Найдено по данным (поиск без QR)') }}</h5>
+                    </div>
+                    <div class="card-body table-responsive">
+                        <table class="table">
+                            <thead class="text-success">
+                            <th></th>
+                            <th>ФИО</th>
+                            <th>Телефон</th>
+                            <th>Telegram</th>
+                            <th>Email</th>
+                            <th>Город</th>
+                            <th>Авто</th>
+                            <th>Ребёнок</th>
+                            <th>Тип</th>
+                            <th>№ заказа</th>
+                            <th>Номер</th>
+                            </thead>
+                            <tbody>
+                            @foreach($result[\Baza\Tickets\Responses\SearchResponse::TICKET_SEARCH] as $row)
+                                <tr>
+                                    <td>
+                                        @if(!empty($row['kilter']))
+                                            <form method="post" action="/enterForTable">
+                                                @csrf
+                                                <input type="hidden" name="id" value="{{$row['kilter']}}">
+                                                <input type="hidden" name="type" value="{{$row['type']}}">
+                                                <input type="hidden" name="q" value="{{$q}}">
+                                                <button type="submit" class="btn btn-fill btn-success">Пропустить</button>
+                                            </form>
+                                        @endif
+                                    </td>
+                                    <td>{{$row['fio']}}</td>
+                                    <td>{{$row['phone']}}</td>
+                                    <td>{{$row['telegram']}}</td>
+                                    <td>{{$row['email']}}</td>
+                                    <td>{{$row['city']}}</td>
+                                    <td>{{$row['car_number']}}</td>
+                                    <td>{{$row['child_name']}}</td>
+                                    <td>{{$row['type_ticket']}}</td>
+                                    <td>{{$row['external_order_no']}}</td>
+                                    <td>{{$row['kilter']}}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            @endif
+
             <div class="card">
                 <div class="card-header">
                     <h5 class="title">{{ __('Результат поиска') }}</h5>

--- a/Baza/scr/Ingest/Applications/IngestTicket/IngestTicketApplication.php
+++ b/Baza/scr/Ingest/Applications/IngestTicket/IngestTicketApplication.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Baza\Ingest\Applications\IngestTicket;
 
 use Baza\Ingest\Repositories\IngestRepositoryInterface;
+use Baza\Shared\Services\DefineService;
+use Baza\Tickets\Repositories\TicketSearchRepositoryInterface;
 use InvalidArgumentException;
 
 /**
@@ -14,6 +16,10 @@ use InvalidArgumentException;
  * Возвращает bool «применено ли»: для el/spisok/auto всегда true при успехе,
  * для live — false, если строки с номером ещё нет (org откатится на прямую запись).
  * Неизвестный target / битый контракт → InvalidArgumentException (контроллер отдаст 422).
+ *
+ * Помимо записи в таблицу впуска наполняет поисковый индекс `ticket_search` (богатыми
+ * полями из опционального блока `search`, иначе — узким fallback из `ticket`) — для ручного
+ * поиска на КПП по всем полям, когда у гостя нет QR.
  */
 final class IngestTicketApplication
 {
@@ -32,25 +38,80 @@ final class IngestTicketApplication
         self::TARGET_AUTO,
     ];
 
+    /** target (контракт ingest) → тип билета (DefineService, для моста к впуску). */
+    private const TARGET_TO_TYPE = [
+        self::TARGET_EL => DefineService::ELECTRON_TICKET,
+        self::TARGET_SPISOK => DefineService::SPISOK_TICKET,
+        self::TARGET_LIVE => DefineService::LIVE_TICKET,
+        self::TARGET_AUTO => DefineService::AUTO_TICKET,
+    ];
+
     public function __construct(
         private readonly IngestRepositoryInterface $repository,
+        private readonly TicketSearchRepositoryInterface $ticketSearch,
     ) {}
 
     /**
-     * @param  array<string, mixed>  $ticket
+     * @param  array<string, mixed>  $ticket  поля для таблицы впуска (узкий контракт)
+     * @param  array<string, mixed>  $search  опц. богатые поля для поиска (fio/phone/telegram/car/child/...)
      */
-    public function ingest(string $target, array $ticket): bool
+    public function ingest(string $target, array $ticket, array $search = []): bool
     {
         if (! in_array($target, self::TARGETS, true)) {
             throw new InvalidArgumentException("Неизвестная цель доставки: '{$target}'");
         }
 
-        return match ($target) {
+        $applied = match ($target) {
             self::TARGET_EL => $this->upsertEl($ticket),
             self::TARGET_SPISOK => $this->upsertSpisok($ticket),
             self::TARGET_LIVE => $this->linkLive($ticket),
             self::TARGET_AUTO => $this->upsertAuto($ticket),
         };
+
+        // Поисковый индекс — независимо от результата upsert (self-guard на отсутствие uuid внутри).
+        $this->indexSearch($target, $ticket, $search);
+
+        return $applied;
+    }
+
+    /**
+     * Наполнить ticket_search: ticket_uuid по типу + проекция искомых полей (rich `search`
+     * с fallback на узкий `ticket`). Нет org-идентификатора (напр. live без el_ticket_id) → пропуск.
+     *
+     * @param  array<string, mixed>  $ticket
+     * @param  array<string, mixed>  $search
+     */
+    private function indexSearch(string $target, array $ticket, array $search): void
+    {
+        $ticketUuid = match ($target) {
+            self::TARGET_EL => (string) ($ticket['uuid'] ?? ''),
+            self::TARGET_SPISOK => (string) ($ticket['ticket_uuid'] ?? ''),
+            self::TARGET_LIVE => (string) ($ticket['el_ticket_id'] ?? ''),
+            self::TARGET_AUTO => (string) ($ticket['order_id'] ?? ''),
+            default => '',
+        };
+
+        if ($ticketUuid === '') {
+            return;
+        }
+
+        $this->ticketSearch->index([
+            'ticket_uuid' => $ticketUuid,
+            'festival_id' => $ticket['festival_id'] ?? ($search['festival_id'] ?? null),
+            'type' => self::TARGET_TO_TYPE[$target],
+            'kilter' => $ticket['kilter'] ?? null,
+            'fio' => $search['fio'] ?? ($ticket['name'] ?? null),
+            'phone' => $search['phone'] ?? ($ticket['phone'] ?? null),
+            'telegram' => $search['telegram'] ?? null,
+            'email' => $search['email'] ?? ($ticket['email'] ?? null),
+            'city' => $search['city'] ?? ($ticket['city'] ?? null),
+            'car_number' => $search['car_number'] ?? null,
+            'child_name' => $search['child_name'] ?? null,
+            'parent_phone' => $search['parent_phone'] ?? null,
+            'external_order_no' => $search['external_order_no'] ?? null,
+            'type_ticket' => $search['type_ticket'] ?? ($ticket['type_ticket'] ?? null),
+            'payload' => $search !== [] ? $search : $ticket,
+        ]);
     }
 
     /**

--- a/Baza/scr/Sync/Repositories/InMemoryMySqlSyncRepository.php
+++ b/Baza/scr/Sync/Repositories/InMemoryMySqlSyncRepository.php
@@ -10,6 +10,7 @@ use App\Models\ElTicketsModel;
 use App\Models\LiveTicketModel;
 use App\Models\ParkingTicketModel;
 use App\Models\SpisokTicketModel;
+use App\Models\TicketSearchModel;
 use Carbon\Carbon;
 use InvalidArgumentException;
 use RuntimeException;
@@ -23,12 +24,15 @@ class InMemoryMySqlSyncRepository implements SyncRepositoryInterface
      * если когда-нибудь добавят физический FK по change_id).
      */
     private const TABLE_MODEL_MAP = [
-        ChangesModel::TABLE        => ChangesModel::class,
-        ElTicketsModel::TABLE      => ElTicketsModel::class,
-        LiveTicketModel::TABLE     => LiveTicketModel::class,
-        ParkingTicketModel::TABLE  => ParkingTicketModel::class,
-        SpisokTicketModel::TABLE   => SpisokTicketModel::class,
-        AutoModel::TABLE           => AutoModel::class,
+        ChangesModel::TABLE => ChangesModel::class,
+        ElTicketsModel::TABLE => ElTicketsModel::class,
+        LiveTicketModel::TABLE => LiveTicketModel::class,
+        ParkingTicketModel::TABLE => ParkingTicketModel::class,
+        SpisokTicketModel::TABLE => SpisokTicketModel::class,
+        AutoModel::TABLE => AutoModel::class,
+        // Поисковый индекс билетов — едет на офлайн-ноутбук КПП, чтобы ручной поиск
+        // (без QR) работал офлайн. PK автоинкрементный → синк по id + updated_at как у прочих.
+        TicketSearchModel::TABLE => TicketSearchModel::class,
     ];
 
     public function getSyncTables(): array
@@ -98,7 +102,7 @@ class InMemoryMySqlSyncRepository implements SyncRepositoryInterface
     private function normalize(array $data): array
     {
         foreach (self::TIMESTAMP_FIELDS as $field) {
-            if (!array_key_exists($field, $data) || !is_string($data[$field])) {
+            if (! array_key_exists($field, $data) || ! is_string($data[$field])) {
                 continue;
             }
             $value = $data[$field];
@@ -110,7 +114,7 @@ class InMemoryMySqlSyncRepository implements SyncRepositoryInterface
                 $data[$field] = Carbon::parse($value)->format('Y-m-d H:i:s');
             } catch (Throwable $e) {
                 throw new RuntimeException(
-                    "Невалидный timestamp в поле '{$field}': " . var_export($value, true),
+                    "Невалидный timestamp в поле '{$field}': ".var_export($value, true),
                     0,
                     $e,
                 );
@@ -125,7 +129,7 @@ class InMemoryMySqlSyncRepository implements SyncRepositoryInterface
      */
     private function resolveModel(string $table): string
     {
-        if (!isset(self::TABLE_MODEL_MAP[$table])) {
+        if (! isset(self::TABLE_MODEL_MAP[$table])) {
             throw new InvalidArgumentException("Таблица '{$table}' не разрешена для синхронизации");
         }
 

--- a/Baza/scr/Tickets/Applications/Search/SearchService.php
+++ b/Baza/scr/Tickets/Applications/Search/SearchService.php
@@ -9,19 +9,19 @@ use Baza\Tickets\Repositories\ElTicketsRepositoryInterface;
 use Baza\Tickets\Repositories\FriendlyTicketRepositoryInterface;
 use Baza\Tickets\Repositories\LiveTicketRepositoryInterface;
 use Baza\Tickets\Repositories\SpisokTicketsRepositoryInterface;
+use Baza\Tickets\Repositories\TicketSearchRepositoryInterface;
 use Baza\Tickets\Responses\SearchResponse;
 
 class SearchService
 {
     public function __construct(
-        private SpisokTicketsRepositoryInterface  $spisokTicketsRepository,
-        private ElTicketsRepositoryInterface      $elTicketsRepository,
+        private SpisokTicketsRepositoryInterface $spisokTicketsRepository,
+        private ElTicketsRepositoryInterface $elTicketsRepository,
         private FriendlyTicketRepositoryInterface $friendlyTicketRepository,
         private LiveTicketRepositoryInterface $liveTicketRepository,
         private AutoTicketRepositoryInterface $autoTicketRepository,
-    )
-    {
-    }
+        private TicketSearchRepositoryInterface $ticketSearchRepository,
+    ) {}
 
     public function find(string $q): SearchResponse
     {
@@ -31,6 +31,8 @@ class SearchService
             $this->friendlyTicketRepository->find($q),
             $this->liveTicketRepository->find($q),
             $this->autoTicketRepository->find($q),
+            // Богатый поиск по всем полям (ticket_search) — для гостей без QR.
+            $this->ticketSearchRepository->find($q),
         );
     }
 }

--- a/Baza/scr/Tickets/Repositories/InMemoryMySqlTicketSearch.php
+++ b/Baza/scr/Tickets/Repositories/InMemoryMySqlTicketSearch.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Tickets\Repositories;
+
+use App\Models\TicketSearchModel;
+use Baza\Tickets\Responses\TicketSearchResponse;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Поисковый индекс билетов ticket_search. Наполнение из ingest + поиск без QR. БД только здесь.
+ */
+class InMemoryMySqlTicketSearch implements TicketSearchRepositoryInterface
+{
+    /** Текущий фестиваль (как в остальных репозиториях поиска; кандидат на env, BAZA.md §9). */
+    private const UUID_FESTIVAL = '9d679bcf-b438-4ddb-ac04-023fa9bff4b8';
+
+    /** Сколько результатов отдавать (защита от широких запросов на слабом устройстве). */
+    private const LIMIT = 100;
+
+    /** Колонки проекции, по которым идёт текстовый поиск. */
+    private const SEARCH_COLUMNS = [
+        'fio', 'phone', 'telegram', 'email', 'city',
+        'car_number', 'child_name', 'parent_phone', 'external_order_no',
+    ];
+
+    public function index(array $row): bool
+    {
+        $uuid = (string) ($row['ticket_uuid'] ?? '');
+        if ($uuid === '') {
+            return false;
+        }
+
+        TicketSearchModel::query()->updateOrCreate(
+            ['ticket_uuid' => $uuid],
+            [
+                'festival_id' => $row['festival_id'] ?? null,
+                'type' => (string) ($row['type'] ?? ''),
+                'kilter' => isset($row['kilter']) ? (int) $row['kilter'] : null,
+                'fio' => $this->trimOrNull($row['fio'] ?? null),
+                'phone' => $this->trimOrNull($row['phone'] ?? null),
+                'telegram' => $this->trimOrNull($row['telegram'] ?? null),
+                'email' => $this->trimOrNull($row['email'] ?? null),
+                'city' => $this->trimOrNull($row['city'] ?? null),
+                'car_number' => $this->trimOrNull($row['car_number'] ?? null),
+                'child_name' => $this->trimOrNull($row['child_name'] ?? null),
+                'parent_phone' => $this->trimOrNull($row['parent_phone'] ?? null),
+                'external_order_no' => $this->trimOrNull($row['external_order_no'] ?? null),
+                'type_ticket' => $this->trimOrNull($row['type_ticket'] ?? null),
+                'payload' => is_array($row['payload'] ?? null) ? $row['payload'] : null,
+            ],
+        );
+
+        return true;
+    }
+
+    public function find(string $q): array
+    {
+        $q = trim($q);
+        if ($q === '') {
+            return [];
+        }
+
+        $like = '%'.$q.'%';
+
+        return TicketSearchModel::query()
+            ->where('festival_id', self::UUID_FESTIVAL)
+            ->where(function (Builder $query) use ($like, $q): void {
+                foreach (self::SEARCH_COLUMNS as $column) {
+                    $query->orWhere($column, 'like', $like);
+                }
+                if (ctype_digit($q)) {
+                    $query->orWhere('kilter', (int) $q);
+                }
+            })
+            ->orderBy('id')
+            ->limit(self::LIMIT)
+            ->get()
+            ->map(fn (TicketSearchModel $model) => TicketSearchResponse::fromState($model->toArray()))
+            ->all();
+    }
+
+    private function trimOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return $value === null ? null : (string) $value;
+        }
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/Baza/scr/Tickets/Repositories/TicketSearchRepositoryInterface.php
+++ b/Baza/scr/Tickets/Repositories/TicketSearchRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Tickets\Repositories;
+
+use Baza\Tickets\Responses\TicketSearchResponse;
+
+/**
+ * Поисковый индекс билетов ticket_search (ручной поиск на КПП без QR). БД только здесь.
+ *
+ * Наполняется из ingest (org→Baza), ищется на экране `/search`. Найдя — впуск по type+kilter.
+ */
+interface TicketSearchRepositoryInterface
+{
+    /**
+     * Записать/обновить строку индекса (идемпотентно по ticket_uuid).
+     *
+     * @param  array<string, mixed>  $row  ticket_uuid,festival_id,type,kilter + проекция + payload
+     */
+    public function index(array $row): bool;
+
+    /**
+     * Поиск по строке $q (LIKE по проекции: ФИО/телефон/телега/email/госномер/имя ребёнка/
+     * телефон родителя/№ заказа; либо точный kilter). Фильтр по festival.
+     *
+     * @return TicketSearchResponse[]
+     */
+    public function find(string $q): array;
+}

--- a/Baza/scr/Tickets/Responses/SearchResponse.php
+++ b/Baza/scr/Tickets/Responses/SearchResponse.php
@@ -9,11 +9,15 @@ use Baza\Tickets\Applications\Scan\TicketResponseInterface;
 
 class SearchResponse implements TicketResponseInterface
 {
+    /** Ключ группы богатого поиска (ticket_search) в результате. */
+    public const TICKET_SEARCH = 'ticket_search';
+
     /**
-     * @param SpisokTicketResponse[] $spisok
-     * @param ElTicketResponse[] $electron
-     * @param FriendlyTicketResponse[] $drug
-     * @param LiveTicketResponse[] $live
+     * @param  SpisokTicketResponse[]  $spisok
+     * @param  ElTicketResponse[]  $electron
+     * @param  FriendlyTicketResponse[]  $drug
+     * @param  LiveTicketResponse[]  $live
+     * @param  TicketSearchResponse[]  $ticketSearch  богатый поиск по всем полям (гость без QR)
      */
     public function __construct(
         private array $spisok,
@@ -21,9 +25,8 @@ class SearchResponse implements TicketResponseInterface
         private array $drug,
         private array $live,
         private array $auto,
-    )
-    {
-    }
+        private array $ticketSearch = [],
+    ) {}
 
     public function toArray(): array
     {
@@ -48,6 +51,10 @@ class SearchResponse implements TicketResponseInterface
             $result[DefineService::AUTO_TICKET][] = $item->toArray();
         }
 
+        foreach ($this->ticketSearch as $item) {
+            $result[self::TICKET_SEARCH][] = $item->toArray();
+        }
+
         return $result;
     }
 
@@ -58,7 +65,8 @@ class SearchResponse implements TicketResponseInterface
             $data[DefineService::ELECTRON_TICKET],
             $data[DefineService::DRUG_TICKET],
             $data[DefineService::LIVE_TICKET],
-            $data[DefineService::AUTO_TICKET]
+            $data[DefineService::AUTO_TICKET],
+            $data[self::TICKET_SEARCH] ?? [],
         );
     }
 }

--- a/Baza/scr/Tickets/Responses/TicketSearchResponse.php
+++ b/Baza/scr/Tickets/Responses/TicketSearchResponse.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baza\Tickets\Responses;
+
+/**
+ * Результат поиска в индексе ticket_search (ручной поиск на КПП без QR).
+ * Несёт богатые поля для показа карточки + type/kilter для моста к впуску (enterForTable).
+ */
+final class TicketSearchResponse
+{
+    public function __construct(
+        private readonly string $type,        // DefineService: electron|spisok|live|auto
+        private readonly ?int $kilter,
+        private readonly ?string $fio,
+        private readonly ?string $phone,
+        private readonly ?string $telegram,
+        private readonly ?string $email,
+        private readonly ?string $city,
+        private readonly ?string $carNumber,
+        private readonly ?string $childName,
+        private readonly ?string $parentPhone,
+        private readonly ?string $externalOrderNo,
+        private readonly ?string $typeTicket,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    public static function fromState(array $row): self
+    {
+        return new self(
+            (string) ($row['type'] ?? ''),
+            isset($row['kilter']) ? (int) $row['kilter'] : null,
+            $row['fio'] ?? null,
+            $row['phone'] ?? null,
+            $row['telegram'] ?? null,
+            $row['email'] ?? null,
+            $row['city'] ?? null,
+            $row['car_number'] ?? null,
+            $row['child_name'] ?? null,
+            $row['parent_phone'] ?? null,
+            $row['external_order_no'] ?? null,
+            $row['type_ticket'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'kilter' => $this->kilter,
+            'fio' => $this->fio,
+            'phone' => $this->phone,
+            'telegram' => $this->telegram,
+            'email' => $this->email,
+            'city' => $this->city,
+            'car_number' => $this->carNumber,
+            'child_name' => $this->childName,
+            'parent_phone' => $this->parentPhone,
+            'external_order_no' => $this->externalOrderNo,
+            'type_ticket' => $this->typeTicket,
+        ];
+    }
+}

--- a/Baza/tests/Feature/TicketSearch/TicketSearchTest.php
+++ b/Baza/tests/Feature/TicketSearch/TicketSearchTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TicketSearch;
+
+use App\Models\TicketSearchModel;
+use Baza\Sync\Repositories\SyncRepositoryInterface;
+use Baza\Tickets\Applications\Search\SearchService;
+use Baza\Tickets\Responses\SearchResponse;
+use Carbon\Carbon;
+use Database\Seeders\ChangesTestDataSeeder;
+use Database\Seeders\TicketSearchTestDataSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Ф-rich: поисковый индекс ticket_search — наполнение из ingest + поиск по всем полям
+ * (ручной поиск на КПП без QR). БД baza_test.
+ */
+class TicketSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TOKEN = 'test-baza-ingest-token';
+
+    private const INGEST_URL = '/api/baza/ingest/ticket';
+
+    private const FESTIVAL_ID = ChangesTestDataSeeder::FESTIVAL_ID;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.baza_ingest.tokens' => [self::TOKEN]]);
+    }
+
+    /** @return array<string,string> */
+    private function auth(): array
+    {
+        return ['X-Baza-Token' => self::TOKEN];
+    }
+
+    private function elTicket(string $uuid, int $kilter): array
+    {
+        return [
+            'uuid' => $uuid, 'kilter' => $kilter, 'city' => 'Казань',
+            'name' => 'Иван Петров', 'email' => 'ivan@example.com', 'phone' => '+79991234567',
+            'date_order' => Carbon::now()->toIso8601String(), 'status' => 'paid',
+            'festival_id' => self::FESTIVAL_ID, 'type_ticket' => 'Оргвзнос',
+        ];
+    }
+
+    public function test_ingest_with_search_block_populates_rich_index(): void
+    {
+        $uuid = 'bbb20001-0000-4000-8000-000000000001';
+        $this->postJson(self::INGEST_URL, [
+            'target' => 'el_tickets',
+            'ticket' => $this->elTicket($uuid, 800001),
+            'search' => [
+                'fio' => 'Иван Петров', 'phone' => '+79991234567', 'telegram' => 'ivan',
+                'email' => 'ivan@example.com', 'city' => 'Казань',
+                'external_order_no' => '123', 'type_ticket' => 'Оргвзнос',
+            ],
+        ], $this->auth())->assertStatus(200)->assertJson(['success' => true]);
+
+        $row = TicketSearchModel::query()->where('ticket_uuid', $uuid)->first();
+        self::assertNotNull($row);
+        self::assertSame('electron', $row->type);
+        self::assertSame('ivan', $row->telegram);
+        self::assertSame(800001, (int) $row->kilter);
+        self::assertSame('123', $row->external_order_no);
+    }
+
+    public function test_ingest_without_search_falls_back_to_ticket_fields(): void
+    {
+        $uuid = 'bbb20002-0000-4000-8000-000000000002';
+        $this->postJson(self::INGEST_URL, [
+            'target' => 'el_tickets',
+            'ticket' => $this->elTicket($uuid, 800002),
+        ], $this->auth())->assertStatus(200);
+
+        $row = TicketSearchModel::query()->where('ticket_uuid', $uuid)->first();
+        self::assertNotNull($row);
+        self::assertSame('Иван Петров', $row->fio);   // name → fio
+        self::assertSame('+79991234567', $row->phone);
+        self::assertSame('Казань', $row->city);
+    }
+
+    public function test_ingest_is_idempotent_by_uuid(): void
+    {
+        $uuid = 'bbb20003-0000-4000-8000-000000000003';
+        $body = ['target' => 'el_tickets', 'ticket' => $this->elTicket($uuid, 800003)];
+
+        $this->postJson(self::INGEST_URL, $body, $this->auth())->assertStatus(200);
+        $body['search'] = ['fio' => 'Обновлённое Имя'];
+        $this->postJson(self::INGEST_URL, $body, $this->auth())->assertStatus(200);
+
+        self::assertSame(1, TicketSearchModel::query()->where('ticket_uuid', $uuid)->count());
+        self::assertSame('Обновлённое Имя', TicketSearchModel::query()->where('ticket_uuid', $uuid)->value('fio'));
+    }
+
+    public function test_search_finds_by_rich_fields(): void
+    {
+        $this->seed(TicketSearchTestDataSeeder::class);
+        $search = app(SearchService::class);
+
+        // по ФИО
+        $byName = $search->find('Петров')->toArray()[SearchResponse::TICKET_SEARCH] ?? [];
+        self::assertNotEmpty($byName, 'поиск по ФИО должен найти');
+
+        // по telegram
+        $byTg = $search->find('ivan')->toArray()[SearchResponse::TICKET_SEARCH] ?? [];
+        self::assertNotEmpty($byTg, 'поиск по telegram должен найти');
+
+        // по госномеру
+        $byCar = $search->find('А123БВ77')->toArray()[SearchResponse::TICKET_SEARCH] ?? [];
+        self::assertNotEmpty($byCar, 'поиск по госномеру должен найти');
+        self::assertSame('auto', $byCar[0]['type']);
+
+        // по имени ребёнка
+        $byChild = $search->find('Маша')->toArray()[SearchResponse::TICKET_SEARCH] ?? [];
+        self::assertNotEmpty($byChild, 'поиск по имени ребёнка должен найти');
+    }
+
+    public function test_seeder_is_idempotent(): void
+    {
+        $this->seed(TicketSearchTestDataSeeder::class);
+        $this->seed(TicketSearchTestDataSeeder::class);
+
+        self::assertSame(5, TicketSearchModel::query()->count());
+    }
+
+    public function test_ticket_search_is_in_sync_tables(): void
+    {
+        self::assertContains('ticket_search', app(SyncRepositoryInterface::class)->getSyncTables());
+    }
+}


### PR DESCRIPTION
## Что (поиск по всем полям без QR — часть 1/2)

Единая **локальная** таблица-индекс `ticket_search` для ручного поиска на КПП, когда у гостя **НЕТ работающего QR** (сел телефон, детский билет, парковка). Поиск по ФИО / телефону / telegram / госномеру / имени ребёнка / № заказа.

**Офлайн + мобильный:** `ticket_search` — локальная таблица Baza → поиск = локальный SQL, **работает офлайн**; едет на ноутбук/телефон КПП через **существующий синк** (поэтому PK автоинкрементный, как у синкаемых таблиц).

## Как
- **Миграция** `ticket_search`: `id` autoincrement (для синка) + `ticket_uuid` UNIQUE + `festival_id` + `type` (DefineService) + `kilter` (мост к впуску) + проекция искомых колонок (fio/phone/telegram/email/city/car_number/child_name/parent_phone/external_order_no/type_ticket) + `payload` JSON as-is. Поиск — по лёгким индексированным колонкам, не по JSON.
- **Наполнение из ingest:** контракт стал `{target, ticket, search?}`. `IngestTicketApplication` пишет `ticket_search` из опционального богатого блока `search`, fallback на узкий `ticket`. Идемпотентно по `ticket_uuid`.
- **Поиск:** `TicketSearchRepository` (LIKE по проекции + точный kilter, фильтр festival, лимит 100). `SearchService`/`SearchResponse` получили группу `ticket_search`; в `search.blade` — секция «Найдено по данным (без QR)» с формой «Пропустить» (мост к впуску по `type+kilter`).
- **Синк:** `ticket_search` добавлена в `getSyncTables` → офлайн-ноутбук КПП получает индекс.
- **Сидер** `TicketSearchTestDataSeeder` — идемпотентные демо-строки (5) для проверки поиска на стенде (org→Baza ingest наполняет боевые).

## Проверка
- `TicketSearchTest` (6): ingest с `search`/fallback, идемпотентность по uuid, поиск по ФИО/telegram/госномеру/ребёнку, идемпотентность сидера, наличие в синке.
- Полный сьют Baza — **98**. Pint — чисто.

## Дальше (часть 2/2)
org обогащает ingest-payload блоком `search` (богатые данные гостя из `qr_orders.payload`) при доставке в Baza. Сейчас `ticket_search` уже работает на узких полях (ФИО/email/телефон/город) — org-обогащение добавит telegram/car/child/external_no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
