### PR TITLE
fix(baza): /baza/ nginx 403 — index index.html (Ф5 PR-1)

### DIFF
--- a/Docker/nginx/default.staging.conf
+++ b/Docker/nginx/default.staging.conf
@@ -71,6 +71,9 @@ server {
 
     location /baza/ {
         alias /var/www/baza/dist/;
+        # index ПЕРЕопределяем на index.html: на уровне server задан `index index.php`,
+        # и без этого try_files `$uri/` для каталога /baza/ ищет index.php → 403.
+        index index.html;
         try_files $uri $uri/ /baza/index.html;
     }
 


### PR DESCRIPTION
Фикс 403 на `/baza/` (BazaFront PWA): в vhod-блоке на уровне server задан `index index.php`, поэтому `try_files $uri/` для каталога /baza/ искал index.php → `directory index forbidden` → 403 (подтверждено логом nginx). Добавлен `index index.html;` в `location /baza/`. (У /admin/ работает — его server-блок без index.php.)

Проверено: после фикса `/baza/` отдаёт оболочку PWA. Только nginx-конфиг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)