### PR TITLE
fix(infra): prod compose/nginx под Plesk-фронт (порты + http-отдача)

### DIFF
--- a/Docker/nginx/default.conf
+++ b/Docker/nginx/default.conf
@@ -1,25 +1,16 @@
-server {
-    listen 8083;
-    server_name     org.solarsysto.ru api.solarsysto.ru api.tickets.loc org.tickets.loc baza.tickets.loc vhod.spaceofjoy.ru;
-    return 301 https://$host$request_uri;
-}
-
-
-server {
-    listen 8083;
-    server_name     drug.solarsysto.ru drug.tickets.loc;
-    return 301 http://$host$request_uri;
-}
+# SSL терминирует фронт Plesk-nginx (443) и проксирует сюда по http на 8083.
+# Поэтому docker-nginx отдаёт приложение по http (8083) БЕЗ редиректа http->https,
+# иначе цикл 301. Блоки 8443 ssl оставлены для прямого доступа (не через Plesk).
 
 ######### org ##########################
 # api
 server {
+    listen          8083;
     listen          8443 ssl;
-    server_name     api.solarsysto.ru api.tickets.loc;
+    server_name     api.solarsysto.ru api.spaceofjoy.ru api.tickets.loc;
     ssl_certificate ssl/fullchain.pem; # managed by Certbot
     ssl_certificate_key ssl/privkey.pem;
 
-    # Set the document root of the project
     root ${ENV_ORG_BACKEND_PATCH}/public;
     index           index.php;
 
@@ -37,31 +28,26 @@ server {
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
     }
-
 }
 
-# front
+# front (org)
 server {
-    # Set the port to listen on and the server name
+    listen          8083;
     listen          8443 ssl;
-    server_name     org.solarsysto.ru org.tickets.loc;
+    server_name     org.solarsysto.ru org.spaceofjoy.ru org.tickets.loc;
     ssl_certificate ssl/fullchain.pem; # managed by Certbot
     ssl_certificate_key ssl/privkey.pem;
-    # Specify the default character set
     charset utf-8;
 
     location / {
-        # Set the document root of the project
         root ${ENV_ORG_FRONT_PATCH}/dist;
-        # Set the directory index files
         try_files $uri $uri/ /index.html;
     }
 }
 
-
-
 ########## vhod ##########################
 server {
+    listen          8083;
     listen          8443 ssl;
     server_name     baza.tickets.loc vhod.spaceofjoy.ru;
     ssl_certificate ssl/fullchain.pem; # managed by Certbot

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,6 @@ services:
       context: ./Docker/nginx
     ports:
       - "${NGINX_PORT:-50080}:8083"
-      - "443:8443"
     volumes:
       - ./Docker/nginx/default.conf:/etc/nginx/conf.d/default.conf.template
       - ./Docker/nginx/ssl:/etc/nginx/ssl
@@ -74,7 +73,7 @@ services:
       context: ./Docker/node
     working_dir: ${ENV_ORG_FRONT_PATCH}
     ports:
-      - "8081:8080"
+      - "127.0.0.1:8082:8080"
     container_name: node-solarSysto
     volumes:
       - ./FrontEnd:${ENV_ORG_FRONT_PATCH}
@@ -135,7 +134,7 @@ services:
     image: mysql:8
     restart: unless-stopped
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3307:3306"
     environment:
       MYSQL_DATABASE: 'systo'
       MYSQL_ROOT_PASSWORD: 'secret'


### PR DESCRIPTION
Переносит в репозиторий правки, сделанные **на проде вручную** при восстановлении после выката v2.6.2, чтобы следующий тег-деплой их **не откатил** (иначе прод снова ляжет).

## Контекст
Прод — **Plesk-сервер**: host-nginx (443, SSL) проксирует домены systo на docker по http (`127.0.0.1:50080→8083`); host-mysqld держит 3306, host-apache — 8081. Дефолтный `docker-compose.prod.yml`/`default.conf` конфликтовали с host-сервисами (порты 443/3306/8081) и зацикливали http→https.

## Изменения (только prod-файлы; staging/dev не затронуты)
- **nginx**: убран host-маппинг `443:8443` (443 держит Plesk).
- **mysql**: `3306:3306` → `127.0.0.1:3307:3306` (приложение ходит по внутренней docker-сети `DB_HOST=mysql`).
- **node**: `8081:8080` → `127.0.0.1:8082:8080`.
- **default.conf**: docker-nginx отдаёт приложение по **http на 8083 без redirect http→https** (SSL терминирует Plesk; иначе цикл 301); `server_name` дополнен `*.spaceofjoy.ru`.

Файлы взяты **байт-в-байт** с восстановленного прода → после мержа прод-дерево будет соответствовать репозиторию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)