### PR TITLE
fix(order): IDOR в removeTicket + ownership-сравнение (TD-28)

### DIFF
--- a/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
+++ b/Backend/app/Http/Controllers/TicketsOrder/OrderTickets.php
@@ -519,7 +519,7 @@ class OrderTickets extends Controller
         $orderUuid = new Uuid($id);
         $number    = (string) $request->input('number', '');
 
-        if (! $this->canManageAutoOf($orderUuid)) {
+        if (! $this->canManageOrderOf($orderUuid)) {
             return response()->json(['success' => false, 'message' => 'Нет доступа'], 403);
         }
 
@@ -538,7 +538,7 @@ class OrderTickets extends Controller
     {
         $orderUuid = new Uuid($id);
 
-        if (! $this->canManageAutoOf($orderUuid)) {
+        if (! $this->canManageOrderOf($orderUuid)) {
             return response()->json(['success' => false, 'message' => 'Нет доступа'], 403);
         }
 
@@ -552,8 +552,17 @@ class OrderTickets extends Controller
 
     public function removeTicket(string $orderId, string $ticketId): JsonResponse
     {
+        $orderUuid = new Uuid($orderId);
+
+        // Защита от IDOR: удалять билет может только admin или куратор-создатель
+        // заказа (curator_id == auth_id). Иначе любой залогиненный куратор мог бы
+        // удалить билет из ЧУЖОГО заказа по UUID (TD-28).
+        if (! $this->canManageOrderOf($orderUuid)) {
+            return response()->json(['success' => false, 'message' => 'Нет доступа'], 403);
+        }
+
         $this->changeTicket->remove(
-            new Uuid($orderId),
+            $orderUuid,
             new Uuid($ticketId),
             Auth::id(),
         );
@@ -564,20 +573,23 @@ class OrderTickets extends Controller
     }
 
     /**
-     * Право на управление авто заказа: admin или куратор-создатель.
+     * Право на управление заказом: admin или куратор-создатель (curator_id == auth_id).
      */
-    private function canManageAutoOf(Uuid $orderUuid): bool
+    private function canManageOrderOf(Uuid $orderUuid): bool
     {
         /** @var User $user */
         $user   = Auth::user();
         $authId = Auth::id();
+        // Auth::id() в проекте возвращает Uuid-VO → приводим к строке: иначе сравнение
+        // с curator_id (string) всегда false и владелец-куратор получал бы 403.
+        $authIdStr = $authId instanceof Uuid ? $authId->value() : (string) $authId;
 
         if ($user->role === AccountRoleHelper::admin) {
             return true;
         }
 
         $orderItem = $this->getOrder->getItemById($orderUuid);
-        return $orderItem !== null && $orderItem->getCuratorId() === $authId;
+        return $orderItem !== null && $orderItem->getCuratorId() === $authIdStr;
     }
 
     /**
@@ -770,7 +782,10 @@ class OrderTickets extends Controller
         $authUser = Auth::user();
         if ($authUser->role === AccountRoleHelper::curator || $authUser->role === AccountRoleHelper::pusher_curator) {
             $orderItem = $this->getOrder->getItemById($orderUuid);
-            if ($orderItem === null || $orderItem->getCuratorId() !== Auth::id()) {
+            // Auth::id() — Uuid-VO; нормализуем к строке (иначе !== с curator_id всегда true → куратор заблокирован в своём заказе).
+            $authId    = Auth::id();
+            $authIdStr = $authId instanceof Uuid ? $authId->value() : (string) $authId;
+            if ($orderItem === null || $orderItem->getCuratorId() !== $authIdStr) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Нет доступа к этому заказу',

--- a/Backend/tests/Feature/Order/RemoveTicketOwnershipTest.php
+++ b/Backend/tests/Feature/Order/RemoveTicketOwnershipTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Order;
+
+use App\Models\Ordering\OrderTicketModel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use Tests\TestCase;
+
+/**
+ * IDOR-регресс (TD-28): `DELETE /api/v1/order/removeTicket/{orderId}/{ticketId}`
+ * нельзя применить к ЧУЖОМУ заказу. Доступ — только admin или куратор-создатель
+ * (curator_id == auth_id). До фикса любой залогиненный куратор удалял билет из
+ * чужого заказа по UUID.
+ */
+class RemoveTicketOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Минимальный заказ-список с заданным владельцем-куратором.
+     * FK отключаем на вставку: тест про гейт владения, а не про связи (festival/user/...).
+     */
+    private function makeListOrder(string $curatorId): string
+    {
+        $id = (string) RamseyUuid::uuid4();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        // forceFill — festival_id/др. вне $fillable; FK отключены (тест про гейт владения).
+        (new OrderTicketModel())->forceFill([
+            'id' => $id,
+            'user_id' => (string) RamseyUuid::uuid4(),
+            'festival_id' => (string) RamseyUuid::uuid4(),
+            'status' => 'new_list',
+            'curator_id' => $curatorId,
+            'guests' => '[]',
+            'date' => now()->toDateTimeString(),
+        ])->save();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        return $id;
+    }
+
+    private function url(string $orderId): string
+    {
+        return '/api/v1/order/removeTicket/' . $orderId . '/' . RamseyUuid::uuid4();
+    }
+
+    public function test_stranger_curator_cannot_remove_from_others_order(): void
+    {
+        $owner = User::factory()->create(['role' => 'curator']);
+        $stranger = User::factory()->create(['role' => 'curator']);
+        $orderId = $this->makeListOrder($owner->id->value());
+
+        $this->actingAs($stranger, 'api');
+
+        $this->deleteJson($this->url($orderId))
+            ->assertStatus(403)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_owner_curator_passes_ownership_gate(): void
+    {
+        $owner = User::factory()->create(['role' => 'curator']);
+        $orderId = $this->makeListOrder($owner->id->value());
+
+        $this->actingAs($owner, 'api');
+
+        // Владелец проходит проверку владения — гейт его НЕ блокирует (не 403).
+        $this->assertNotSame(403, $this->deleteJson($this->url($orderId))->status());
+    }
+
+    public function test_admin_passes_ownership_gate(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $orderId = $this->makeListOrder((string) RamseyUuid::uuid4());
+
+        $this->actingAs($admin, 'api');
+
+        // Admin — суперроль, проходит без проверки владельца (не 403).
+        $this->assertNotSame(403, $this->deleteJson($this->url($orderId))->status());
+    }
+}


### PR DESCRIPTION
## Fix: IDOR в `removeTicket` (TD-28) + латентный баг ownership-сравнения

### Проблема
`DELETE /api/v1/order/removeTicket/{orderId}/{ticketId}` **не проверял владение заказом**. Роут открыт для `admin,curator,pusher_curator` → любой залогиненный куратор мог удалить билет из **чужого** заказа по UUID. (Подтверждено security-ревью / встречей команды.)

### Фикс
- Добавлен ownership-гейт в `removeTicket`: **admin** или **куратор-создатель** (`curator_id == auth_id`), по образцу `addAuto`/`removeAuto`. Helper переименован `canManageAutoOf` → `canManageOrderOf` (он про владение заказом, а не только авто).
- **Бонус-баг (нашёлся при написании теста):** `Auth::id()` в проекте возвращает `Uuid`-VO, а `getCuratorId()` — строку. Сравнение `string === Uuid-object` **всегда false** → реальные владельцы-кураторы получали `403` в `addAuto`/`removeAuto`/`changeTicket` (тихое переблокирование своих же заказов). Нормализовано к строке (`$authId->value()`) в `canManageOrderOf` и в проверке `changeTicket`.

### Тест
`RemoveTicketOwnershipTest` (3): чужой куратор → **403**, владелец-куратор → проходит гейт, admin → проходит.

### Проверка
Backend PHPUnit **489/489** зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
