### PR TITLE
feat(email): событие questionnaire_rejected (slug questionnaireRejected)

### DIFF
--- a/Backend/src/EmailDelivery/Domain/EmailEvent.php
+++ b/Backend/src/EmailDelivery/Domain/EmailEvent.php
@@ -35,6 +35,7 @@ final class EmailEvent
     public const INVITE = 'invite';
     public const QUESTIONNAIRE = 'questionnaire';
     public const QUESTIONNAIRE_APPROVED = 'questionnaire_approved';
+    public const QUESTIONNAIRE_REJECTED = 'questionnaire_rejected';
 
     /** event → дефолтный slug шаблона (= текущий зашитый в Mailable). */
     private const DEFAULT_SLUG = [
@@ -54,6 +55,7 @@ final class EmailEvent
         self::INVITE => 'invate',
         self::QUESTIONNAIRE => 'questionnaire',
         self::QUESTIONNAIRE_APPROVED => 'questionnaireApproved',
+        self::QUESTIONNAIRE_REJECTED => 'questionnaireRejected',
     ];
 
     /** event → человекочитаемая метка (для селектора события в админке). */
@@ -74,6 +76,7 @@ final class EmailEvent
         self::INVITE => 'Приглашение',
         self::QUESTIONNAIRE => 'Анкета гостя',
         self::QUESTIONNAIRE_APPROVED => 'Анкета одобрена',
+        self::QUESTIONNAIRE_REJECTED => 'Анкета отклонена',
     ];
 
     /** @return string[] все коды событий */

--- a/Backend/tests/Unit/EmailDelivery/EmailEventCatalogTest.php
+++ b/Backend/tests/Unit/EmailDelivery/EmailEventCatalogTest.php
@@ -31,4 +31,23 @@ class EmailEventCatalogTest extends TestCase
         $this->assertNotEmpty($entry);
         $this->assertSame('Анкета одобрена', $entry[0]['label']);
     }
+
+    public function test_questionnaire_rejected_is_registered(): void
+    {
+        $this->assertSame('questionnaire_rejected', EmailEvent::QUESTIONNAIRE_REJECTED);
+        $this->assertTrue(EmailEvent::isValid(EmailEvent::QUESTIONNAIRE_REJECTED));
+        $this->assertSame('questionnaireRejected', EmailEvent::defaultSlug(EmailEvent::QUESTIONNAIRE_REJECTED));
+        $this->assertContains('questionnaire_rejected', EmailEvent::all());
+    }
+
+    public function test_catalog_contains_questionnaire_rejected_label(): void
+    {
+        $entry = array_values(array_filter(
+            EmailEvent::catalog(),
+            static fn (array $i): bool => $i['value'] === 'questionnaire_rejected',
+        ));
+
+        $this->assertNotEmpty($entry);
+        $this->assertSame('Анкета отклонена', $entry[0]['label']);
+    }
 }


### PR DESCRIPTION
## Что

Регистрирует событие `questionnaire_rejected` в каталоге `EmailEvent` (`Backend/src/EmailDelivery/Domain/EmailEvent.php`):
- константа `QUESTIONNAIRE_REJECTED = 'questionnaire_rejected'`
- `defaultSlug` → `questionnaireRejected`
- метка → «Анкета отклонена»

## Зачем

Без события S2S-приём `POST /api/v1/emailNotification/send` возвращал **422** на `questionnaire_rejected` (валидация через `EmailEvent::isValid`). Теперь событие валидно, появляется в каталоге `GET /api/v1/templateBinding/events` и в резолвере slug. Шаблон `questionnaireRejected` подхватывается как `defaultSlug`. Витрина qr сможет повесить `send` на `reject_survey`.

## Тесты

`Backend/tests/Unit/EmailDelivery/EmailEventCatalogTest.php` — 2 новых метода (регистрация события + метка в каталоге). Локально `phpunit --filter EmailEventCatalogTest` → 4/4 зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)