### PR TITLE
feat(baza): обогащение доставки богатыми данными гостя для поиска без QR (2/2)

### DIFF
--- a/Backend/app/Models/BazaDelivery/BazaDeliveryModel.php
+++ b/Backend/app/Models/BazaDelivery/BazaDeliveryModel.php
@@ -28,8 +28,10 @@ use Shared\Infrastructure\Models\HasUuid;
  * @property Carbon|null $delivered_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ *
  * @method static Builder|BazaDeliveryModel query()
  * @method static Builder|BazaDeliveryModel whereId($value)
+ *
  * @mixin Eloquent
  */
 class BazaDeliveryModel extends Model
@@ -54,6 +56,7 @@ class BazaDeliveryModel extends Model
         'festival_id',
         'source',
         'subject_blob',
+        'search_blob',
         'delivered_at',
     ];
 

--- a/Backend/database/migrations/2026_06_20_160000_add_search_blob_to_baza_deliveries.php
+++ b/Backend/database/migrations/2026_06_20_160000_add_search_blob_to_baza_deliveries.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Богатые данные гостя для поискового индекса Baza (ticket_search, поиск без QR).
+ *
+ * Рядом с subject_blob (узкий TicketResponse для записи в таблицу впуска) храним search_blob —
+ * base64(json) богатых полей гостя (fio/phone/telegram/car/child/...). DeliverTicketToBazaJob
+ * прикладывает их к ingest-запросу как блок `search`, Baza наполняет ticket_search.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('baza_deliveries', 'search_blob')) {
+            return;
+        }
+
+        Schema::table('baza_deliveries', function (Blueprint $table) {
+            $table->longText('search_blob')->nullable()->after('subject_blob');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('baza_deliveries', 'search_blob')) {
+            return;
+        }
+
+        Schema::table('baza_deliveries', function (Blueprint $table) {
+            $table->dropColumn('search_blob');
+        });
+    }
+};

--- a/Backend/src/BazaDelivery/Application/BazaDeliveryDispatcher.php
+++ b/Backend/src/BazaDelivery/Application/BazaDeliveryDispatcher.php
@@ -25,22 +25,26 @@ use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
 final class BazaDeliveryDispatcher
 {
     public const TARGET_EL = 'el_tickets';
+
     public const TARGET_SPISOK = 'spisok_tickets';
+
     public const TARGET_LIVE = 'live_tickets';
+
     public const TARGET_AUTO = 'auto';
 
     public function __construct(
         private readonly BazaDeliveryRepositoryInterface $repository,
         private readonly HistoryRepositoryInterface $history,
-    ) {
-    }
+    ) {}
 
     /**
      * Поставить доставку билета (обычного/списочного) в очередь. target выводится из билета:
      * списочный (isList) → spisok_tickets, иначе → el_tickets. Описательные поля — из самого билета.
      * Возвращает id записи baza_deliveries.
+     *
+     * @param  array<string, mixed>|null  $search  богатые поля гостя для поискового индекса Baza (ticket_search)
      */
-    public function dispatch(TicketResponse $ticket, BazaDeliveryContext $ctx): Uuid
+    public function dispatch(TicketResponse $ticket, BazaDeliveryContext $ctx, ?array $search = null): Uuid
     {
         $target = $ticket->isList() ? self::TARGET_SPISOK : self::TARGET_EL;
 
@@ -58,6 +62,7 @@ final class BazaDeliveryDispatcher
             ),
             // Несём готовый TicketResponse: getTicket не пересоберёт qr-билет (заказ в qr_orders, не order_tickets).
             base64_encode(serialize($ticket)),
+            $search !== null && $search !== [] ? base64_encode((string) json_encode($search)) : null,
         );
     }
 
@@ -110,7 +115,7 @@ final class BazaDeliveryDispatcher
      *
      * Используется dispatch() (el/spisok) и точечными вызовами live/auto (target задан явно).
      */
