### PR TITLE
fix(order): прод-готовность v2.6.0 — FK-гарды миграций + festival_id + fallback мигратора

### DIFF
--- a/Backend/database/migrations/2026_06_14_150000_drop_tickets_order_ticket_id_foreign.php
+++ b/Backend/database/migrations/2026_06_14_150000_drop_tickets_order_ticket_id_foreign.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -20,9 +21,28 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('tickets', static function (Blueprint $table): void {
-            $table->dropForeign(['order_ticket_id']);
-        });
+        // На части окружений (в т.ч. прод) у tickets есть только ИНДЕКС
+        // tickets_order_ticket_id_foreign, но самого FK-ограничения нет — безусловный
+        // dropForeign падал бы (SQLSTATE[42000] 1091 «Can't DROP ...; check that key exists»).
+        // Снимаем FK только если он реально существует.
+        if ($this->foreignKeyExists('tickets', 'order_ticket_id')) {
+            Schema::table('tickets', static function (Blueprint $table): void {
+                $table->dropForeign(['order_ticket_id']);
+            });
+        }
+    }
+
+    /**
+     * Есть ли на колонке внешний ключ (именно FK-ограничение, а не просто индекс).
+     */
+    private function foreignKeyExists(string $table, string $column): bool
+    {
+        return DB::table('information_schema.KEY_COLUMN_USAGE')
+            ->where('TABLE_SCHEMA', DB::getDatabaseName())
+            ->where('TABLE_NAME', $table)
+            ->where('COLUMN_NAME', $column)
+            ->whereNotNull('REFERENCED_TABLE_NAME')
+            ->exists();
     }
 
     public function down(): void

--- a/Backend/database/migrations/2026_06_21_120000_evolve_comment_table_for_thread.php
+++ b/Backend/database/migrations/2026_06_21_120000_evolve_comment_table_for_thread.php
@@ -26,25 +26,24 @@ return new class extends Migration
         }
 
         // 1) Делаем user_id nullable. Под FK + без doctrine/dbal: дропаем FK → MODIFY → возвращаем nullable FK.
-        // dropForeign требует существующего FK; оборачиваем в try на случай повторного прогона.
-        Schema::table('comment', static function (Blueprint $table): void {
-            try {
+        // ВАЖНО: try/catch ВНУТРИ Schema::table-замыкания НЕ ловит ошибку — она бросается на
+        // build() уже вне замыкания. На проде у comment FK отсутствует вовсе → безусловный
+        // dropForeign падал бы (SQLSTATE 1091). Поэтому снимаем FK только если он реально есть.
+        if ($this->foreignKeyExists('comment', 'user_id')) {
+            Schema::table('comment', static function (Blueprint $table): void {
                 $table->dropForeign(['user_id']);
-            } catch (\Throwable $e) {
-                // FK уже снят (повторный прогон) — игнорируем.
-            }
-        });
+            });
+        }
 
         DB::statement('ALTER TABLE comment MODIFY user_id CHAR(36) NULL');
 
-        Schema::table('comment', static function (Blueprint $table): void {
-            try {
-                // nullable FK допускает NULL — автор может быть не-org (baza/qr/system).
+        // nullable FK допускает NULL — автор может быть не-org (baza/qr/system).
+        // Добавляем только если FK ещё нет (идемпотентно при повторном прогоне).
+        if (! $this->foreignKeyExists('comment', 'user_id')) {
+            Schema::table('comment', static function (Blueprint $table): void {
                 $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
-            } catch (\Throwable $e) {
-                // FK уже добавлен (повторный прогон) — игнорируем.
-            }
-        });
+            });
+        }
 
         // 2) Новые колонки треда (с гардом — идемпотентно).
         Schema::table('comment', static function (Blueprint $table): void {
@@ -74,20 +73,31 @@ return new class extends Migration
         });
 
         // Возврат user_id к NOT NULL: дропаем nullable FK → MODIFY NOT NULL → возвращаем строгий FK.
-        Schema::table('comment', static function (Blueprint $table): void {
-            try {
+        if ($this->foreignKeyExists('comment', 'user_id')) {
+            Schema::table('comment', static function (Blueprint $table): void {
                 $table->dropForeign(['user_id']);
-            } catch (\Throwable $e) {
-            }
-        });
+            });
+        }
 
         DB::statement('ALTER TABLE comment MODIFY user_id CHAR(36) NOT NULL');
 
