### PR TITLE
fix(baza): экран смен висел на «Загрузка…» — не вызывался onMounted(reload)

### DIFF
--- a/BazaFront/src/views/ShiftsView.vue
+++ b/BazaFront/src/views/ShiftsView.vue
@@ -84,6 +84,9 @@ async function doClose(id) {
         err.value = e?.response?.status === 403 ? 'Можно закрыть только свою смену' : 'Не удалось закрыть';
     }
 }
+
+// Без этого вызова «Открытые смены» висели на «Загрузка…»: onMounted был импортирован, но не дёргался.
+onMounted(reload);
 </script>
 
 <template>


### PR DESCRIPTION
## Баг (нашёл владелец на стенде)
`/baza/shifts` → «Открытые смены: Загрузка…» висит вечно, состав не подгружается, форма в не-админской ветке.

## Причина
`ShiftsView.vue` импортировал `onMounted`, но **не вызывал** его. `reload()` дёргался только из `submit()`/`doClose()` → на открытии экрана список смен и состав не загружались, `loading` навсегда `true`.

## Фикс
`onMounted(reload)` (как в `StaffView`/`PermissionMatrixView`). Один вызов, бэкенд не трогаем (методы `listOpen`/`users->list` на стенде проверены — 2 смены / 36 польз.).

На стенде уже выложено (ветка → staging).