-    public function enqueue(Uuid $ticketId, string $target, BazaDeliveryContext $ctx, ?string $subjectBlob = null): Uuid
+    public function enqueue(Uuid $ticketId, string $target, BazaDeliveryContext $ctx, ?string $subjectBlob = null, ?string $searchBlob = null): Uuid
     {
         $existing = $this->repository->findByTicketTarget($ticketId, $target);
 
@@ -123,7 +128,7 @@ final class BazaDeliveryDispatcher
             $this->repository->requeue($id);
         } else {
             $id = Uuid::random();
-            $this->repository->create(BazaDeliveryDto::queued($id, $ticketId, $target, $ctx), $subjectBlob);
+            $this->repository->create(BazaDeliveryDto::queued($id, $ticketId, $target, $ctx), $subjectBlob, $searchBlob);
         }
 
         $this->history->save(new SaveHistoryDto(

--- a/Backend/src/BazaDelivery/Application/Client/BazaIngestClient.php
+++ b/Backend/src/BazaDelivery/Application/Client/BazaIngestClient.php
@@ -30,24 +30,27 @@ final class BazaIngestClient
 
     /**
      * @param  array<string, mixed>  $ticket
+     * @param  array<string, mixed>  $search  опц. богатые поля гостя для поискового индекса Baza (ticket_search)
      * @return bool|null true — Baza применила запись; false — Baza явно НЕ применила (200 success:false,
      *                   напр. live-номера ещё нет); null — канал выключен / HTTP-ошибка / транспорт упал.
      *                   В случае false/null вызывающий откатывается на прямую запись.
      */
-    public function send(string $target, array $ticket): ?bool
+    public function send(string $target, array $ticket, array $search = []): ?bool
     {
         if (! $this->isEnabled()) {
             return null;
+        }
+
+        $body = ['target' => $target, 'ticket' => $ticket];
+        if ($search !== []) {
+            $body['search'] = $search;
         }
 
         try {
             $response = Http::withHeaders(['X-Baza-Token' => $this->token()])
                 ->acceptJson()
                 ->timeout(self::TIMEOUT)
-                ->post($this->baseUrl().self::PATH, [
-                    'target' => $target,
-                    'ticket' => $ticket,
-                ]);
+                ->post($this->baseUrl().self::PATH, $body);
 
             if (! $response->successful()) {
                 BazaDeliveryLog::logger()->warning('baza.ingest.http_error', [

--- a/Backend/src/BazaDelivery/Application/Job/DeliverTicketToBazaJob.php
+++ b/Backend/src/BazaDelivery/Application/Job/DeliverTicketToBazaJob.php
@@ -145,15 +145,18 @@ final class DeliverTicketToBazaJob implements ShouldQueue
         AutoRepositoryInterface $autos,
         BazaIngestClient $client,
     ): bool {
+        // Богатые поля гостя для поискового индекса Baza (ticket_search) — если org их приложил.
+        $search = $this->resolveSearch($delivery, $repository);
+
         switch ($delivery->getTarget()) {
             case 'el_tickets':
                 $ticket = $this->resolveTicket($delivery, $repository, $tickets);
 
-                return $this->ingestOrDirect($client, 'el_tickets', $ticket->toArrayForBaza(), fn () => $tickets->setInBaza($ticket));
+                return $this->ingestOrDirect($client, 'el_tickets', $ticket->toArrayForBaza(), $search, fn () => $tickets->setInBaza($ticket));
             case 'spisok_tickets':
                 $ticket = $this->resolveTicket($delivery, $repository, $tickets);
 
-                return $this->ingestOrDirect($client, 'spisok_tickets', $ticket->toArrayForSpisok(), fn () => $tickets->setInBazaList($ticket));
+                return $this->ingestOrDirect($client, 'spisok_tickets', $ticket->toArrayForSpisok(), $search, fn () => $tickets->setInBazaList($ticket));
             case 'live_tickets':
                 $number = (int) $delivery->getNumber();
                 $ticketId = $delivery->getTicketId();
@@ -162,10 +165,11 @@ final class DeliverTicketToBazaJob implements ShouldQueue
                     $client,
                     'live_tickets',
                     ['kilter' => $number, 'el_ticket_id' => $ticketId?->value()],
+                    $search,
                     fn () => $tickets->setInBazaLive($number, $ticketId),
                 );
             case 'auto':
-                return $this->deliverAuto($delivery, $autos, $client);
+                return $this->deliverAuto($delivery, $autos, $client, $search);
             default:
                 throw new RuntimeException('Неизвестная цель доставки в Baza: '.$delivery->getTarget());
         }
@@ -178,15 +182,33 @@ final class DeliverTicketToBazaJob implements ShouldQueue
      * напр. нет live-номера) / null (канал выключен или ошибка транспорта) → прямая запись.
      *
      * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $search  богатые поля для ticket_search (пусто → fallback на ticket в Baza)
      * @param  callable(): bool  $direct
      */
-    private function ingestOrDirect(BazaIngestClient $client, string $target, array $payload, callable $direct): bool
+    private function ingestOrDirect(BazaIngestClient $client, string $target, array $payload, array $search, callable $direct): bool
     {
-        if ($client->send($target, $payload) === true) {
+        if ($client->send($target, $payload, $search) === true) {
             return true;
         }
 
         return (bool) $direct();
+    }
+
+    /**
+     * Богатые поля гостя из search_blob (base64-json), приложенные org-доставкой. Пусто → [].
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveSearch(BazaDeliveryDto $delivery, BazaDeliveryRepositoryInterface $repository): array
+    {
+        $blob = $repository->getSearchBlob($delivery->getId());
+        if ($blob === null || $blob === '') {
+            return [];
+        }
+
+        $decoded = json_decode((string) base64_decode($blob), true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**
@@ -209,8 +231,12 @@ final class DeliverTicketToBazaJob implements ShouldQueue
         return $tickets->getTicket($delivery->getTicketId(), true);
     }
 
-    /** Запись авто заказа-списка в Baza: пересобираем AutoDto по id, ingest-API → fallback setInBazaAuto. */
-    private function deliverAuto(BazaDeliveryDto $delivery, AutoRepositoryInterface $autos, BazaIngestClient $client): bool
+    /**
+     * Запись авто заказа-списка в Baza: пересобираем AutoDto по id, ingest-API → fallback setInBazaAuto.
+     *
+     * @param  array<string, mixed>  $search
+     */
+    private function deliverAuto(BazaDeliveryDto $delivery, AutoRepositoryInterface $autos, BazaIngestClient $client, array $search): bool
     {
         $auto = $autos->getById($delivery->getTicketId());
         if ($auto === null) {
@@ -230,6 +256,7 @@ final class DeliverTicketToBazaJob implements ShouldQueue
             $client,
             'auto',
             $payload,
+            $search,
             fn () => $autos->setInBazaAuto($auto, $festivalId !== null ? new Uuid($festivalId) : null),
         );
     }

--- a/Backend/src/BazaDelivery/Repositories/BazaDeliveryRepositoryInterface.php
+++ b/Backend/src/BazaDelivery/Repositories/BazaDeliveryRepositoryInterface.php
@@ -20,13 +20,17 @@ interface BazaDeliveryRepositoryInterface
     /**
      * Создать запись доставки (status=queued). Одна строка на (ticket_id, target) — UNIQUE.
      * $subjectBlob = base64(serialize(TicketResponse)) для el/spisok (для записи в Baza/повтора).
+     * $searchBlob = base64(json) богатых полей гостя для поискового индекса Baza (ticket_search).
      */
-    public function create(BazaDeliveryDto $dto, ?string $subjectBlob = null): bool;
+    public function create(BazaDeliveryDto $dto, ?string $subjectBlob = null, ?string $searchBlob = null): bool;
 
     public function findById(Uuid $id): ?BazaDeliveryDto;
 
     /** Сериализованный субъект доставки (TicketResponse) для el/spisok, или null. */
     public function getSubjectBlob(Uuid $id): ?string;
+
+    /** base64(json) богатых полей гостя для ingest-блока `search` (ticket_search), или null. */
+    public function getSearchBlob(Uuid $id): ?string;
 
     /** Текущая доставка по (билет, цель) — для идемпотентного диспатча (создать/повторить). */
     public function findByTicketTarget(Uuid $ticketId, string $target): ?BazaDeliveryDto;

--- a/Backend/src/BazaDelivery/Repositories/InMemoryMySqlBazaDeliveryRepository.php
+++ b/Backend/src/BazaDelivery/Repositories/InMemoryMySqlBazaDeliveryRepository.php
@@ -19,15 +19,14 @@ final class InMemoryMySqlBazaDeliveryRepository implements BazaDeliveryRepositor
 {
     public function __construct(
         private BazaDeliveryModel $model,
-    ) {
-    }
+    ) {}
 
-    public function create(BazaDeliveryDto $dto, ?string $subjectBlob = null): bool
+    public function create(BazaDeliveryDto $dto, ?string $subjectBlob = null, ?string $searchBlob = null): bool
     {
         // create() (а не insert) — единая точка форматирования через Eloquent-касты.
         return (bool) $this->model::create(array_merge(
             $dto->toArrayForCreate(),
-            ['subject_blob' => $subjectBlob],
+            ['subject_blob' => $subjectBlob, 'search_blob' => $searchBlob],
         ));
     }
 
@@ -41,6 +40,11 @@ final class InMemoryMySqlBazaDeliveryRepository implements BazaDeliveryRepositor
     public function getSubjectBlob(Uuid $id): ?string
     {
         return $this->model::query()->select('subject_blob')->whereId($id->value())->first()?->subject_blob;
+    }
+
+    public function getSearchBlob(Uuid $id): ?string
+    {
+        return $this->model::query()->select('search_blob')->whereId($id->value())->first()?->search_blob;
     }
 
     public function findByTicketTarget(Uuid $ticketId, string $target): ?BazaDeliveryDto

--- a/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
+++ b/Backend/src/QrOrder/Application/Step/PushToBazaStep.php
@@ -8,6 +8,7 @@ use Tickets\BazaDelivery\Application\BazaDeliveryContext;
 use Tickets\BazaDelivery\Application\BazaDeliveryDispatcher;
 use Tickets\History\Domain\ActorType;
 use Tickets\QrOrder\Application\Support\PipelineLog;
+use Tickets\QrOrder\Application\Support\QrTicketId;
 use Tickets\QrOrder\Dto\QrOrderDto;
 use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
 
@@ -23,8 +24,7 @@ final class PushToBazaStep implements PipelineStepInterface
 {
     public function __construct(
         private readonly BazaDeliveryDispatcher $dispatcher,
-    ) {
-    }
+    ) {}
 
     public function name(): string
     {
@@ -38,6 +38,11 @@ final class PushToBazaStep implements PipelineStepInterface
         $log = PipelineLog::logger();
         $queued = 0;
 
+        // Карта детерминированный ticket_id → исходный гость (rich-данные для поиска без QR).
+        // Тот же id, что в CreateTicketsStep (QrTicketId::forGuest) — связываем билет с гостем.
+        $guestByTicketId = $this->mapGuestsByTicketId($order);
+        $externalOrderNo = $order->getExternalOrderNo();
+
         foreach ($responses as $response) {
             // el_tickets-билету нужен type_ticket_id (как в классике). Списочный билет (isList)
             // пишется в spisok_tickets и в типе билета не нуждается.
@@ -50,9 +55,12 @@ final class PushToBazaStep implements PipelineStepInterface
                 continue;
             }
 
+            $guest = $guestByTicketId[$response->getId()->value()] ?? [];
+
             $this->dispatcher->dispatch(
                 $response,
                 new BazaDeliveryContext(source: 'qr_pipeline', actorType: ActorType::QR),
+                $this->buildSearch($guest, $externalOrderNo),
             );
             $queued++;
         }
@@ -63,5 +71,57 @@ final class PushToBazaStep implements PipelineStepInterface
         ]);
 
         return $carry;
+    }
+
+    /**
+     * Сопоставить гостей контракта с билетами по детерминированному id (как в CreateTicketsStep).
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function mapGuestsByTicketId(QrOrderDto $order): array
+    {
+        $guests = $order->getPayload()['guests'] ?? [];
+        if (! is_array($guests)) {
+            return [];
+        }
+
+        $map = [];
+        foreach ($guests as $index => $guest) {
+            if (! is_array($guest)) {
+                continue;
+            }
+            $map[QrTicketId::forGuest($order->getId(), $index)->value()] = $guest;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Богатые поля гостя для поискового индекса Baza (ticket_search) — поиск без QR.
+     *
+     * @param  array<string, mixed>  $guest
+     * @return array<string, mixed>
+     */
+    private function buildSearch(array $guest, ?string $externalOrderNo): array
+    {
+        $car = is_array($guest['car'] ?? null) ? $guest['car'] : [];
+        $child = is_array($guest['child'] ?? null) ? $guest['child'] : [];
+        $typeTicket = is_array($guest['type_ticket'] ?? null) ? $guest['type_ticket'] : [];
+
+        $search = [
+            'fio' => $guest['fio'] ?? ($guest['name'] ?? null),
+            'phone' => $guest['phone'] ?? null,
+            'telegram' => $guest['telegram'] ?? null,
+            'email' => $guest['email'] ?? null,
+            'city' => $guest['city'] ?? null,
+            'car_number' => $car['number'] ?? null,
+            'child_name' => $child['name'] ?? null,
+            'parent_phone' => $child['parent_phone'] ?? null,
+            'external_order_no' => $externalOrderNo,
+            'type_ticket' => $typeTicket['title'] ?? null,
+        ];
+
+        // Отбрасываем пустые — пусть Baza применит fallback на узкий ticket для отсутствующих.
+        return array_filter($search, static fn ($v) => $v !== null && $v !== '');
     }
 }

--- a/Backend/tests/Feature/BazaDelivery/BazaSearchEnrichmentTest.php
+++ b/Backend/tests/Feature/BazaDelivery/BazaSearchEnrichmentTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\BazaDelivery;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Shared\Domain\ValueObject\Uuid;
+use Tests\TestCase;
+use Tickets\Auto\Repositories\AutoRepositoryInterface;
+use Tickets\BazaDelivery\Application\BazaDeliveryContext;
+use Tickets\BazaDelivery\Application\BazaDeliveryDispatcher;
+use Tickets\BazaDelivery\Application\Job\DeliverTicketToBazaJob;
+use Tickets\BazaDelivery\Repositories\BazaDeliveryRepositoryInterface;
+use Tickets\History\Repositories\HistoryRepositoryInterface;
+use Tickets\Ticket\CreateTickets\Application\GetTicket\TicketResponse;
+use Tickets\Ticket\CreateTickets\Repositories\TicketsRepositoryInterface;
+
+/**
+ * Ф-rich (часть 2/2): org обогащает доставку в Baza богатыми полями гостя (search_blob) →
+ * прикладывает их к ingest как блок `search` → Baza наполняет ticket_search (поиск без QR).
+ */
+class BazaSearchEnrichmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const BASE = 'https://baza.test';
+
+    private function ticketResponse(): TicketResponse
+    {
+        return new TicketResponse(
+            name: 'Иван Петров',
+            kilter: 12345,
+            uuid: Uuid::random(),
+            status: 'paid',
+            email: 'ivan@example.com',
+            phone: '+79991234567',
+            city: 'Казань',
+            comment: null,
+            date_order: Carbon::now(),
+            festival_id: Uuid::random(),
+            type_ticket_id: Uuid::random(),
+        );
+    }
+
+    /** @return array<string,mixed> */
+    private function search(): array
+    {
+        return [
+            'fio' => 'Иван Петров', 'phone' => '+79991234567', 'telegram' => 'ivan',
+            'car_number' => 'А123БВ77', 'child_name' => 'Маша Петрова', 'external_order_no' => '123',
+        ];
+    }
+
+    public function test_dispatcher_stores_search_blob(): void
+    {
+        $id = app(BazaDeliveryDispatcher::class)->dispatch(
+            $this->ticketResponse(),
+            new BazaDeliveryContext(source: 'qr_pipeline'),
+            $this->search(),
+        );
+
+        $blob = app(BazaDeliveryRepositoryInterface::class)->getSearchBlob($id);
+        self::assertNotNull($blob);
+        $decoded = json_decode(base64_decode($blob), true);
+        self::assertSame('ivan', $decoded['telegram']);
+        self::assertSame('А123БВ77', $decoded['car_number']);
+    }
+
+    public function test_deliver_includes_search_in_ingest_body(): void
+    {
+        config(['services.baza_ingest.url' => self::BASE, 'services.baza_ingest.token' => 'tok']);
+        Http::fake([self::BASE.'/*' => Http::response(['success' => true], 200)]);
+
+        $id = app(BazaDeliveryDispatcher::class)->dispatch(
+            $this->ticketResponse(),
+            new BazaDeliveryContext(source: 'qr_pipeline'),
+            $this->search(),
+        );
+
+        $this->runJob($id);
+
+        Http::assertSent(fn ($req) => $req->url() === self::BASE.'/api/baza/ingest/ticket'
+            && isset($req['search'])
+            && $req['search']['telegram'] === 'ivan'
+            && $req['search']['child_name'] === 'Маша Петрова');
+    }
+
+    public function test_no_search_blob_omits_search_block(): void
+    {
+        config(['services.baza_ingest.url' => self::BASE, 'services.baza_ingest.token' => 'tok']);
+        Http::fake([self::BASE.'/*' => Http::response(['success' => true], 200)]);
+
+        // Доставка без search (классический путь) → в теле ingest нет блока search.
+        $id = app(BazaDeliveryDispatcher::class)->dispatch(
+            $this->ticketResponse(),
+            new BazaDeliveryContext(source: 'qr_pipeline'),
+        );
+
+        $this->runJob($id);
+
+        Http::assertSent(fn ($req) => $req->url() === self::BASE.'/api/baza/ingest/ticket' && ! isset($req['search']));
+    }
+
+    private function runJob(Uuid $id): void
+    {
+        (new DeliverTicketToBazaJob($id->value()))->handle(
+            app(BazaDeliveryRepositoryInterface::class),
+            app(TicketsRepositoryInterface::class),
+            app(HistoryRepositoryInterface::class),
+            app(AutoRepositoryInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
## Что (поиск по всем полям без QR — часть 2/2)

org прикладывает к ingest-запросу в Baza **богатые поля гостя** (`search`) из rich-контракта qr → Baza наполняет `ticket_search` (PR #113) → ручной поиск на КПП работает по **telegram / госномеру / имени ребёнка / № заказа**, а не только по ФИО/email/телефону.

## Как
- **Миграция:** колонка `search_blob` в `baza_deliveries` (рядом с `subject_blob`).
- **`PushToBazaStep`** сопоставляет билет ↔ гостя по детерминированному `QrTicketId::forGuest` (тот же id, что в `CreateTicketsStep`) и собирает `search`-блок: fio/phone/telegram/email/city/car_number/child_name/parent_phone/external_order_no/type_ticket из `guests[]` контракта qr.
- **Диспетчер** хранит `search_blob`; **`DeliverTicketToBazaJob`** читает его и прикладывает к ingest как блок `search`; **`BazaIngestClient.send(target, ticket, search)`** добавляет в тело.
- **Узкий контракт `ticket` НЕ тронут** (1:1 со схемой `el_tickets`) — богатое едет отдельным блоком, нулевой риск для записи в таблицу впуска.

## Важно
- `ticket_search` наполняется через **ingest-API** → требует канал ingest ON (`BAZA_INGEST_URL/TOKEN`). Уже работает на узких полях (ФИО/email/телефон/город) даже без обогащения.
- Идемпотентность `(ticket_id, target)`: `search_blob` ставится при первой доставке; ретрай/повтор не переписывает (как `subject_blob`).

## Проверка
- `BazaSearchEnrichmentTest` (3): `search_blob` хранится; тело ingest содержит `search` (telegram/child_name); доставка без `search` не шлёт блок.
- Существующие `DeliverTicketToBazaJobTest` (8) + `BazaIngestRoutingTest` (4) — зелёные (обратная совместимость).
- Полный сьют Backend — **486**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