-        Schema::table('comment', static function (Blueprint $table): void {
-            try {
+        if (! $this->foreignKeyExists('comment', 'user_id')) {
+            Schema::table('comment', static function (Blueprint $table): void {
                 $table->foreign('user_id')->references('id')->on('users');
-            } catch (\Throwable $e) {
-            }
-        });
+            });
+        }
+    }
+
+    /**
+     * Есть ли на колонке внешний ключ (именно FK-ограничение, а не просто индекс).
+     */
+    private function foreignKeyExists(string $table, string $column): bool
+    {
+        return DB::table('information_schema.KEY_COLUMN_USAGE')
+            ->where('TABLE_SCHEMA', DB::getDatabaseName())
+            ->where('TABLE_NAME', $table)
+            ->where('COLUMN_NAME', $column)
+            ->whereNotNull('REFERENCED_TABLE_NAME')
+            ->exists();
     }
 };

--- a/Backend/src/Order/OrderTicket/Migration/OrderGuestsMigrator.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderGuestsMigrator.php
@@ -66,7 +66,7 @@ class OrderGuestsMigrator
 
         // Обрабатываем чанками — на 50k заказов разом память не закончится.
         $this->db->table('order_tickets')
-            ->select(['id', 'guests', 'ticket_type_id', 'promo_code', 'price', 'discount'])
+            ->select(['id', 'guests', 'ticket_type_id', 'promo_code', 'price', 'discount', 'festival_id'])
             ->orderBy('id')
             ->chunk($chunkSize, function ($rows) use ($report, $liveByTicketType, $dryRun) {
                 foreach ($rows as $row) {
@@ -83,14 +83,18 @@ class OrderGuestsMigrator
      *
      * @param  array<int, array<string, mixed>>  $guests   текущий массив гостей (legacy или уже новый)
      * @param  array<string, bool>  $liveByTicketType   map [ticket_type_id → is_live_ticket]
+     * @param  ?string  $orderFestivalId  festival_id заказа — инжектится в гостей, у которых
+     *                                     его нет (legacy-формат хранил festival_id на уровне заказа,
+     *                                     а OrderGuestLine::fromState требует его per-guest)
      * @return array{
      *     guests: array<int, array<string, mixed>>,
      *     migrated: bool,
      *     totalBefore: float,
      *     totalAfter: float,
      *     emptyGuests: bool,
+     *     orphanTicketType: bool,
+     *     clampedDiscount: bool,
      * }
-     * @throws \RuntimeException при некорректных данных (отрицательный total, неизвестный ticket_type)
      */
     public function transformOrderGuests(
         array $guests,
@@ -99,6 +103,7 @@ class OrderGuestsMigrator
         float $price,
         float $discount,
         array $liveByTicketType,
+        ?string $orderFestivalId = null,
     ): array {
         if (empty($guests)) {
             return [
@@ -107,41 +112,41 @@ class OrderGuestsMigrator
                 'totalBefore' => 0.0,
                 'totalAfter' => 0.0,
                 'emptyGuests' => true,
+                'orphanTicketType' => false,
+                'clampedDiscount' => false,
             ];
         }
 
-        // Идемпотентность: если у ПЕРВОГО гостя есть price_snapshot — заказ уже мигрирован.
-        // Не разбираем массив целиком, потому что миграция всех гостей атомарна
-        // (UPDATE order_tickets.guests = ... обновляет весь JSON одной операцией).
-        if (isset($guests[0]['price_snapshot'])) {
+        // Идемпотентность: заказ считается мигрированным, только если у ПЕРВОГО гостя есть
+        // И price_snapshot, И festival_id. festival_id добавлен позже самого price_snapshot —
+        // заказы, мигрированные ранней версией без festival_id, должны до-мигрироваться
+        // (recompute детерминирован: цена берётся из тех же order.price/discount).
+        if (isset($guests[0]['price_snapshot'], $guests[0]['festival_id'])) {
             return [
                 'guests' => $guests,
                 'migrated' => false,
                 'totalBefore' => 0.0,
                 'totalAfter' => 0.0,
                 'emptyGuests' => false,
+                'orphanTicketType' => false,
+                'clampedDiscount' => false,
             ];
         }
 
-        // Валидация: discount > price — означает кривые данные.
-        // Money не может быть отрицательным (конструктор VO кидает exception),
-        // поэтому отказываем заранее с понятным сообщением.
+        // Clamp: discount > price — кривые данные (напр. детский билет в статусе new с битым
+        // discount). Money не может быть отрицательным → клампим discount к price (total = 0).
+        // Это историческое легаси; заказ всё равно мигрируется, факт фиксируем в отчёте.
+        $clampedDiscount = false;
         if ($discount > $price) {
-            throw new \RuntimeException(sprintf(
-                'discount > price (%.2f > %.2f) — отрицательный totalPerGuest недопустим',
-                $discount, $price,
-            ));
+            $discount = $price;
+            $clampedDiscount = true;
         }
 
-        // Валидация: если ticket_type указан, но его нет в preload-карте, это сломанные данные
-        // (orphan FK / удалённый тип). Молчаливый fallback на is_live_ticket=false скрыл бы
-        // аномалию — лучше явно репортить и дать оператору решить.
-        if ($ticketTypeId !== null && ! array_key_exists($ticketTypeId, $liveByTicketType)) {
-            throw new \RuntimeException(sprintf(
-                'ticket_type %s не найден (orphan FK или удалённый тип)',
-                $ticketTypeId,
-            ));
-        }
+        // Orphan/удалённый ticket_type (старые фесты, тип удалён из каталога): тип нужен ТОЛЬКО
+        // для флага is_live_ticket — цена берётся из самого заказа (order.price/discount).
+        // Безопасный fallback на is_live_ticket=false (вместо падения), заказ мигрируется.
+        // Факт фиксируем в отчёте (не глушим молча).
+        $orphanTicketType = $ticketTypeId !== null && ! array_key_exists($ticketTypeId, $liveByTicketType);
 
         $count = count($guests);
         $totalBefore = $price - $discount;
@@ -172,6 +177,10 @@ class OrderGuestsMigrator
                 'promo_code' => $promoCode,
                 'price_snapshot' => $snapshot,
                 'is_live_ticket' => $isLiveTicket,
+                // festival_id обязателен для OrderGuestLine::fromState. Legacy-гости часто его
+                // НЕ имели (festival_id жил на уровне заказа) → инжектим из заказа, сохраняя
+                // значение гостя, если оно уже есть.
+                'festival_id' => $guest['festival_id'] ?? $orderFestivalId,
             ]);
 
             $totalAfter += $totalPerGuest;
@@ -183,6 +192,8 @@ class OrderGuestsMigrator
             'totalBefore' => (float) $totalBefore,
             'totalAfter' => $totalAfter,
             'emptyGuests' => false,
+            'orphanTicketType' => $orphanTicketType,
+            'clampedDiscount' => $clampedDiscount,
         ];
     }
 
@@ -213,6 +224,7 @@ class OrderGuestsMigrator
                 price: (float) ($row->price ?? 0.0),
                 discount: (float) ($row->discount ?? 0.0),
                 liveByTicketType: $liveByTicketType,
+                orderFestivalId: $row->festival_id ?? null,
             );
 
             if ($result['emptyGuests']) {
@@ -230,6 +242,13 @@ class OrderGuestsMigrator
             $report->totalBefore += $result['totalBefore'];
             $report->totalAfter += $result['totalAfter'];
             $report->maxAllowedRoundingError += max(0, count($rawGuests) - 1);
+
+            if ($result['orphanTicketType']) {
+                $report->fallbackOrphanTicketType++;
+            }
+            if ($result['clampedDiscount']) {
+                $report->clampedDiscount++;
+            }
 
             if (! $dryRun) {
                 $this->db->table('order_tickets')

--- a/Backend/src/Order/OrderTicket/Migration/OrderMigrationReport.php
+++ b/Backend/src/Order/OrderTicket/Migration/OrderMigrationReport.php
@@ -25,8 +25,12 @@ final class OrderMigrationReport
         public int $emptyGuestsSkipped = 0,
         /** Заказов фактически мигрированных в этом прогоне */
         public int $migrated = 0,
-        /** Заказов с ошибкой (битый JSON, неконсистентные поля, неизвестный ticket_type) */
+        /** Заказов с ошибкой (битый JSON, неконсистентные поля) */
         public int $errors = 0,
+        /** Заказов с fallback на is_live_ticket=false из-за orphan/удалённого ticket_type (старые фесты) */
+        public int $fallbackOrphanTicketType = 0,
+        /** Заказов где discount склампен к price (битые данные discount > price → total=0) */
+        public int $clampedDiscount = 0,
         /** Контрольная сумма `price - discount` ДО миграции (по всем мигрируемым заказам) */
         public float $totalBefore = 0.0,
         /** Контрольная сумма `Σ price_snapshot.total` ПО ВСЕМ ГОСТЯМ ПОСЛЕ миграции */
@@ -64,6 +68,8 @@ final class OrderMigrationReport
             ['Пустые guests (skip)', $this->emptyGuestsSkipped],
             ['Фактически мигрировано', $this->migrated],
             ['Ошибок', $this->errors],
+            ['Fallback orphan ticket_type (is_live=false)', $this->fallbackOrphanTicketType],
+            ['Склампен discount>price (total=0)', $this->clampedDiscount],
             ['Сумма ДО (price - discount)', number_format($this->totalBefore, 2, '.', ' ')],
             ['Сумма ПОСЛЕ (Σ price_snapshot.total)', number_format($this->totalAfter, 2, '.', ' ')],
             ['Расхождение (округление)', number_format($this->roundingDelta(), 2, '.', ' ')],

--- a/Backend/tests/Unit/Order/OrderTicket/Migration/OrderGuestsMigratorTest.php
+++ b/Backend/tests/Unit/Order/OrderTicket/Migration/OrderGuestsMigratorTest.php
@@ -220,39 +220,88 @@ class OrderGuestsMigratorTest extends TestCase
     }
 
     /** @test */
-    public function throws_when_ticket_type_unknown(): void
+    public function falls_back_to_non_live_when_ticket_type_unknown(): void
     {
-        // Раньше silent fallback на is_live_ticket=false скрывал orphan FK / удалённые типы.
-        // Теперь явно репортим — заказ попадёт в errors отчёта и команда вернёт FAILURE.
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('ticket_type ffffffff-ffff-ffff-ffff-ffffffffffff не найден');
-
-        $this->migrator->transformOrderGuests(
+        // Orphan/удалённый ticket_type (старые фесты): НЕ падаем — мигрируем с is_live_ticket=false,
+        // цена берётся из заказа. Факт помечается флагом orphanTicketType (для отчёта).
+        $result = $this->migrator->transformOrderGuests(
             guests: [$this->legacyGuest('Иван')],
             ticketTypeId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
             promoCode: null,
             price: 4200.0,
             discount: 0.0,
-            liveByTicketType: [],  // пустой map
+            liveByTicketType: [],  // пустой map — тип не найден
         );
+
+        self::assertTrue($result['migrated']);
+        self::assertTrue($result['orphanTicketType']);
+        self::assertFalse($result['guests'][0]['is_live_ticket']);
+        self::assertSame(4200, $result['guests'][0]['price_snapshot']['total']);
+        self::assertSame('ffffffff-ffff-ffff-ffff-ffffffffffff', $result['guests'][0]['ticket_type_id']);
     }
 
     /** @test */
-    public function throws_when_discount_exceeds_price(): void
+    public function clamps_when_discount_exceeds_price(): void
     {
-        // discount > price → отрицательный total. Money не может быть отрицательным,
-        // поэтому отвергаем заранее с понятным сообщением (вместо ошибки в Domain VO).
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('discount > price');
-
-        $this->migrator->transformOrderGuests(
+        // discount > price (битые данные) → клампим discount к price, total = 0. НЕ падаем.
+        // Money не может быть отрицательным; заказ всё равно мигрируется (флаг clampedDiscount).
+        $result = $this->migrator->transformOrderGuests(
             guests: [$this->legacyGuest('Иван')],
             ticketTypeId: self::TICKET_TYPE_ORG,
             promoCode: null,
-            price: 100.0,
-            discount: 500.0,  // больше чем price
+            price: 900.0,
+            discount: 1000.0,  // больше чем price
             liveByTicketType: [self::TICKET_TYPE_ORG => false],
         );
+
+        self::assertTrue($result['migrated']);
+        self::assertTrue($result['clampedDiscount']);
+        self::assertSame(0, $result['guests'][0]['price_snapshot']['total']);
+        self::assertSame(0.0, $result['totalBefore']);
+        self::assertSame(0.0, $result['totalAfter']);
+    }
+
+    /** @test */
+    public function injects_festival_id_from_order_when_guest_lacks_it(): void
+    {
+        // Legacy-гость без festival_id (раньше festival_id жил на уровне заказа). Мигратор
+        // инжектит festival_id заказа в гостя — иначе OrderGuestLine::fromState упадёт.
+        $guestWithoutFestival = [
+            'id' => '550e8400-e29b-41d4-a716-446655440000',
+            'value' => 'Иван',
+            'email' => 'ivan@example.com',
+            'number' => null,
+        ];
+
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$guestWithoutFestival],
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+            orderFestivalId: '660e8400-e29b-41d4-a716-446655440099',
+        );
+
+        self::assertTrue($result['migrated']);
+        self::assertSame('660e8400-e29b-41d4-a716-446655440099', $result['guests'][0]['festival_id']);
+    }
+
+    /** @test */
+    public function preserves_guest_festival_id_over_order_festival_id(): void
+    {
+        // Если у гостя уже есть festival_id — он сохраняется (festival_id заказа не перетирает).
+        $result = $this->migrator->transformOrderGuests(
+            guests: [$this->legacyGuest('Иван')],  // legacyGuest содержит festival_id ...440001
+            ticketTypeId: self::TICKET_TYPE_ORG,
+            promoCode: null,
+            price: 4200.0,
+            discount: 0.0,
+            liveByTicketType: [self::TICKET_TYPE_ORG => false],
+            orderFestivalId: '660e8400-e29b-41d4-a716-446655440099',
+        );
+
+        self::assertSame('660e8400-e29b-41d4-a716-446655440001', $result['guests'][0]['festival_id']);
     }
 
     /** @test */


### PR DESCRIPTION
Подготовка к выкату v2.6.0/master на прод. Репетиция на **копии прод-БД (10 024 заказа)** поймала 3 прод-блокера, невидимых на стенде (он собран fresh-данными нового фронта) и в юнит-тестах. Все три починены и доказаны на прод-данных.

## Что чинит
1. **Схемные миграции падали на прод-схеме без FK** — `2026_06_14_150000_drop_tickets_order_ticket_id_foreign` (у прод-`tickets` только индекс, FK нет → `dropForeign` SQLSTATE 1091) и `2026_06_21_120000_evolve_comment_table_for_thread` (`try/catch` вокруг `dropForeign` стоял ВНУТРИ `Schema::table`-замыкания — в Laravel не ловит ошибку с `build()`). → защитный `dropForeign` через `information_schema.KEY_COLUMN_USAGE`.
2. **Мигратор не клал `festival_id` гостям** (ГЛАВНОЕ) — `OrderGuestLine::fromState` требует `festival_id` per-guest, а у 7 715/10 017 прод-заказов (77%) его не было (legacy хранил на уровне заказа). Без фикса `findOrder()` падал → ломалась смена статуса, изменение/удаление билета, цена, Auto и публичные `questionnaire/getByOrderTicket`. → мигратор инжектит `order.festival_id` в каждого гостя.
3. **258 «грязных» заказов 2023** data-миграция отвергала (команда → FAILURE) — удалённый из каталога `ticket_type` + `discount > price`. → fallback: orphan→`is_live_ticket=false` (цена из заказа), `discount>price`→clamp total к 0. Факты — в отчёте (`fallbackOrphanTicketType`/`clampedDiscount`).

Идемпотентность ужесточена: «мигрирован» = есть И `price_snapshot`, И `festival_id`.

## Доказано на свежем импорте прод-дампа
- Схемные миграции **15/15 DONE**.
- Data-миграция: **10 017 мигрировано, 0 ошибок** (fallback orphan 255 + clamp 3), суммы ДО=ПОСЛЕ (67 749 261 ₽, расхождение **0.00**), идемпотентна.
- `findOrder` работает на ранее-сломанных заказах; публичные анкеты гостей → **200** (был 422).
- Юнит-тесты мигратора **15/15**.

⚠️ Перед тегом прода: см. парный PR с `deploy-prod.yml`. Выкат = апгрейд Laravel 9→11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)