### PR TITLE
feat(template): колонка «описание» шаблона + бэкафилл текущим

### DIFF
--- a/AdminFront/src/views/admin/TemplateEditorView.vue
+++ b/AdminFront/src/views/admin/TemplateEditorView.vue
@@ -18,6 +18,7 @@ const isNew = computed(() => id.value === 'new');
 
 // Форма
 const title = ref('');
+const description = ref('');
 const kind = ref('email');
 const engine = ref('html');
 const slug = ref('');
@@ -105,6 +106,7 @@ async function loadVariables() {
 async function load() {
     if (isNew.value) {
         title.value = '';
+        description.value = '';
         kind.value = 'email';
         engine.value = 'html';
         slug.value = '';
@@ -116,6 +118,7 @@ async function load() {
 
     const item = await store.dispatch('appTemplate/loadItem', { id: id.value });
     title.value = item.title ?? '';
+    description.value = item.description ?? '';
     kind.value = item.kind ?? 'email';
     engine.value = item.engine ?? 'html';
     slug.value = item.slug ?? '';
@@ -178,7 +181,7 @@ async function onActivate() {
 
 async function onCreate() {
     const r = await store.dispatch('appTemplate/create', {
-        data: { slug: slug.value, kind: kind.value, engine: engine.value, title: title.value || slug.value, body: editing.value, active: false }
+        data: { slug: slug.value, kind: kind.value, engine: engine.value, title: title.value || slug.value, description: description.value, body: editing.value, active: false }
     });
     if (r.item?.id) {
         flash('Шаблон создан');
@@ -263,6 +266,10 @@ onMounted(load);
                     <div class="ed-field">
                         <label>Название</label>
                         <InputText v-model="title" placeholder="Напр. Письмо об оплате" />
+                    </div>
+                    <div class="ed-field ed-field-wide">
+                        <label>Описание</label>
+                        <InputText v-model="description" placeholder="Краткое описание: что это за письмо/PDF" />
                     </div>
                     <div class="ed-field">
                         <label>Тип</label>
@@ -412,6 +419,10 @@ onMounted(load);
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
+}
+
+.ed-field-wide {
+    grid-column: 1 / -1;
 }
 
 .ed-field label {

--- a/AdminFront/src/views/admin/TemplateListView.vue
+++ b/AdminFront/src/views/admin/TemplateListView.vue
@@ -77,6 +77,11 @@ onMounted(reload);
                     <template #empty><div class="tpl-empty">Шаблоны не найдены</div></template>
 
                     <Column field="title" header="Название" sortable :style="{ minWidth: '14rem' }" />
+                    <Column field="description" header="Описание" :style="{ minWidth: '18rem' }">
+                        <template #body="{ data }">
+                            <span class="tpl-desc">{{ data.description || '—' }}</span>
+                        </template>
+                    </Column>
                     <Column field="kind" header="Тип" :style="{ minWidth: '8rem' }">
                         <template #body="{ data }">
                             <Tag :value="kindLabel(data.kind)" :severity="data.kind === 'pdf' ? 'warn' : 'info'" />
@@ -129,6 +134,11 @@ onMounted(reload);
 .tpl-subtitle {
     margin: 0.25rem 0 0;
     color: var(--p-text-muted-color, #6b7280);
+}
+
+.tpl-desc {
+    color: var(--p-text-muted-color, #6b7280);
+    font-size: 0.9rem;
 }
 
 .tpl-filter-card {

--- a/Backend/app/Models/Template/TemplateModel.php
+++ b/Backend/app/Models/Template/TemplateModel.php
@@ -19,6 +19,7 @@ use Shared\Infrastructure\Models\HasUuid;
  * @property string $kind
  * @property string $engine
  * @property string $title
+ * @property string|null $description
  * @property string $body
  * @property string|null $draft_body
  * @property string|null $compiled_html
@@ -47,6 +48,7 @@ class TemplateModel extends Model
         'kind',
         'engine',
         'title',
+        'description',
         'body',
         'draft_body',
         'compiled_html',

--- a/Backend/database/migrations/2026_06_20_170000_add_description_to_templates_table.php
+++ b/Backend/database/migrations/2026_06_20_170000_add_description_to_templates_table.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Колонка `description` для шаблонов (AF-3) — краткое описание шаблона для админки
+ * («что это за письмо/PDF»). Видно в списке и в редакторе; в рендере НЕ участвует.
+ *
+ * up() заодно проставляет описания текущим шаблонам по `slug` (идемпотентно —
+ * только там, где описание ещё пустое, чтобы не затереть правки админа).
+ */
+return new class extends Migration
+{
+    /** Краткие описания текущих шаблонов по slug. */
+    private const DESCRIPTIONS = [
+        // ── Письма по заказам ──────────────────────────────────────────────
+        'orderToCreate' => 'Письмо «заказ создан» (двухшаговый qr-цикл, билеты ещё не выпущены)',
+        'orderToPaid' => 'Письмо «заказ оплачен» — с PDF-билетами',
+        'orderToPaidAvto' => 'Письмо об оплате заказа с авто-пропуском (парковка)',
+        'orderToCancel' => 'Письмо об отмене заказа',
+        'orderToChangeTicket' => 'Письмо «данные заказа изменены»',
+        'orderToDifficultiesArose' => 'Письмо о трудностях с заказом',
+        'orderToLiveTicketIssued' => 'Письмо «живой билет выдан»',
+        'orderToPaidLiveTicket' => 'Письмо «живой билет оплачен»',
+        'orderToPaidLiveTicket2' => 'Письмо «живой билет оплачен» (вариант 2)',
+        'orderToPaidLiveKokaoTicket' => 'Письмо «живой билет оплачен» (лесная карта / Кокао)',
+        // ── Письма по заказам-спискам ──────────────────────────────────────
+        'orderListApproved' => 'Письмо «заказ-список одобрен» — PDF-билеты получателю',
+        'orderListCancel' => 'Письмо об отмене заказа-списка',
+        'orderListDifficultiesArose' => 'Письмо о трудностях с заказом-списком',
+        // ── Письма «заказ оплачен» под конкретные типы билетов ─────────────
+        'TypeTicketMailOrderToPaid1' => 'Письмо «заказ оплачен» для типа билета №1',
+        'TypeTicketMailOrderToPaid2' => 'Письмо «заказ оплачен» для типа билета №2',
+        'TypeTicketMailOrderToPaid3' => 'Письмо «заказ оплачен» для типа билета №3',
+        'TypeTicketMailOrderToPaid20' => 'Письмо «заказ оплачен» для типа билета №20',
+        'TypeTicketMailOrderToPaidChild' => 'Письмо «заказ оплачен» для детского билета',
+        'TypeTicketMailOrderToPaidChildFriendly' => 'Письмо «заказ оплачен» — детский Friendly-билет',
+        'TypeTicketMailOrderToPaidFriendly1' => 'Письмо «заказ оплачен» (Friendly) для типа билета №1',
+        // ── Аккаунт / анкеты ───────────────────────────────────────────────
+        'newUser' => 'Письмо при регистрации нового пользователя',
+        'passwordResets' => 'Письмо со ссылкой для сброса пароля',
+        'invate' => 'Письмо-приглашение (ссылка после одобрения анкеты)',
+        'questionnaire' => 'Письмо со ссылкой на анкету гостя',
+        // ── PDF-билеты ─────────────────────────────────────────────────────
+        'pdf' => 'Базовый шаблон PDF-билета',
+        'pdf2' => 'Базовый шаблон PDF-билета (вариант 2)',
+        'TypeAvtoPdf1' => 'PDF авто-пропуска (парковка)',
+        'TypeTicketPdf1' => 'PDF-билет для типа билета №1',
+        'TypeTicketPdf2' => 'PDF-билет для типа билета №2',
+        'TypeTicketPdf3' => 'PDF-билет для типа билета №3',
+        'TypeTicketPdf4' => 'PDF-билет для типа билета №4',
+        'TypeTicketPdfChild' => 'PDF детского билета',
+        'TypeTicketPdfList' => 'PDF-билет по заказу-списку',
+    ];
+
+    public function up(): void
+    {
+        Schema::table('templates', static function (Blueprint $table): void {
+            $table->string('description', 500)->nullable()->after('title');
+        });
+
+        foreach (self::DESCRIPTIONS as $slug => $description) {
+            DB::table('templates')
+                ->where('slug', $slug)
+                ->where(static function ($query): void {
+                    $query->whereNull('description')->orWhere('description', '');
+                })
+                ->update(['description' => $description]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('templates', static function (Blueprint $table): void {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/Backend/src/Template/Dto/TemplateDto.php
+++ b/Backend/src/Template/Dto/TemplateDto.php
@@ -22,6 +22,7 @@ class TemplateDto extends AbstractionEntity implements Response
         protected string $kind,
         protected string $engine,
         protected string $title,
+        protected ?string $description,
         protected string $body,
         protected ?string $draft_body,
         protected ?string $compiled_html,
@@ -40,6 +41,7 @@ class TemplateDto extends AbstractionEntity implements Response
             TemplateKind::isValid($data['kind'] ?? null) ? $data['kind'] : TemplateKind::EMAIL,
             TemplateEngine::isValid($data['engine'] ?? null) ? $data['engine'] : TemplateEngine::HTML,
             $data['title'] ?? $data['slug'],
+            $data['description'] ?? null,
             $data['body'] ?? '',
             $data['draft_body'] ?? null,
             $data['compiled_html'] ?? null,
@@ -73,6 +75,11 @@ class TemplateDto extends AbstractionEntity implements Response
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
     }
 
     public function getBody(): string

--- a/Backend/tests/Feature/Template/TemplateFoundationTest.php
+++ b/Backend/tests/Feature/Template/TemplateFoundationTest.php
@@ -136,6 +136,60 @@ class TemplateFoundationTest extends TestCase
         $this->assertTrue($loaded->getActive());
     }
 
+    public function test_create_persists_description(): void
+    {
+        $id = Uuid::random();
+        $dto = TemplateDto::fromState([
+            'id' => $id->value(),
+            'slug' => 'orderToPaid',
+            'kind' => TemplateKind::EMAIL,
+            'engine' => 'html',
+            'title' => 'Оплата',
+            'description' => 'Письмо «заказ оплачен» — с PDF-билетами',
+            'body' => 'Привет',
+            'active' => true,
+        ]);
+
+        $this->assertTrue($this->repo()->create($dto));
+        $this->assertSame(
+            'Письмо «заказ оплачен» — с PDF-билетами',
+            $this->repo()->getItem($id)->getDescription(),
+        );
+    }
+
+    public function test_description_defaults_to_null_when_absent(): void
+    {
+        $model = $this->makeTemplate(); // без description
+        $this->assertNull($this->repo()->getItem(new Uuid($model->id))->getDescription());
+    }
+
+    public function test_edit_updates_description(): void
+    {
+        $model = $this->makeTemplate(['description' => 'старое описание']);
+        $id = new Uuid($model->id);
+
+        $dto = TemplateDto::fromState(array_merge($model->toArray(), ['description' => 'новое описание']));
+        $this->assertTrue($this->repo()->editItem($id, $dto));
+        $this->assertSame('новое описание', $this->repo()->getItem($id)->getDescription());
+    }
+
+    public function test_description_present_in_serialized_array(): void
+    {
+        // toArray идёт в ответ API (getItem/getList) — поле должно быть в проекции.
+        $dto = TemplateDto::fromState([
+            'slug' => 'pdf',
+            'kind' => TemplateKind::PDF,
+            'engine' => 'html',
+            'title' => 'PDF',
+            'description' => 'Базовый шаблон PDF-билета',
+            'body' => 'x',
+            'active' => true,
+        ]);
+
+        $this->assertArrayHasKey('description', $dto->toArray());
+        $this->assertSame('Базовый шаблон PDF-билета', $dto->toArray()['description']);
+    }
+
     public function test_activate_toggles_flag(): void
     {
         $model = $this->makeTemplate(['active' => true]);


### PR DESCRIPTION
## Колонка «Описание» для шаблонов

Добавлена колонка `description` к шаблонам писем/PDF — краткое описание «что это за шаблон» для админки (список + редактор). В рендере не участвует.

### Что вошло
- **Миграция** `2026_06_20_170000` — колонка `description` (nullable, 500) + **бэкафилл описаний всем 33 текущим шаблонам** по slug (идемпотентно, только пустым).
- **Backend** — `TemplateModel` (fillable), `TemplateDto` (поле + `getDescription()`); проходит в API через `fromState`/`toArray` (create/edit/getItem/getList) без правок контроллера.
- **AdminFront** — колонка «Описание» в списке + поле в редакторе (паритет с «Название»).
- **Тесты** — 4 новых (create/edit/null/сериализация). **Backend 490/490 OK**, AdminFront build зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
